### PR TITLE
Fix codecov badge, CodeQL vcpkg noise, dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,47 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "vcpkg"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "vcpkg"
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           APCA_API_SECRET_KEY: "DUMMY_SECRET_FOR_TESTING"
 
       - name: Upload Python coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -363,6 +363,23 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
+        with:
+          output: sarif-results
+          upload: failure-only
+
+      - name: Filter SARIF to exclude vcpkg
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -**/vcpkg/**
+            -**/vcpkg_installed/**
+          input: sarif-results/cpp.sarif
+          output: sarif-results/cpp.sarif
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif-results/
 
       - name: Upload security scan results
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rich on Paper - Low-Latency Trading Engine
 
 [![Build and Test](https://github.com/DanielMarchukov/rich-on-paper/actions/workflows/build.yml/badge.svg)](https://github.com/DanielMarchukov/rich-on-paper/actions/workflows/build.yml)
-[![codecov](https://codecov.io/gh/DanielMarchukov/rich-on-paper/branch/main/graph/badge.svg)](https://codecov.io/gh/DanielMarchukov/rich-on-paper)
+[![codecov](https://codecov.io/gh/DanielMarchukov/rich-on-paper/branch/mainline/graph/badge.svg)](https://codecov.io/gh/DanielMarchukov/rich-on-paper)
 
 A production-grade, ultra-low latency trading engine built with modern C++23 and Python, targeting sub-50 microsecond
 internal processing latency. The system demonstrates professional software engineering practices including comprehensive


### PR DESCRIPTION
Fix codecov badge branch, filter vcpkg paths from CodeQL SARIF, upgrade codecov-action to v5, and expand dependabot with github-actions + vcpkg ecosystems.