### PR TITLE
Add concurrency and correctness tests for coverage gaps

### DIFF
--- a/tests/test_position_manager.cpp
+++ b/tests/test_position_manager.cpp
@@ -211,6 +211,70 @@ TEST_F(PositionManagerTest, ConcurrentFillsForSameSymbol) {
   EXPECT_EQ(pm.getFilledPosition("AAPL"), 1000);
 }
 
+TEST_F(PositionManagerTest, RegisterSymbolStartsAtZero) {
+  pm.registerSymbol("AAPL");
+
+  EXPECT_EQ(pm.getFilledPosition("AAPL"), 0);
+  EXPECT_EQ(pm.getPendingPosition("AAPL"), 0);
+  EXPECT_EQ(pm.getTotalExposure("AAPL"), 0);
+}
+
+TEST_F(PositionManagerTest, DoubleRegisterDoesNotResetState) {
+  pm.registerSymbol("AAPL");
+
+  const Order filled_order = createOrder("AAPL", OrderSide::Buy, 200, 1000);
+  pm.onOrderSent(filled_order);
+  pm.onFill(createFill("AAPL", OrderSide::Buy, 200));
+
+  pm.onOrderSent(createOrder("AAPL", OrderSide::Buy, 50, 1000));
+
+  EXPECT_EQ(pm.getFilledPosition("AAPL"), 200);
+  EXPECT_EQ(pm.getPendingPosition("AAPL"), 50);
+
+  pm.registerSymbol("AAPL");
+
+  EXPECT_EQ(pm.getFilledPosition("AAPL"), 200);
+  EXPECT_EQ(pm.getPendingPosition("AAPL"), 50);
+  EXPECT_EQ(pm.getTotalExposure("AAPL"), 250);
+}
+
+TEST_F(PositionManagerTest, ConcurrentOrderSentAndFill) {
+  constexpr int orders_per_thread = 500;
+  constexpr int num_sender_threads = 4;
+
+  std::atomic<bool> start{false};
+  std::vector<std::thread> threads;
+
+  for (int t = 0; t < num_sender_threads; ++t) {
+    threads.emplace_back([&]() {
+      while (!start.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < orders_per_thread; ++i) {
+        pm.onOrderSent(createOrder("AAPL", OrderSide::Buy, 1, 1000));
+      }
+    });
+  }
+
+  threads.emplace_back([&]() {
+    while (!start.load(std::memory_order_acquire)) {
+    }
+    for (int i = 0; i < num_sender_threads * orders_per_thread; ++i) {
+      pm.onFill(createFill("AAPL", OrderSide::Buy, 1));
+    }
+  });
+
+  start.store(true, std::memory_order_release);
+
+  for (auto &t : threads) {
+    t.join();
+  }
+
+  const int64_t total_sent = num_sender_threads * orders_per_thread;
+  EXPECT_EQ(pm.getFilledPosition("AAPL"), total_sent);
+  EXPECT_EQ(pm.getPendingPosition("AAPL"), 0);
+  EXPECT_EQ(pm.getTotalExposure("AAPL"), total_sent);
+}
+
 TEST_F(PositionManagerTest, SequentialOrderFillCancelFlow) {
   const Order order1 = createOrder("AAPL", OrderSide::Buy, 100, 1000);
   pm.onOrderSent(order1);

--- a/tests/test_risk_manager.cpp
+++ b/tests/test_risk_manager.cpp
@@ -137,6 +137,39 @@ TEST_F(RiskManagerTest, RejectsOrderWhenNotionalCalculationWouldOverflow32Bit) {
   EXPECT_FALSE(risk_manager_->onNewOrder(extreme_order));
 }
 
+TEST_F(RiskManagerTest, ConcurrentOnNewOrderFromMultipleThreads) {
+  constexpr int num_threads = 4;
+  constexpr int orders_per_thread = 250;
+
+  std::atomic<bool> start{false};
+  std::atomic<int> approved{0};
+  std::vector<std::thread> threads;
+
+  for (int t = 0; t < num_threads; ++t) {
+    threads.emplace_back([&]() {
+      while (!start.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < orders_per_thread; ++i) {
+        const Order order =
+            createOrder("AAPL", OrderSide::Buy, 1, 100 * SCALING_FACTOR);
+        if (risk_manager_->onNewOrder(order)) {
+          approved.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+
+  start.store(true, std::memory_order_release);
+
+  for (auto &t : threads) {
+    t.join();
+  }
+
+  const int64_t total_exposure = pos_manager_->getTotalExposure("AAPL");
+  EXPECT_EQ(total_exposure, approved.load(std::memory_order_relaxed));
+  EXPECT_GE(total_exposure, 1);
+}
+
 TEST_F(RiskManagerTest, ApprovesOrderAtLimitWithLargeInputs) {
   constexpr int64_t qty = 10;
   const uint64_t price = static_cast<uint64_t>((10000.0 * SCALING_FACTOR) /

--- a/tests/test_thread_safe_queue.cpp
+++ b/tests/test_thread_safe_queue.cpp
@@ -1,6 +1,8 @@
 #include "Order.hpp"
 #include "ThreadSafeQueue.hpp"
+#include <atomic>
 #include <gtest/gtest.h>
+#include <set>
 #include <thread>
 #include <vector>
 
@@ -55,6 +57,53 @@ TEST_F(ThreadSafeQueueTest, MultiThreadedProducerConsumer) {
   consumer_thread.join();
 
   EXPECT_EQ(produced_orders.size(), num_items);
+}
+
+TEST_F(ThreadSafeQueueTest, MultiProducerSingleConsumer) {
+  constexpr int num_producers = 4;
+  constexpr int items_per_producer = 1000;
+  constexpr int total_items = num_producers * items_per_producer;
+
+  std::vector<std::thread> producers;
+  std::atomic<bool> start{false};
+
+  for (int p = 0; p < num_producers; ++p) {
+    producers.emplace_back([&, p]() {
+      while (!start.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < items_per_producer; ++i) {
+        Order order{};
+        order.id = p * items_per_producer + i;
+        queue.push(order);
+      }
+    });
+  }
+
+  start.store(true, std::memory_order_release);
+
+  std::set<uint64_t> received;
+  int consumed = 0;
+
+  while (consumed < total_items) {
+    Order order{};
+    if (queue.try_pop(order)) {
+      received.insert(order.id);
+      ++consumed;
+    }
+  }
+
+  for (auto &t : producers) {
+    t.join();
+  }
+
+  EXPECT_EQ(received.size(), total_items);
+  for (int i = 0; i < total_items; ++i) {
+    EXPECT_TRUE(received.count(static_cast<uint64_t>(i)) > 0)
+        << "Missing order id " << i;
+  }
+
+  Order leftover{};
+  EXPECT_FALSE(queue.try_pop(leftover));
 }
 
 TEST_F(ThreadSafeQueueTest, WaitAndPopWithTimeout) {


### PR DESCRIPTION
## Summary
- Test `registerSymbol` idempotency: starts at {0,0}, double-register preserves existing state
- Test concurrent `onOrderSent` + `onFill` on same symbol (4 senders + 1 filler)
- Test concurrent `RiskManager::onNewOrder` from 4 threads (TOCTOU scenario)
- Test multi-producer `ThreadSafeQueue` with 4 producers x 1000 items

6 of 10 original ACs dropped after review -- they tested orchestration, OS APIs, third-party libraries, or already-covered code paths. See [issue #24 comment](https://github.com/DanielMarchukov/rich-on-paper/issues/24#issuecomment-3982884553) for rationale.

Closes #24

## Test plan
- [ ] Verify all 78 tests pass: `cd build && ctest --output-on-failure`
- [ ] Run concurrency tests under TSAN to check for data races