### PR TITLE
Add static_assert for struct layout on hot-path types

### DIFF
--- a/include/Fill.hpp
+++ b/include/Fill.hpp
@@ -1,6 +1,7 @@
 #pragma once
-#include "Order.hpp" // We can reuse the OrderSide enum
+#include "Order.hpp"
 #include <cstdint>
+#include <type_traits>
 
 struct Fill {
   char symbol[8];
@@ -10,3 +11,8 @@ struct Fill {
   int64_t quantity;
   double price;
 };
+
+static_assert(sizeof(Fill) == 48, "Fill must be 48 bytes");
+static_assert(alignof(Fill) == 8, "Fill must be 8-byte aligned");
+static_assert(std::is_trivially_copyable_v<Fill>,
+              "Fill must be trivially copyable for lock-free queues");

--- a/include/MarketEvent.hpp
+++ b/include/MarketEvent.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 struct MarketEvent {
   uint64_t eventType;
@@ -14,3 +15,6 @@ struct MarketEvent {
 };
 
 static_assert(sizeof(MarketEvent) == 64, "Struct size mismatch");
+static_assert(alignof(MarketEvent) == 8, "MarketEvent must be 8-byte aligned");
+static_assert(std::is_trivially_copyable_v<MarketEvent>,
+              "MarketEvent must be trivially copyable for lock-free queues");

--- a/include/Order.hpp
+++ b/include/Order.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 enum class OrderSide : uint8_t { Buy, Sell };
 
@@ -18,3 +19,6 @@ struct Order {
 };
 
 static_assert(sizeof(Order) == 40, "Expected size is 40 bytes");
+static_assert(alignof(Order) == 8, "Order must be 8-byte aligned");
+static_assert(std::is_trivially_copyable_v<Order>,
+              "Order must be trivially copyable for lock-free queues");

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -15,6 +15,8 @@ struct SymbolKey {
   }
 };
 
+static_assert(sizeof(SymbolKey) == 8, "SymbolKey must be exactly 8 bytes");
+
 struct SymbolKeyHashCompare {
   static std::size_t hash(const SymbolKey &k) {
     return std::hash<std::string_view>{}(
@@ -30,6 +32,10 @@ struct PositionState {
   int64_t filled = 0;
   int64_t pending = 0;
 };
+
+static_assert(sizeof(PositionState) == 16, "PositionState must be 16 bytes");
+static_assert(alignof(PositionState) == 8,
+              "PositionState must be 8-byte aligned");
 
 class PositionManager {
 public:


### PR DESCRIPTION
Closes #26

## Summary

- Add `static_assert(std::is_trivially_copyable_v<T>)` for MarketEvent, Order, Fill — required for safe use in lock-free queues
- Add `static_assert(sizeof(...))` and `static_assert(alignof(...))` for Fill (48B), SymbolKey (8B), PositionState (16B)
- MarketEvent and Order already had sizeof asserts; added alignof and trivial copyability checks

## Test plan

- Verify the project builds — any struct layout change will now fail at compile time
- Run `ctest --output-on-failure` — all 78 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal compile-time validation checks for data structure alignment and memory layout to ensure system stability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->