### PR TITLE
Add sanitizer CMake options: ASAN, TSAN, UBSAN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,6 +314,8 @@ jobs:
 
   sanitizer-asan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,6 +312,57 @@ jobs:
             build/Debug/paper_money.exe
           if-no-files-found: ignore
 
+  sanitizer-asan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.28.3"
+
+      - name: Install build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake autoconf-archive libtool pkg-config
+
+      - name: Cache vcpkg dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/vcpkg_installed
+          key: ${{ runner.os }}-asan-${{ hashFiles('**/vcpkg.json') }}
+          restore-keys: |
+            ${{ runner.os }}-asan-
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        env:
+          VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        with:
+          vcpkgJsonGlob: "**/vcpkg.json"
+
+      - name: Configure CMake (ASAN + UBSAN)
+        run: >
+          cmake -B build -S .
+          -DCMAKE_BUILD_TYPE=Debug
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+          -DSANITIZE_ADDRESS=ON
+          -DSANITIZE_UNDEFINED=ON
+          -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_CXX_COMPILER=g++
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Run tests under ASAN + UBSAN
+        working-directory: ./build
+        run: ctest --output-on-failure
+        env:
+          ASAN_OPTIONS: "halt_on_error=1:detect_leaks=1"
+          UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+
   security-scan:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/nightly-tsan.yml
+++ b/.github/workflows/nightly-tsan.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   sanitizer-tsan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/nightly-tsan.yml
+++ b/.github/workflows/nightly-tsan.yml
@@ -1,0 +1,56 @@
+name: Nightly TSAN
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  sanitizer-tsan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.28.3"
+
+      - name: Install build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake autoconf-archive libtool pkg-config
+
+      - name: Cache vcpkg dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/vcpkg_installed
+          key: ${{ runner.os }}-tsan-${{ hashFiles('**/vcpkg.json') }}
+          restore-keys: |
+            ${{ runner.os }}-tsan-
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        env:
+          VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        with:
+          vcpkgJsonGlob: "**/vcpkg.json"
+
+      - name: Configure CMake (TSAN)
+        run: >
+          cmake -B build -S .
+          -DCMAKE_BUILD_TYPE=Debug
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+          -DSANITIZE_THREAD=ON
+          -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_CXX_COMPILER=g++
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Run tests under TSAN
+        working-directory: ./build
+        run: ctest --output-on-failure
+        env:
+          TSAN_OPTIONS: "halt_on_error=1:second_deadlock_stack=1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,14 @@ if(SANITIZE_ADDRESS AND SANITIZE_THREAD)
     message(FATAL_ERROR "ASAN and TSAN are incompatible — use separate builds.")
 endif()
 
+if(MSVC
+   AND (SANITIZE_ADDRESS
+        OR SANITIZE_THREAD
+        OR SANITIZE_UNDEFINED))
+    message(
+        FATAL_ERROR "Sanitizers are not supported under MSVC in this project. Use GCC or Clang.")
+endif()
+
 set(SANITIZER_FLAGS "")
 set(SANITIZER_ACTIVE OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,46 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
-include(CheckIPOSupported)
-check_ipo_supported(RESULT LTO_SUPPORTED)
-if(LTO_SUPPORTED)
-    message(STATUS "LTO is supported")
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+option(SANITIZE_ADDRESS "Enable AddressSanitizer (ASAN)" OFF)
+option(SANITIZE_THREAD "Enable ThreadSanitizer (TSAN)" OFF)
+option(SANITIZE_UNDEFINED "Enable UndefinedBehaviorSanitizer (UBSAN)" OFF)
+
+if(SANITIZE_ADDRESS AND SANITIZE_THREAD)
+    message(FATAL_ERROR "ASAN and TSAN are incompatible — use separate builds.")
+endif()
+
+set(SANITIZER_FLAGS "")
+set(SANITIZER_ACTIVE OFF)
+
+if(SANITIZE_ADDRESS)
+    list(APPEND SANITIZER_FLAGS "-fsanitize=address")
+    set(SANITIZER_ACTIVE ON)
+endif()
+if(SANITIZE_THREAD)
+    list(APPEND SANITIZER_FLAGS "-fsanitize=thread")
+    set(SANITIZER_ACTIVE ON)
+endif()
+if(SANITIZE_UNDEFINED)
+    list(APPEND SANITIZER_FLAGS "-fsanitize=undefined")
+    set(SANITIZER_ACTIVE ON)
+endif()
+
+if(SANITIZER_ACTIVE)
+    list(APPEND SANITIZER_FLAGS "-fno-omit-frame-pointer" "-g" "-O1")
+    message(STATUS "Sanitizers enabled: ${SANITIZER_FLAGS}")
+endif()
+
+if(NOT SANITIZER_ACTIVE)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT LTO_SUPPORTED)
+    if(LTO_SUPPORTED)
+        message(STATUS "LTO is supported")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    else()
+        message(WARNING "LTO is not supported")
+    endif()
 else()
-    message(WARNING "LTO is not supported")
+    message(STATUS "LTO disabled (incompatible with sanitizers)")
 endif()
 
 if(MSVC)
@@ -26,7 +59,10 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 else()
     set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-    add_compile_options("-Wall" "-Wextra" "-Wpedantic" "-march=native")
+    add_compile_options("-Wall" "-Wextra" "-Wpedantic")
+    if(NOT SANITIZER_ACTIVE)
+        add_compile_options("-march=native")
+    endif()
 endif()
 
 find_package(Boost CONFIG REQUIRED COMPONENTS lockfree)
@@ -60,9 +96,11 @@ if(MSVC)
     target_compile_definitions(paper_money PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-# ===================================================================
-# Testing Configuration
-# ===================================================================
+if(SANITIZER_ACTIVE AND NOT MSVC)
+    target_compile_options(paper_money PRIVATE ${SANITIZER_FLAGS})
+    target_link_options(paper_money PRIVATE ${SANITIZER_FLAGS})
+endif()
+
 enable_testing()
 option(ENABLE_COVERAGE "Enable code coverage" OFF)
 
@@ -76,6 +114,11 @@ target_link_libraries(
            nlohmann_json::nlohmann_json
            GTest::gtest_main
            TBB::tbb)
+
+if(SANITIZER_ACTIVE AND NOT MSVC)
+    target_compile_options(rich_on_tests PRIVATE ${SANITIZER_FLAGS})
+    target_link_options(rich_on_tests PRIVATE ${SANITIZER_FLAGS})
+endif()
 
 if(ENABLE_COVERAGE)
     message(STATUS "Code coverage enabled")
@@ -99,4 +142,8 @@ if(ENABLE_COVERAGE)
 endif()
 
 include(GoogleTest)
-gtest_discover_tests(rich_on_tests)
+if(SANITIZER_ACTIVE)
+    gtest_discover_tests(rich_on_tests DISCOVERY_MODE PRE_TEST)
+else()
+    gtest_discover_tests(rich_on_tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ cmake -B build-asan -S . -DCMAKE_BUILD_TYPE=Debug \
   -DSANITIZE_ADDRESS=ON -DSANITIZE_UNDEFINED=ON \
   -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
 cmake --build build-asan
-cd build-asan && ctest --output-on-failure
+(cd build-asan && ctest --output-on-failure)
 
 # TSAN (data races) — separate build, incompatible with ASAN
 cmake -B build-tsan -S . -DCMAKE_BUILD_TYPE=Debug \
   -DSANITIZE_THREAD=ON \
   -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
 cmake --build build-tsan
-cd build-tsan && ctest --output-on-failure
+(cd build-tsan && ctest --output-on-failure)
 ```
 
 ASAN+UBSAN runs on every push in CI. TSAN runs nightly.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,32 @@ cmake --build build
 cd build && ctest
 ```
 
+### Sanitizer Builds
+
+Sanitizer builds instrument the binary to detect memory errors, undefined behavior, and data races at runtime. They run
+the same test suite but with runtime checks enabled.
+
+```bash
+# ASAN + UBSAN (memory errors + undefined behavior)
+cmake -B build-asan -S . -DCMAKE_BUILD_TYPE=Debug \
+  -DSANITIZE_ADDRESS=ON -DSANITIZE_UNDEFINED=ON \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build-asan
+cd build-asan && ctest --output-on-failure
+
+# TSAN (data races) — separate build, incompatible with ASAN
+cmake -B build-tsan -S . -DCMAKE_BUILD_TYPE=Debug \
+  -DSANITIZE_THREAD=ON \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build-tsan
+cd build-tsan && ctest --output-on-failure
+```
+
+ASAN+UBSAN runs on every push in CI. TSAN runs nightly.
+
 ### Code Quality Tools
 
-- **C++**: clang-format, clang-tidy, LLVM coverage
+- **C++**: clang-format, clang-tidy, LLVM coverage, ASAN/TSAN/UBSAN
 - **Python**: black, isort, pylint, mypy
 - **Security**: CodeQL, bandit, safety
 

--- a/include/LockFreeMPSCQueue.hpp
+++ b/include/LockFreeMPSCQueue.hpp
@@ -27,6 +27,9 @@ public:
     T dummy;
     while (try_pop(dummy)) {
     }
+    if (tail_ != &stub_) {
+      delete tail_;
+    }
   }
 
   LockFreeMPSCQueue(const LockFreeMPSCQueue &) = delete;


### PR DESCRIPTION
## What are sanitizers?

Sanitizers are compiler-instrumented runtime checks that detect bugs
your normal tests miss. The compiler inserts extra instructions around
every memory access, thread operation, or arithmetic operation to
catch errors the moment they happen, with exact stack traces.

**AddressSanitizer (ASAN)** catches memory bugs: buffer overflows,
use-after-free, double-free, memory leaks. These are the bugs that
cause random crashes in production, often far from the actual error.
ASAN caught a real memory leak in `LockFreeMPSCQueue` on the first
run.

**UndefinedBehaviorSanitizer (UBSAN)** catches C++ undefined behavior:
signed integer overflow, null pointer dereference, misaligned access,
type punning violations. These are bugs where "it works on my
machine" but breaks with a different compiler or optimization level.

**ThreadSanitizer (TSAN)** catches data races: two threads accessing
the same memory without synchronization, where at least one is a
write. Critical for a trading engine with per-symbol consumer threads,
shared PositionManager, and concurrent risk checks.

## How it's set up

Three CMake options, all OFF by default:
- `-DSANITIZE_ADDRESS=ON` (combinable with UBSAN)
- `-DSANITIZE_UNDEFINED=ON` (combinable with ASAN)
- `-DSANITIZE_THREAD=ON` (must be a separate build -- TSAN and ASAN
  are incompatible at the compiler level)

When any sanitizer is active:
- LTO is disabled (incompatible with sanitizer instrumentation)
- `-march=native` is excluded (SIMD instructions can confuse ASAN's
  instrumented memcpy)
- Test discovery is deferred to ctest time (`PRE_TEST` mode) instead
  of build time, since the instrumented binary may behave differently
  during discovery

## CI integration

- **ASAN+UBSAN**: runs on every push and PR (same as existing build
  matrix). Added as a `sanitizer-asan` job in `build.yml`.
- **TSAN**: runs nightly at 04:00 UTC via a separate
  `nightly-tsan.yml` workflow. TSAN has 2-20x slowdown and 5-10x
  memory overhead, so it's too expensive for every push.

## Changes

- `CMakeLists.txt`: sanitizer options, mutual exclusion guard, flag
  propagation to both targets, LTO/march-native gating
- `.github/workflows/build.yml`: ASAN+UBSAN job on every push
- `.github/workflows/nightly-tsan.yml`: TSAN nightly cron job
- `README.md`: sanitizer build instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI sanitizer runs for AddressSanitizer, ThreadSanitizer, and UndefinedBehaviorSanitizer with guarded combinations and scheduled/nightly execution.
* **Documentation**
  * Added instructions for building, running, and interpreting sanitizer-enabled builds and CI schedules.
* **Bug Fixes**
  * Improved destructor cleanup to ensure a leftover tail node is released during teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->