### PR TITLE
Implement Alpaca WebSocket fill listener

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,108 @@
+# Architecture Rules
+
+Sources: [Alpaca WebSocket streaming docs][1], [Alpaca trading API docs][2], [uWebSockets GitHub][3]
+
+## Process Boundaries
+
+- Python publisher and C++ engine are separate OS processes
+- Communication is via ZeroMQ (IPC on Unix, TCP on Windows)
+- Wire format is the 64-byte `MarketEvent` struct — both sides agree
+- Any change to `MarketEvent` must update both `publisher.py` and `MarketEvent.hpp` atomically
+
+## Thread Model
+
+- Core 0 (housekeeping): OrderGateway, FillListener, OS interrupts, main thread — all cold-path I/O-bound work
+- Core 1 (data path): Python publisher — receives market data from Alpaca WebSocket, packs MarketEvent structs,
+  publishes via ZMQ. Pin with `taskset -c 1` at launch.
+- Cores 2+ (hot path): per-symbol MarketEventConsumer threads, one per core, pinned at startup
+- No thread may block another thread on the hot path
+
+## Alpaca Integration
+
+### REST API (v2)
+
+- Base URL: `https://paper-api.alpaca.markets` (paper)
+- Auth headers: `APCA-API-KEY-ID`, `APCA-API-SECRET-KEY`
+- Key endpoints: `POST /v2/orders` (place), `DELETE /v2/orders/{id}` (cancel), `GET /v2/positions` (reconcile)
+- Rate limit: 200 requests/minute. Track `X-Ratelimit-Remaining` header. Never exceed — queue orders if approaching
+  limit.
+- **Connection reuse is critical**: cpr::Post() creates a new TCP+TLS connection per call (~20-50ms overhead). Use
+  `cpr::Session` for persistent connections, or migrate to Boost.Beast.
+- Always set `TCP_NODELAY` — Nagle's algorithm adds up to 200ms delay
+- Set `TCP_QUICKACK` on Linux to disable delayed ACKs (not sticky, must re-set after each recv)
+
+### WebSocket — Trade Updates (fill listener)
+
+- Endpoint: `wss://paper-api.alpaca.markets/stream`
+- Auth: `{"action":"auth","key":"...","secret":"..."}`
+- Subscribe: `{"action":"listen","data":{"streams":["trade_updates"]}}`
+- Fill event fields: `event` ("fill"/"partial_fill"), `timestamp`, `price` (per-share), `qty` (this fill),
+  `position_qty` (total after), plus full `order` object
+- Other events: `new`, `canceled`, `expired`, `replaced`, `done_for_day`, `rejected`
+- **No message replay on reconnect** — must reconcile via REST `GET /v2/orders?status=all&after=<last_timestamp>` after
+  reconnect
+- Use exponential backoff with jitter: 100ms * 2^n + random(0,100ms), capped at 30s
+
+### WebSocket — Market Data
+
+- Endpoint: `wss://stream.data.alpaca.markets/v2/iex`
+- msgpack mode: append `?encoding=msgpack` to URL
+- Trades: `{"T":"t","S":"AAPL","p":150.25,"s":100,"t":"..."}`
+- Quotes: `{"T":"q","S":"AAPL","bp":150.20,"bs":200,"ap":150.30,...}`
+- Python publisher currently handles this; C++ rewrite planned
+
+### Library Choices
+
+- **uWebSockets** (already in vcpkg): zero-copy design, `onMessage` gives `std::string_view` into internal buffer. Best
+  for fill listener and future C++ data publisher.
+- **msgpack-c**: zero-copy unpack with reference mode — strings point into original buffer. Buffer must outlive
+  msgpack::object.
+- **simdjson**: 4x faster than RapidJSON for parsing REST responses. Use for any JSON parsing that becomes
+  latency-sensitive.
+
+## Component Ownership
+
+- `TradingEngine` owns everything via `std::unique_ptr` / `std::shared_ptr`
+- `PositionManager` is shared (read by hot path, written by fill listener) — use TBB `concurrent_hash_map` (current
+  approach is correct)
+- `RiskManager` holds `shared_ptr<PositionManager>` for read access
+- Order queue is shared between consumer threads (producers) and OrderGateway (consumer)
+
+## Dependency Direction
+
+- `MarketEventConsumer` depends on Strategy (template), RiskManager, order callback
+- `RiskManager` depends on PositionManager
+- `OrderGateway` depends on IRestClient, order queue
+- Fill listener depends on PositionManager (write) and order tracker
+- No circular dependencies
+- Strategy knows nothing about execution — it only produces orders
+
+## Configuration (planned)
+
+- Risk limits, strategy params, symbols, addresses must be configurable without recompilation
+- Environment variables for secrets (API keys)
+- Config file (YAML/JSON) for everything else
+- Defaults must be safe (conservative risk limits)
+
+## Order Lifecycle
+
+Current (broken — open loop):
+
+1. Strategy generates Order
+1. RiskManager approves, PositionManager tracks as pending
+1. OrderGateway sends to Alpaca
+1. **(gap)** — no fill tracking, pending accumulates forever
+
+Target (closed loop):
+
+1. Strategy generates Order
+1. RiskManager approves, PositionManager tracks as pending
+1. OrderGateway sends to Alpaca, records `client_order_id`
+1. Fill listener receives `fill`/`partial_fill` via WebSocket
+1. PositionManager::onFill() — decrements pending, increments filled
+1. On `canceled`/`expired` — PositionManager::onOrderCancelled()
+1. Strategy manages order lifecycle (cancel stale, replace prices)
+
+[1]: https://docs.alpaca.markets/docs/websocket-streaming
+[2]: https://docs.alpaca.markets/docs/trading-api
+[3]: https://github.com/uNetworking/uWebSockets

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -34,3 +34,4 @@ ignore:
   - "vcpkg_installed/"
   - "**/test_*.cpp"
   - "**/test_*.py"
+  - "src/TradingEngine.cpp"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,12 +420,13 @@ jobs:
           output: sarif-results
           upload: failure-only
 
-      - name: Filter SARIF to exclude vcpkg
+      - name: Filter SARIF to exclude vcpkg and test files
         uses: advanced-security/filter-sarif@v1
         with:
           patterns: |
             -**/vcpkg/**
             -**/vcpkg_installed/**
+            -**/tests/**
           input: sarif-results/cpp.sarif
           output: sarif-results/cpp.sarif
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# Rich on Paper — Claude Code Instructions
+
+## Project Overview
+
+Ultra-low-latency paper-trading engine. C++23 core, Python data
+ingestion, Alpaca Markets integration. Target: sub-50μs hot path.
+
+This is a **greenfield project**, not yet live. Refactors and
+breaking changes are welcome when they improve the design. No
+backwards compatibility constraints.
+
+## Build & Test
+
+```bash
+# Configure
+cmake -B build -S . \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+# Build
+cmake --build build
+
+# Test (C++)
+cd build && ctest --output-on-failure
+
+# Test (Python)
+pytest data-ingestion/src/ -v
+```
+
+## Critical: Low-Latency by Default
+
+Every code change must respect the hot path / cold path boundary.
+Before writing any C++ code, check `.claude/rules/low-latency.md`.
+
+Key non-negotiables:
+- **No virtual dispatch on the hot path** — use templates/CRTP
+- **No heap allocation on the hot path** — pre-allocate at startup
+- **No mutex on the hot path** — use atomics and lock-free structures
+- **No exceptions on the hot path** — use error codes
+- **Cache-line align** all hot-path structs: `alignas(64)`,
+  `static_assert(sizeof(T) == expected)`
+- **Measure before/after** every optimization
+
+When unsure if something is hot path: if it runs between ZMQ recv
+and order_queue push, it's hot path.
+
+## C++ Conventions
+
+- C++23 standard (`-std=c++23`)
+- LLVM clang-format style (see `.clang-format`)
+- `#pragma once` for header guards
+- One class per file, `PascalCase.hpp` / `PascalCase.cpp`
+- `static_assert` all struct sizes and alignment
+- `[[nodiscard]]` on functions returning values
+- Parenthesize `(std::min)` / `(std::max)` for MSVC compat
+- Platform guards: `#if defined(_WIN32)` / `__linux__` / `__APPLE__`
+
+## Python Conventions
+
+- Python 3.14, formatted with black (88 chars), sorted with isort
+- asyncio for I/O, struct.Struct for binary packing
+- Wire format must match C++ `MarketEvent` exactly (64 bytes)
+
+## Project Management
+
+Uses **Taskwarrior** with `project:rop` for all tasks.
+- `/task-next` — pick up next task, create branch
+- `/task-done` — complete current task, show what unblocked
+- `/task-status` — project progress report
+- T-shirt estimates: XS, S, M, L, XL
+- Priorities: H (critical path), M (important), L (nice-to-have)
+
+### Git Discipline
+- Branch per task: `<taskwarrior-id>/<short-slug>`
+- Commit messages: `[<id>] <imperative description>`
+- One logical change per commit
+- Explain **why** not **what**
+- **Never force push.** Always add fixup commits on top. Multiple
+  commits per PR is fine.
+- **Before every commit/push**, run `pre-commit run --all-files`
+  and stage any auto-fixes. Do not push code that fails
+  pre-commit checks.
+
+### Pull Requests
+- Always reference the matching GitHub issue with `Closes #N` or
+  `Fixes #N` in the PR body. Find the issue number via
+  `gh issue list --search "<keywords>"` before creating the PR.
+
+## Web Research
+
+When implementing low-latency patterns, performance optimizations,
+or financial protocol integrations, **always search the web** for
+current best practices. Key topics to research as needed:
+- Lock-free queue designs (Vyukov MPSC, Disruptor pattern)
+- Linux kernel bypass (io_uring, DPDK, AF_XDP)
+- Alpaca Markets API (REST v2, WebSocket streaming, msgpack framing)
+- Cache-oblivious algorithms and data structures
+- Modern C++ template metaprogramming patterns
+- FIX protocol and market microstructure
+
+## CI Pipeline
+
+GitHub Actions matrix: Ubuntu/macOS/Windows x GCC/Clang/MSVC x
+Debug/Release. Coverage via Codecov (80% target). CodeQL security
+scanning. Pre-commit hooks enforced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,11 @@
 
 ## Project Overview
 
-Ultra-low-latency paper-trading engine. C++23 core, Python data
-ingestion, Alpaca Markets integration. Target: sub-50μs hot path.
+Ultra-low-latency paper-trading engine. C++23 core, Python data ingestion, Alpaca Markets integration. Target: sub-50μs
+hot path.
 
-This is a **greenfield project**, not yet live. Refactors and
-breaking changes are welcome when they improve the design. No
-backwards compatibility constraints.
+This is a **greenfield project**, not yet live. Refactors and breaking changes are welcome when they improve the design.
+No backwards compatibility constraints.
 
 ## Build & Test
 
@@ -29,20 +28,19 @@ pytest data-ingestion/src/ -v
 
 ## Critical: Low-Latency by Default
 
-Every code change must respect the hot path / cold path boundary.
-Before writing any C++ code, check `.claude/rules/low-latency.md`.
+Every code change must respect the hot path / cold path boundary. Before writing any C++ code, check
+`.claude/rules/low-latency.md`.
 
 Key non-negotiables:
+
 - **No virtual dispatch on the hot path** — use templates/CRTP
 - **No heap allocation on the hot path** — pre-allocate at startup
 - **No mutex on the hot path** — use atomics and lock-free structures
 - **No exceptions on the hot path** — use error codes
-- **Cache-line align** all hot-path structs: `alignas(64)`,
-  `static_assert(sizeof(T) == expected)`
+- **Cache-line align** all hot-path structs: `alignas(64)`, `static_assert(sizeof(T) == expected)`
 - **Measure before/after** every optimization
 
-When unsure if something is hot path: if it runs between ZMQ recv
-and order_queue push, it's hot path.
+When unsure if something is hot path: if it runs between ZMQ recv and order_queue push, it's hot path.
 
 ## C++ Conventions
 
@@ -64,6 +62,7 @@ and order_queue push, it's hot path.
 ## Project Management
 
 Uses **Taskwarrior** with `project:rop` for all tasks.
+
 - `/task-next` — pick up next task, create branch
 - `/task-done` — complete current task, show what unblocked
 - `/task-status` — project progress report
@@ -71,26 +70,25 @@ Uses **Taskwarrior** with `project:rop` for all tasks.
 - Priorities: H (critical path), M (important), L (nice-to-have)
 
 ### Git Discipline
+
 - Branch per task: `<taskwarrior-id>/<short-slug>`
 - Commit messages: `[<id>] <imperative description>`
 - One logical change per commit
 - Explain **why** not **what**
-- **Never force push.** Always add fixup commits on top. Multiple
-  commits per PR is fine.
-- **Before every commit/push**, run `pre-commit run --all-files`
-  and stage any auto-fixes. Do not push code that fails
+- **Never force push.** Always add fixup commits on top. Multiple commits per PR is fine.
+- **Before every commit/push**, run `pre-commit run --all-files` and stage any auto-fixes. Do not push code that fails
   pre-commit checks.
 
 ### Pull Requests
-- Always reference the matching GitHub issue with `Closes #N` or
-  `Fixes #N` in the PR body. Find the issue number via
+
+- Always reference the matching GitHub issue with `Closes #N` or `Fixes #N` in the PR body. Find the issue number via
   `gh issue list --search "<keywords>"` before creating the PR.
 
 ## Web Research
 
-When implementing low-latency patterns, performance optimizations,
-or financial protocol integrations, **always search the web** for
-current best practices. Key topics to research as needed:
+When implementing low-latency patterns, performance optimizations, or financial protocol integrations, **always search
+the web** for current best practices. Key topics to research as needed:
+
 - Lock-free queue designs (Vyukov MPSC, Disruptor pattern)
 - Linux kernel bypass (io_uring, DPDK, AF_XDP)
 - Alpaca Markets API (REST v2, WebSocket streaming, msgpack framing)
@@ -100,6 +98,5 @@ current best practices. Key topics to research as needed:
 
 ## CI Pipeline
 
-GitHub Actions matrix: Ubuntu/macOS/Windows x GCC/Clang/MSVC x
-Debug/Release. Coverage via Codecov (80% target). CodeQL security
-scanning. Pre-commit hooks enforced.
+GitHub Actions matrix: Ubuntu/macOS/Windows x GCC/Clang/MSVC x Debug/Release. Coverage via Codecov (80% target). CodeQL
+security scanning. Pre-commit hooks enforced.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ find_package(nlohmann_json REQUIRED)
 find_package(GTest REQUIRED)
 find_package(unofficial-uwebsockets CONFIG REQUIRED)
 find_package(TBB CONFIG REQUIRED)
+find_package(ixwebsocket CONFIG REQUIRED)
 
 file(GLOB_RECURSE SOURCES src/*.cpp)
 file(GLOB_RECURSE HEADERS include/*.hpp)
@@ -97,7 +98,8 @@ target_link_libraries(
             nlohmann_json::nlohmann_json
             cpr::cpr
             unofficial::uwebsockets::uwebsockets
-            TBB::tbb)
+            TBB::tbb
+            ixwebsocket::ixwebsocket)
 
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
@@ -121,7 +123,8 @@ target_link_libraries(
            cpr::cpr
            nlohmann_json::nlohmann_json
            GTest::gtest_main
-           TBB::tbb)
+           TBB::tbb
+           ixwebsocket::ixwebsocket)
 
 if(SANITIZER_ACTIVE AND NOT MSVC)
     target_compile_options(rich_on_tests PRIVATE ${SANITIZER_FLAGS})

--- a/data-ingestion/src/publisher.py
+++ b/data-ingestion/src/publisher.py
@@ -223,5 +223,5 @@ async def main(zmq_address=None):
 
 
 if __name__ == "__main__":
-    set_cpu_affinity(0)
+    set_cpu_affinity(1)
     asyncio.run(main())

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <nlohmann/json_fwd.hpp>
 #include <string>
+#include <thread>
 #include <variant>
 
 struct FillEvent {
@@ -50,4 +51,5 @@ private:
   std::string api_key_;
   std::string api_secret_;
   ix::WebSocket ws_;
+  std::thread thread_;
 };

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "IFillListener.hpp"
+#include "PositionManager.hpp"
+#include <atomic>
+#include <ixwebsocket/IXWebSocket.h>
+#include <memory>
+#include <string>
+#include <variant>
+
+struct FillEvent {
+  char symbol[8];
+  OrderSide side;
+  int64_t quantity;
+  double price;
+};
+
+struct CancelEvent {
+  char symbol[8];
+  OrderSide side;
+  int64_t quantity;
+};
+
+using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
+
+[[nodiscard]] TradeUpdate parseTradingUpdate(const std::string &json);
+
+class AlpacaFillListener : public IFillListener {
+public:
+  AlpacaFillListener(std::shared_ptr<PositionManager> position_manager,
+                     std::atomic<bool> &is_running,
+                     const std::string &api_key,
+                     const std::string &api_secret);
+
+  void start() override;
+  void stop() override;
+
+private:
+  void onMessage(const ix::WebSocketMessagePtr &msg);
+  void sendAuth();
+  void sendSubscribe();
+  void handleTradeUpdate(const std::string &json);
+
+  std::shared_ptr<PositionManager> position_manager_;
+  std::atomic<bool> &is_running_;
+  std::string api_key_;
+  std::string api_secret_;
+  ix::WebSocket ws_;
+};

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <ixwebsocket/IXWebSocket.h>
 #include <memory>
+#include <nlohmann/json_fwd.hpp>
 #include <string>
 #include <variant>
 
@@ -23,13 +24,15 @@ struct CancelEvent {
 
 using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 
-[[nodiscard]] TradeUpdate parseTradingUpdate(const std::string &json);
+[[nodiscard]] TradeUpdate parseTradingUpdate(const nlohmann::json &parsed);
 
 class AlpacaFillListener : public IFillListener {
 public:
   AlpacaFillListener(std::shared_ptr<PositionManager> position_manager,
                      std::atomic<bool> &is_running, const std::string &api_key,
                      const std::string &api_secret);
+
+  ~AlpacaFillListener() override;
 
   void start() override;
   void stop() override;

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -28,8 +28,7 @@ using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 class AlpacaFillListener : public IFillListener {
 public:
   AlpacaFillListener(std::shared_ptr<PositionManager> position_manager,
-                     std::atomic<bool> &is_running,
-                     const std::string &api_key,
+                     std::atomic<bool> &is_running, const std::string &api_key,
                      const std::string &api_secret);
 
   void start() override;

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -27,6 +27,8 @@ using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 [[nodiscard]] TradeUpdate parseTradingUpdate(const nlohmann::json &parsed);
 
 class AlpacaFillListener : public IFillListener {
+  friend class FillListenerTest;
+
 public:
   AlpacaFillListener(std::shared_ptr<PositionManager> position_manager,
                      std::atomic<bool> &is_running, const std::string &api_key,

--- a/include/IFillListener.hpp
+++ b/include/IFillListener.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+class IFillListener {
+public:
+  virtual ~IFillListener() = default;
+  virtual void start() = 0;
+  virtual void stop() = 0;
+};

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -11,6 +11,8 @@
 #include <thread>
 #include <vector>
 
+class IFillListener;
+
 void pin_thread_to_core(std::thread &t, size_t core_id);
 
 class TradingEngine {
@@ -44,4 +46,5 @@ private:
   std::unique_ptr<OrderGateway> order_gateway_;
   std::thread order_gateway_thread_;
   std::vector<ConsumerThread> consumer_threads_;
+  std::unique_ptr<IFillListener> fill_listener_;
 };

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <iostream>
 #include <nlohmann/json.hpp>
+#include <optional>
 
 namespace {
 
@@ -19,23 +20,45 @@ void copySymbol(char (&dest)[8], const std::string &src) {
   }
 }
 
-OrderSide parseSide(const std::string &side_str) {
+[[nodiscard]] std::optional<OrderSide> parseSide(const std::string &side_str) {
+  if (side_str == "buy") {
+    return OrderSide::Buy;
+  }
   if (side_str == "sell") {
     return OrderSide::Sell;
   }
-  return OrderSide::Buy;
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<int64_t> parseQty(const nlohmann::json &val) {
+  try {
+    if (val.is_string()) {
+      return std::stoll(val.get<std::string>());
+    }
+    if (val.is_number_integer()) {
+      return val.get<int64_t>();
+    }
+  } catch (const std::exception &) {
+  }
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<double> parsePrice(const nlohmann::json &val) {
+  try {
+    if (val.is_string()) {
+      return std::stod(val.get<std::string>());
+    }
+    if (val.is_number()) {
+      return val.get<double>();
+    }
+  } catch (const std::exception &) {
+  }
+  return std::nullopt;
 }
 
 } // namespace
 
-TradeUpdate parseTradingUpdate(const std::string &json) {
-  nlohmann::json parsed;
-  try {
-    parsed = nlohmann::json::parse(json);
-  } catch (const nlohmann::json::parse_error &) {
-    return std::monostate{};
-  }
-
+TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
   if (!parsed.contains("stream") || parsed["stream"] != "trade_updates") {
     return std::monostate{};
   }
@@ -56,56 +79,58 @@ TradeUpdate parseTradingUpdate(const std::string &json) {
   }
 
   const auto &order = data["order"];
-  if (!order.contains("symbol") || !order.contains("side")) {
+  if (!order.contains("symbol") || !order["symbol"].is_string() ||
+      !order.contains("side") || !order["side"].is_string()) {
     return std::monostate{};
   }
 
   const std::string symbol = order["symbol"];
-  const std::string side_str = order["side"];
-  const OrderSide side = parseSide(side_str);
+  const auto side = parseSide(order["side"].get<std::string>());
+  if (!side.has_value()) {
+    return std::monostate{};
+  }
 
   if (event == "fill" || event == "partial_fill") {
     if (!data.contains("qty") || !data.contains("price")) {
       return std::monostate{};
     }
 
+    const auto qty = parseQty(data["qty"]);
+    const auto price = parsePrice(data["price"]);
+    if (!qty.has_value() || !price.has_value()) {
+      return std::monostate{};
+    }
+
     FillEvent fill{};
     copySymbol(fill.symbol, symbol);
-    fill.side = side;
-
-    const auto &qty_val = data["qty"];
-    if (qty_val.is_string()) {
-      fill.quantity = std::stoll(qty_val.get<std::string>());
-    } else {
-      fill.quantity = qty_val.get<int64_t>();
-    }
-
-    const auto &price_val = data["price"];
-    if (price_val.is_string()) {
-      fill.price = std::stod(price_val.get<std::string>());
-    } else {
-      fill.price = price_val.get<double>();
-    }
-
+    fill.side = *side;
+    fill.quantity = *qty;
+    fill.price = *price;
     return fill;
   }
 
   if (event == "canceled" || event == "expired" || event == "rejected") {
     CancelEvent cancel{};
     copySymbol(cancel.symbol, symbol);
-    cancel.side = side;
+    cancel.side = *side;
+
+    int64_t total_qty = 0;
+    int64_t filled_qty = 0;
 
     if (order.contains("qty")) {
-      const auto &qty_val = order["qty"];
-      if (qty_val.is_string()) {
-        cancel.quantity = std::stoll(qty_val.get<std::string>());
-      } else {
-        cancel.quantity = qty_val.get<int64_t>();
+      const auto q = parseQty(order["qty"]);
+      if (q.has_value()) {
+        total_qty = *q;
       }
-    } else {
-      cancel.quantity = 0;
+    }
+    if (order.contains("filled_qty")) {
+      const auto fq = parseQty(order["filled_qty"]);
+      if (fq.has_value()) {
+        filled_qty = *fq;
+      }
     }
 
+    cancel.quantity = (std::max)(int64_t{0}, total_qty - filled_qty);
     return cancel;
   }
 
@@ -118,6 +143,8 @@ AlpacaFillListener::AlpacaFillListener(
     const std::string &api_secret)
     : position_manager_(std::move(position_manager)), is_running_(is_running),
       api_key_(api_key), api_secret_(api_secret) {}
+
+AlpacaFillListener::~AlpacaFillListener() { stop(); }
 
 void AlpacaFillListener::start() {
   ws_.setUrl(kStreamUrl);
@@ -195,11 +222,29 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
   }
 
   if (parsed.contains("stream") && parsed["stream"] == "listening") {
-    std::cout << "FillListener: Subscribed to trade_updates" << std::endl;
+    if (parsed.contains("data") && parsed["data"].contains("streams") &&
+        parsed["data"]["streams"].is_array()) {
+      const auto &streams = parsed["data"]["streams"];
+      bool found = false;
+      for (const auto &s : streams) {
+        if (s.is_string() && s.get<std::string>() == "trade_updates") {
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        std::cout << "FillListener: Subscribed to trade_updates" << std::endl;
+      } else {
+        std::cerr << "FillListener: trade_updates not in streams list"
+                  << std::endl;
+      }
+    } else {
+      std::cerr << "FillListener: Malformed listening response" << std::endl;
+    }
     return;
   }
 
-  const TradeUpdate update = parseTradingUpdate(json);
+  const TradeUpdate update = parseTradingUpdate(parsed);
 
   if (std::holds_alternative<FillEvent>(update)) {
     const auto &fill_event = std::get<FillEvent>(update);
@@ -212,7 +257,8 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     fill.price = fill_event.price;
     position_manager_->onFill(fill);
     std::cout << "FillListener: Fill processed ("
-              << std::string_view(fill_event.symbol, kSymbolCapacity)
+              << std::string_view(fill_event.symbol,
+                                  strnlen(fill_event.symbol, kSymbolCapacity))
               << " qty=" << fill_event.quantity << ")" << std::endl;
   } else if (std::holds_alternative<CancelEvent>(update)) {
     const auto &cancel_event = std::get<CancelEvent>(update);
@@ -225,7 +271,8 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     order.type = OrderType::Market;
     position_manager_->onOrderCancelled(order);
     std::cout << "FillListener: Cancel processed ("
-              << std::string_view(cancel_event.symbol, kSymbolCapacity)
+              << std::string_view(cancel_event.symbol,
+                                  strnlen(cancel_event.symbol, kSymbolCapacity))
               << " qty=" << cancel_event.quantity << ")" << std::endl;
   }
 }

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -4,6 +4,9 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <thread>
+
+void pin_thread_to_core(std::thread &t, size_t core_id);
 
 namespace {
 
@@ -154,10 +157,17 @@ void AlpacaFillListener::start() {
   ws_.setOnMessageCallback(
       [this](const ix::WebSocketMessagePtr &msg) { onMessage(msg); });
 
-  ws_.start();
+  thread_ = std::thread(&ix::WebSocket::run, &ws_);
+  pin_thread_to_core(thread_, 0);
+  std::cout << "Pinned FillListener thread to CPU Core 0" << std::endl;
 }
 
-void AlpacaFillListener::stop() { ws_.stop(); }
+void AlpacaFillListener::stop() {
+  ws_.stop();
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
 
 void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
   if (!is_running_.load()) {

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -1,0 +1,243 @@
+#include "AlpacaFillListener.hpp"
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+namespace {
+
+constexpr const char *kStreamUrl =
+    "wss://paper-api.alpaca.markets/stream";
+constexpr int kMinReconnectMs = 100;
+constexpr int kMaxReconnectMs = 30000;
+constexpr std::size_t kSymbolCapacity = 8;
+
+void copySymbol(char (&dest)[8], const std::string &src) {
+  std::memset(dest, 0, kSymbolCapacity);
+  const auto len = (std::min)(src.size(), kSymbolCapacity);
+  if (len > 0) {
+    std::memcpy(dest, src.data(), len);
+  }
+}
+
+OrderSide parseSide(const std::string &side_str) {
+  if (side_str == "sell") {
+    return OrderSide::Sell;
+  }
+  return OrderSide::Buy;
+}
+
+} // namespace
+
+TradeUpdate parseTradingUpdate(const std::string &json) {
+  nlohmann::json parsed;
+  try {
+    parsed = nlohmann::json::parse(json);
+  } catch (const nlohmann::json::parse_error &) {
+    return std::monostate{};
+  }
+
+  if (!parsed.contains("stream") ||
+      parsed["stream"] != "trade_updates") {
+    return std::monostate{};
+  }
+
+  if (!parsed.contains("data") || !parsed["data"].is_object()) {
+    return std::monostate{};
+  }
+
+  const auto &data = parsed["data"];
+  if (!data.contains("event") || !data["event"].is_string()) {
+    return std::monostate{};
+  }
+
+  const std::string event = data["event"];
+
+  if (!data.contains("order") || !data["order"].is_object()) {
+    return std::monostate{};
+  }
+
+  const auto &order = data["order"];
+  if (!order.contains("symbol") || !order.contains("side")) {
+    return std::monostate{};
+  }
+
+  const std::string symbol = order["symbol"];
+  const std::string side_str = order["side"];
+  const OrderSide side = parseSide(side_str);
+
+  if (event == "fill" || event == "partial_fill") {
+    if (!data.contains("qty") || !data.contains("price")) {
+      return std::monostate{};
+    }
+
+    FillEvent fill{};
+    copySymbol(fill.symbol, symbol);
+    fill.side = side;
+
+    const auto &qty_val = data["qty"];
+    if (qty_val.is_string()) {
+      fill.quantity = std::stoll(qty_val.get<std::string>());
+    } else {
+      fill.quantity = qty_val.get<int64_t>();
+    }
+
+    const auto &price_val = data["price"];
+    if (price_val.is_string()) {
+      fill.price = std::stod(price_val.get<std::string>());
+    } else {
+      fill.price = price_val.get<double>();
+    }
+
+    return fill;
+  }
+
+  if (event == "canceled" || event == "expired" ||
+      event == "rejected") {
+    CancelEvent cancel{};
+    copySymbol(cancel.symbol, symbol);
+    cancel.side = side;
+
+    if (order.contains("qty")) {
+      const auto &qty_val = order["qty"];
+      if (qty_val.is_string()) {
+        cancel.quantity = std::stoll(qty_val.get<std::string>());
+      } else {
+        cancel.quantity = qty_val.get<int64_t>();
+      }
+    } else {
+      cancel.quantity = 0;
+    }
+
+    return cancel;
+  }
+
+  return std::monostate{};
+}
+
+AlpacaFillListener::AlpacaFillListener(
+    std::shared_ptr<PositionManager> position_manager,
+    std::atomic<bool> &is_running, const std::string &api_key,
+    const std::string &api_secret)
+    : position_manager_(std::move(position_manager)),
+      is_running_(is_running), api_key_(api_key),
+      api_secret_(api_secret) {}
+
+void AlpacaFillListener::start() {
+  ws_.setUrl(kStreamUrl);
+  ws_.setMinWaitBetweenReconnectionRetries(kMinReconnectMs);
+  ws_.setMaxWaitBetweenReconnectionRetries(kMaxReconnectMs);
+
+  ws_.setOnMessageCallback(
+      [this](const ix::WebSocketMessagePtr &msg) { onMessage(msg); });
+
+  ws_.start();
+}
+
+void AlpacaFillListener::stop() {
+  ws_.stop();
+}
+
+void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
+  if (!is_running_.load()) {
+    return;
+  }
+
+  switch (msg->type) {
+  case ix::WebSocketMessageType::Open:
+    std::cout << "FillListener: WebSocket connected" << std::endl;
+    sendAuth();
+    break;
+
+  case ix::WebSocketMessageType::Message:
+    handleTradeUpdate(msg->str);
+    break;
+
+  case ix::WebSocketMessageType::Error:
+    std::cerr << "FillListener: WebSocket error: " << msg->errorInfo.reason
+              << std::endl;
+    break;
+
+  case ix::WebSocketMessageType::Close:
+    std::cout << "FillListener: WebSocket closed (code="
+              << msg->closeInfo.code << ")" << std::endl;
+    break;
+
+  default:
+    break;
+  }
+}
+
+void AlpacaFillListener::sendAuth() {
+  nlohmann::json auth_msg = {{"action", "auth"},
+                             {"key", api_key_},
+                             {"secret", api_secret_}};
+  ws_.send(auth_msg.dump());
+}
+
+void AlpacaFillListener::sendSubscribe() {
+  nlohmann::json sub_msg = {
+      {"action", "listen"},
+      {"data", {{"streams", {"trade_updates"}}}}};
+  ws_.send(sub_msg.dump());
+}
+
+void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
+  nlohmann::json parsed;
+  try {
+    parsed = nlohmann::json::parse(json);
+  } catch (const nlohmann::json::parse_error &) {
+    std::cerr << "FillListener: Failed to parse message" << std::endl;
+    return;
+  }
+
+  if (parsed.contains("stream") &&
+      parsed["stream"] == "authorization") {
+    if (parsed.contains("data") &&
+        parsed["data"].contains("status") &&
+        parsed["data"]["status"] == "authorized") {
+      std::cout << "FillListener: Authorized" << std::endl;
+      sendSubscribe();
+    } else {
+      std::cerr << "FillListener: Authorization failed" << std::endl;
+    }
+    return;
+  }
+
+  if (parsed.contains("stream") &&
+      parsed["stream"] == "listening") {
+    std::cout << "FillListener: Subscribed to trade_updates"
+              << std::endl;
+    return;
+  }
+
+  const TradeUpdate update = parseTradingUpdate(json);
+
+  if (std::holds_alternative<FillEvent>(update)) {
+    const auto &fill_event = std::get<FillEvent>(update);
+    Fill fill{};
+    std::memcpy(fill.symbol, fill_event.symbol, kSymbolCapacity);
+    fill.executionId = 0;
+    fill.orderId = 0;
+    fill.side = fill_event.side;
+    fill.quantity = fill_event.quantity;
+    fill.price = fill_event.price;
+    position_manager_->onFill(fill);
+    std::cout << "FillListener: Fill processed ("
+              << std::string_view(fill_event.symbol, kSymbolCapacity)
+              << " qty=" << fill_event.quantity << ")" << std::endl;
+  } else if (std::holds_alternative<CancelEvent>(update)) {
+    const auto &cancel_event = std::get<CancelEvent>(update);
+    Order order{};
+    order.id = 0;
+    std::memcpy(order.symbol, cancel_event.symbol, kSymbolCapacity);
+    order.quantity = cancel_event.quantity;
+    order.price = 0;
+    order.side = cancel_event.side;
+    order.type = OrderType::Market;
+    position_manager_->onOrderCancelled(order);
+    std::cout << "FillListener: Cancel processed ("
+              << std::string_view(cancel_event.symbol, kSymbolCapacity)
+              << " qty=" << cancel_event.quantity << ")" << std::endl;
+  }
+}

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -6,8 +6,7 @@
 
 namespace {
 
-constexpr const char *kStreamUrl =
-    "wss://paper-api.alpaca.markets/stream";
+constexpr const char *kStreamUrl = "wss://paper-api.alpaca.markets/stream";
 constexpr int kMinReconnectMs = 100;
 constexpr int kMaxReconnectMs = 30000;
 constexpr std::size_t kSymbolCapacity = 8;
@@ -37,8 +36,7 @@ TradeUpdate parseTradingUpdate(const std::string &json) {
     return std::monostate{};
   }
 
-  if (!parsed.contains("stream") ||
-      parsed["stream"] != "trade_updates") {
+  if (!parsed.contains("stream") || parsed["stream"] != "trade_updates") {
     return std::monostate{};
   }
 
@@ -92,8 +90,7 @@ TradeUpdate parseTradingUpdate(const std::string &json) {
     return fill;
   }
 
-  if (event == "canceled" || event == "expired" ||
-      event == "rejected") {
+  if (event == "canceled" || event == "expired" || event == "rejected") {
     CancelEvent cancel{};
     copySymbol(cancel.symbol, symbol);
     cancel.side = side;
@@ -119,9 +116,8 @@ AlpacaFillListener::AlpacaFillListener(
     std::shared_ptr<PositionManager> position_manager,
     std::atomic<bool> &is_running, const std::string &api_key,
     const std::string &api_secret)
-    : position_manager_(std::move(position_manager)),
-      is_running_(is_running), api_key_(api_key),
-      api_secret_(api_secret) {}
+    : position_manager_(std::move(position_manager)), is_running_(is_running),
+      api_key_(api_key), api_secret_(api_secret) {}
 
 void AlpacaFillListener::start() {
   ws_.setUrl(kStreamUrl);
@@ -134,9 +130,7 @@ void AlpacaFillListener::start() {
   ws_.start();
 }
 
-void AlpacaFillListener::stop() {
-  ws_.stop();
-}
+void AlpacaFillListener::stop() { ws_.stop(); }
 
 void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
   if (!is_running_.load()) {
@@ -159,8 +153,8 @@ void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
     break;
 
   case ix::WebSocketMessageType::Close:
-    std::cout << "FillListener: WebSocket closed (code="
-              << msg->closeInfo.code << ")" << std::endl;
+    std::cout << "FillListener: WebSocket closed (code=" << msg->closeInfo.code
+              << ")" << std::endl;
     break;
 
   default:
@@ -169,16 +163,14 @@ void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
 }
 
 void AlpacaFillListener::sendAuth() {
-  nlohmann::json auth_msg = {{"action", "auth"},
-                             {"key", api_key_},
-                             {"secret", api_secret_}};
+  nlohmann::json auth_msg = {
+      {"action", "auth"}, {"key", api_key_}, {"secret", api_secret_}};
   ws_.send(auth_msg.dump());
 }
 
 void AlpacaFillListener::sendSubscribe() {
-  nlohmann::json sub_msg = {
-      {"action", "listen"},
-      {"data", {{"streams", {"trade_updates"}}}}};
+  nlohmann::json sub_msg = {{"action", "listen"},
+                            {"data", {{"streams", {"trade_updates"}}}}};
   ws_.send(sub_msg.dump());
 }
 
@@ -191,10 +183,8 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     return;
   }
 
-  if (parsed.contains("stream") &&
-      parsed["stream"] == "authorization") {
-    if (parsed.contains("data") &&
-        parsed["data"].contains("status") &&
+  if (parsed.contains("stream") && parsed["stream"] == "authorization") {
+    if (parsed.contains("data") && parsed["data"].contains("status") &&
         parsed["data"]["status"] == "authorized") {
       std::cout << "FillListener: Authorized" << std::endl;
       sendSubscribe();
@@ -204,10 +194,8 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     return;
   }
 
-  if (parsed.contains("stream") &&
-      parsed["stream"] == "listening") {
-    std::cout << "FillListener: Subscribed to trade_updates"
-              << std::endl;
+  if (parsed.contains("stream") && parsed["stream"] == "listening") {
+    std::cout << "FillListener: Subscribed to trade_updates" << std::endl;
     return;
   }
 

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -106,8 +106,8 @@ void TradingEngine::setup_signal_handler() {
 
 void TradingEngine::launch_gateway() {
   order_gateway_thread_ = std::thread(&OrderGateway::run, order_gateway_.get());
-  std::cout << "Pinned OrderGateway thread to CPU Core 1" << std::endl;
-  pin_thread_to_core(order_gateway_thread_, 1);
+  pin_thread_to_core(order_gateway_thread_, 0);
+  std::cout << "Pinned OrderGateway thread to CPU Core 0" << std::endl;
 }
 
 void TradingEngine::launch_consumers() {

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -1,5 +1,8 @@
 #include "TradingEngine.hpp"
+#include "AlpacaFillListener.hpp"
+#include "Utils.hpp"
 #include <csignal>
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 
@@ -67,6 +70,15 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
   order_gateway_ = std::make_unique<OrderGateway>(is_running_, order_queue_,
                                                   std::move(rest_client));
 
+  const char *api_key = std::getenv("APCA_API_KEY_ID");
+  const char *api_secret = std::getenv("APCA_API_SECRET_KEY");
+  if (!api_key || !api_secret) {
+    throw std::runtime_error(
+        "APCA_API_KEY_ID and APCA_API_SECRET_KEY must be set");
+  }
+  fill_listener_ = std::make_unique<AlpacaFillListener>(
+      position_manager, is_running_, api_key, api_secret);
+
 #ifdef _WIN32
   ipc_address_ = "tcp://127.0.0.1:5555";
 #else
@@ -128,6 +140,7 @@ void TradingEngine::main_loop() const {
 }
 
 void TradingEngine::shutdown() {
+  fill_listener_->stop();
   if (order_gateway_thread_.joinable()) {
     order_gateway_thread_.join();
   }
@@ -143,6 +156,8 @@ void TradingEngine::shutdown() {
 
 void TradingEngine::run() {
   std::cout << "Starting trading engine..." << std::endl;
+  fill_listener_->start();
+  std::cout << "FillListener started" << std::endl;
   launch_gateway();
   launch_consumers();
   main_loop();

--- a/tests/TestHelpers.hpp
+++ b/tests/TestHelpers.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Fill.hpp"
+#include "Order.hpp"
+#include <algorithm>
+#include <cstring>
+
+namespace test_helpers {
+
+[[nodiscard]] inline Order createOrder(const char *symbol, const OrderSide side,
+                                       const int64_t qty,
+                                       const uint64_t price) {
+  Order order{};
+  std::memset(order.symbol, 0, sizeof(order.symbol));
+  const auto len = (std::min)(std::strlen(symbol), sizeof(order.symbol));
+  std::memcpy(order.symbol, symbol, len);
+  order.side = side;
+  order.quantity = qty;
+  order.price = price;
+  return order;
+}
+
+[[nodiscard]] inline Fill createFill(const char *symbol, const OrderSide side,
+                                     const int64_t qty) {
+  Fill fill{};
+  std::memset(fill.symbol, 0, sizeof(fill.symbol));
+  const auto len = (std::min)(std::strlen(symbol), sizeof(fill.symbol));
+  std::memcpy(fill.symbol, symbol, len);
+  fill.side = side;
+  fill.quantity = qty;
+  return fill;
+}
+
+} // namespace test_helpers

--- a/tests/test_error_scenarios.cpp
+++ b/tests/test_error_scenarios.cpp
@@ -52,8 +52,3 @@ TEST(MarketEventConsumerErrorTest, HandlesStrategyException) {
 
   EXPECT_FALSE(callback_called);
 }
-
-// HandlesRestClientException: covered by
-//   test_order_gateway.cpp::CatchesStdExceptionInMainLoop
-// HandlesNullPositionManager: covered by test_risk_manager.cpp
-// HandlesMultiThreadedUpdates: covered by test_position_manager.cpp

--- a/tests/test_error_scenarios.cpp
+++ b/tests/test_error_scenarios.cpp
@@ -1,5 +1,4 @@
 #include "MarketEventConsumer.hpp"
-#include "OrderGateway.hpp"
 #include "RiskManager.hpp"
 #include "Strategy.hpp"
 #include <cstring>
@@ -10,13 +9,6 @@ class ThrowingStrategy final : public Strategy {
 public:
   static std::vector<Order> onMarketEvent(const MarketEvent &) {
     throw std::runtime_error("Strategy error");
-  }
-};
-
-class ThrowingRestClient final : public IRestClient {
-public:
-  void placeOrder(const Order &) override {
-    throw std::runtime_error("Network error");
   }
 };
 
@@ -61,24 +53,7 @@ TEST(MarketEventConsumerErrorTest, HandlesStrategyException) {
   EXPECT_FALSE(callback_called);
 }
 
-TEST(OrderGatewayErrorTest, HandlesRestClientException) {
-  std::atomic is_running(true);
-  const auto order_queue = std::make_shared<ThreadSafeQueue<Order>>();
-  auto throwing_client = std::make_unique<ThrowingRestClient>();
-
-  OrderGateway gateway(is_running, order_queue, std::move(throwing_client));
-
-  Order test_order{};
-  test_order.id = 1;
-  order_queue->push(test_order);
-
-  std::thread gateway_thread(&OrderGateway::run, &gateway);
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  is_running.store(false);
-  gateway_thread.join();
-
-  SUCCEED();
-}
-
+// HandlesRestClientException: covered by
+//   test_order_gateway.cpp::CatchesStdExceptionInMainLoop
 // HandlesNullPositionManager: covered by test_risk_manager.cpp
 // HandlesMultiThreadedUpdates: covered by test_position_manager.cpp

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -1,5 +1,6 @@
 #include "AlpacaFillListener.hpp"
 #include "PositionManager.hpp"
+#include <cstring>
 #include <gtest/gtest.h>
 #include <memory>
 #include <nlohmann/json.hpp>

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -382,3 +382,42 @@ TEST_F(FillListenerTest, OnMessageHandlesCloseType) {
   auto msg = makeMessage(ix::WebSocketMessageType::Close, body);
   callOnMessage(msg);
 }
+
+TEST_F(FillListenerTest, StopDuringActiveProcessingCompletesCorrectly) {
+  constexpr int num_fills = 100;
+
+  for (int i = 0; i < num_fills; ++i) {
+    addPendingOrder("AAPL", 1, OrderSide::Buy);
+  }
+
+  std::atomic<int> processed{0};
+  std::thread processor([&]() {
+    for (int i = 0; i < num_fills; ++i) {
+      callHandleTradeUpdate(R"({
+        "stream": "trade_updates",
+        "data": {
+          "event": "fill",
+          "qty": "1",
+          "price": "150.25",
+          "order": {"symbol": "AAPL", "side": "buy"}
+        }
+      })");
+      processed.fetch_add(1, std::memory_order_relaxed);
+    }
+  });
+
+  // Wait until processing has started, then stop
+  while (processed.load(std::memory_order_relaxed) < 5) {
+    std::this_thread::yield();
+  }
+  listener_->stop();
+
+  processor.join();
+
+  // All fills that were dispatched must have completed atomically —
+  // no partial state corruption
+  const int64_t filled = position_manager_->getFilledPosition("AAPL");
+  const int64_t pending = position_manager_->getPendingPosition("AAPL");
+  EXPECT_EQ(filled + pending, num_fills);
+  EXPECT_EQ(filled, processed.load(std::memory_order_relaxed));
+}

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -12,13 +12,43 @@ protected:
     position_manager_ = std::make_shared<PositionManager>();
     position_manager_->registerSymbol("AAPL");
     position_manager_->registerSymbol("GOOGL");
+    listener_ = std::make_unique<AlpacaFillListener>(
+        position_manager_, is_running_, "test_key", "test_secret");
   }
 
   static TradeUpdate parse(const std::string &json_str) {
     return parseTradingUpdate(nlohmann::json::parse(json_str));
   }
 
+  void addPendingOrder(const char *symbol, int64_t qty, OrderSide side) {
+    Order order{};
+    order.id = 1;
+    std::memcpy(order.symbol, symbol, strnlen(symbol, 8));
+    order.quantity = qty;
+    order.price = 1000000;
+    order.side = side;
+    order.type = OrderType::Limit;
+    position_manager_->onOrderSent(order);
+  }
+
+  ix::WebSocketMessagePtr makeMessage(ix::WebSocketMessageType type,
+                                      const std::string &body) {
+    return std::make_unique<ix::WebSocketMessage>(
+        type, body, body.size(), ix::WebSocketErrorInfo{},
+        ix::WebSocketOpenInfo{}, ix::WebSocketCloseInfo{});
+  }
+
+  void callHandleTradeUpdate(const std::string &json) {
+    listener_->handleTradeUpdate(json);
+  }
+
+  void callOnMessage(const ix::WebSocketMessagePtr &msg) {
+    listener_->onMessage(msg);
+  }
+
   std::shared_ptr<PositionManager> position_manager_;
+  std::atomic<bool> is_running_{true};
+  std::unique_ptr<AlpacaFillListener> listener_;
 };
 
 TEST_F(FillListenerTest, ParsesFillEvent) {
@@ -337,4 +367,158 @@ TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {
   const auto &fill = std::get<FillEvent>(update);
   EXPECT_EQ(fill.quantity, 75);
   EXPECT_DOUBLE_EQ(fill.price, 99.50);
+}
+
+// --- handleTradeUpdate tests (full dispatch pipeline) ---
+
+TEST_F(FillListenerTest, HandleTradeUpdateRejectsInvalidJson) {
+  addPendingOrder("AAPL", 100, OrderSide::Buy);
+  callHandleTradeUpdate("not valid json{{{");
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateProcessesAuthSuccess) {
+  callHandleTradeUpdate(R"({
+    "stream": "authorization",
+    "data": {"status": "authorized"}
+  })");
+  // sendSubscribe calls ws_.send on non-connected socket — no crash
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateProcessesAuthFailure) {
+  callHandleTradeUpdate(R"({
+    "stream": "authorization",
+    "data": {"status": "unauthorized"}
+  })");
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateProcessesListeningSuccess) {
+  callHandleTradeUpdate(R"({
+    "stream": "listening",
+    "data": {"streams": ["trade_updates"]}
+  })");
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateProcessesListeningMissingStream) {
+  callHandleTradeUpdate(R"({
+    "stream": "listening",
+    "data": {"streams": ["account_updates"]}
+  })");
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateProcessesMalformedListening) {
+  callHandleTradeUpdate(R"({
+    "stream": "listening",
+    "data": {}
+  })");
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateDispatchesFill) {
+  addPendingOrder("AAPL", 100, OrderSide::Buy);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {"symbol": "AAPL", "side": "buy"}
+    }
+  })");
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateDispatchesCancel) {
+  addPendingOrder("AAPL", 100, OrderSide::Buy);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "canceled",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "100",
+        "filled_qty": "0"
+      }
+    }
+  })");
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+}
+
+TEST_F(FillListenerTest, HandleTradeUpdateIgnoresUnknownEvent) {
+  addPendingOrder("AAPL", 100, OrderSide::Buy);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "new",
+      "order": {"symbol": "AAPL", "side": "buy", "qty": "100"}
+    }
+  })");
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
+}
+
+// --- onMessage tests (WebSocket dispatch) ---
+
+TEST_F(FillListenerTest, OnMessageIgnoresWhenNotRunning) {
+  addPendingOrder("AAPL", 100, OrderSide::Buy);
+  is_running_.store(false);
+
+  std::string body = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {"symbol": "AAPL", "side": "buy"}
+    }
+  })";
+  auto msg = makeMessage(ix::WebSocketMessageType::Message, body);
+  callOnMessage(msg);
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 0);
+}
+
+TEST_F(FillListenerTest, OnMessageDispatchesFillEvent) {
+  addPendingOrder("AAPL", 50, OrderSide::Buy);
+
+  std::string body = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "50",
+      "price": "200.00",
+      "order": {"symbol": "AAPL", "side": "buy"}
+    }
+  })";
+  auto msg = makeMessage(ix::WebSocketMessageType::Message, body);
+  callOnMessage(msg);
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 50);
+}
+
+TEST_F(FillListenerTest, OnMessageHandlesOpenType) {
+  std::string body;
+  auto msg = makeMessage(ix::WebSocketMessageType::Open, body);
+  callOnMessage(msg);
+  // sendAuth calls ws_.send on non-connected socket — no crash
+}
+
+TEST_F(FillListenerTest, OnMessageHandlesErrorType) {
+  std::string body;
+  auto msg = makeMessage(ix::WebSocketMessageType::Error, body);
+  callOnMessage(msg);
+}
+
+TEST_F(FillListenerTest, OnMessageHandlesCloseType) {
+  std::string body;
+  auto msg = makeMessage(ix::WebSocketMessageType::Close, body);
+  callOnMessage(msg);
 }

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -1,0 +1,286 @@
+#include "AlpacaFillListener.hpp"
+#include "PositionManager.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+class FillListenerTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    position_manager_ = std::make_shared<PositionManager>();
+    position_manager_->registerSymbol("AAPL");
+    position_manager_->registerSymbol("GOOGL");
+  }
+
+  std::shared_ptr<PositionManager> position_manager_;
+};
+
+TEST_F(FillListenerTest, ParsesFillEvent) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
+
+  const auto &fill = std::get<FillEvent>(update);
+  EXPECT_EQ(std::string_view(fill.symbol, 4), "AAPL");
+  EXPECT_EQ(fill.side, OrderSide::Buy);
+  EXPECT_EQ(fill.quantity, 100);
+  EXPECT_DOUBLE_EQ(fill.price, 150.25);
+}
+
+TEST_F(FillListenerTest, ParsesPartialFillEvent) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "partial_fill",
+      "qty": "50",
+      "price": "200.00",
+      "order": {
+        "symbol": "GOOGL",
+        "side": "sell"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
+
+  const auto &fill = std::get<FillEvent>(update);
+  EXPECT_EQ(fill.side, OrderSide::Sell);
+  EXPECT_EQ(fill.quantity, 50);
+  EXPECT_DOUBLE_EQ(fill.price, 200.0);
+}
+
+TEST_F(FillListenerTest, ParsesCanceledEvent) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "canceled",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "100"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
+
+  const auto &cancel = std::get<CancelEvent>(update);
+  EXPECT_EQ(std::string_view(cancel.symbol, 4), "AAPL");
+  EXPECT_EQ(cancel.side, OrderSide::Buy);
+  EXPECT_EQ(cancel.quantity, 100);
+}
+
+TEST_F(FillListenerTest, ParsesExpiredEvent) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "expired",
+      "order": {
+        "symbol": "AAPL",
+        "side": "sell",
+        "qty": "200"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
+}
+
+TEST_F(FillListenerTest, ParsesRejectedEvent) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "rejected",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "50"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
+}
+
+TEST_F(FillListenerTest, IgnoresNewEvent) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "new",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "100"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
+TEST_F(FillListenerTest, IgnoresAuthorizationMessage) {
+  const std::string json = R"({
+    "stream": "authorization",
+    "data": {
+      "status": "authorized"
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
+TEST_F(FillListenerTest, HandlesMalformedJson) {
+  const TradeUpdate update = parseTradingUpdate("not valid json{{{");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
+TEST_F(FillListenerTest, HandlesMissingFields) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {}
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
+TEST_F(FillListenerTest, HandlesMissingQtyOnFill) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "price": "150.00",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
+TEST_F(FillListenerTest, FillUpdatesPositionManager) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy"
+      }
+    }
+  })";
+
+  // Simulate pending order first
+  Order pending{};
+  pending.id = 1;
+  std::memcpy(pending.symbol, "AAPL\0\0\0\0", 8);
+  pending.quantity = 100;
+  pending.price = 1502500;
+  pending.side = OrderSide::Buy;
+  pending.type = OrderType::Limit;
+  position_manager_->onOrderSent(pending);
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 0);
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
+
+  const auto &fill_event = std::get<FillEvent>(update);
+  Fill fill{};
+  std::memcpy(fill.symbol, fill_event.symbol, 8);
+  fill.executionId = 0;
+  fill.orderId = 0;
+  fill.side = fill_event.side;
+  fill.quantity = fill_event.quantity;
+  fill.price = fill_event.price;
+  position_manager_->onFill(fill);
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
+}
+
+TEST_F(FillListenerTest, CancelUpdatesPositionManager) {
+  Order pending{};
+  pending.id = 1;
+  std::memcpy(pending.symbol, "AAPL\0\0\0\0", 8);
+  pending.quantity = 100;
+  pending.price = 1502500;
+  pending.side = OrderSide::Buy;
+  pending.type = OrderType::Limit;
+  position_manager_->onOrderSent(pending);
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
+
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "canceled",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "100"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
+
+  const auto &cancel_event = std::get<CancelEvent>(update);
+  Order cancel_order{};
+  cancel_order.id = 0;
+  std::memcpy(cancel_order.symbol, cancel_event.symbol, 8);
+  cancel_order.quantity = cancel_event.quantity;
+  cancel_order.price = 0;
+  cancel_order.side = cancel_event.side;
+  cancel_order.type = OrderType::Market;
+  position_manager_->onOrderCancelled(cancel_order);
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+}
+
+TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {
+  const std::string json = R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": 75,
+      "price": 99.50,
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy"
+      }
+    }
+  })";
+
+  const TradeUpdate update = parseTradingUpdate(json);
+  ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
+
+  const auto &fill = std::get<FillEvent>(update);
+  EXPECT_EQ(fill.quantity, 75);
+  EXPECT_DOUBLE_EQ(fill.price, 99.50);
+}

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -2,6 +2,7 @@
 #include "PositionManager.hpp"
 #include <gtest/gtest.h>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 
 class FillListenerTest : public ::testing::Test {
@@ -12,11 +13,15 @@ protected:
     position_manager_->registerSymbol("GOOGL");
   }
 
+  static TradeUpdate parse(const std::string &json_str) {
+    return parseTradingUpdate(nlohmann::json::parse(json_str));
+  }
+
   std::shared_ptr<PositionManager> position_manager_;
 };
 
 TEST_F(FillListenerTest, ParsesFillEvent) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "fill",
@@ -27,20 +32,21 @@ TEST_F(FillListenerTest, ParsesFillEvent) {
         "side": "buy"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
 
   const auto &fill = std::get<FillEvent>(update);
-  EXPECT_EQ(std::string_view(fill.symbol, 4), "AAPL");
+  EXPECT_EQ(
+      std::string_view(fill.symbol, strnlen(fill.symbol, sizeof(fill.symbol))),
+      "AAPL");
   EXPECT_EQ(fill.side, OrderSide::Buy);
   EXPECT_EQ(fill.quantity, 100);
   EXPECT_DOUBLE_EQ(fill.price, 150.25);
 }
 
 TEST_F(FillListenerTest, ParsesPartialFillEvent) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "partial_fill",
@@ -51,9 +57,8 @@ TEST_F(FillListenerTest, ParsesPartialFillEvent) {
         "side": "sell"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
 
   const auto &fill = std::get<FillEvent>(update);
@@ -63,63 +68,83 @@ TEST_F(FillListenerTest, ParsesPartialFillEvent) {
 }
 
 TEST_F(FillListenerTest, ParsesCanceledEvent) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "canceled",
       "order": {
         "symbol": "AAPL",
         "side": "buy",
-        "qty": "100"
+        "qty": "100",
+        "filled_qty": "0"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
 
   const auto &cancel = std::get<CancelEvent>(update);
-  EXPECT_EQ(std::string_view(cancel.symbol, 4), "AAPL");
+  EXPECT_EQ(std::string_view(cancel.symbol,
+                             strnlen(cancel.symbol, sizeof(cancel.symbol))),
+            "AAPL");
   EXPECT_EQ(cancel.side, OrderSide::Buy);
   EXPECT_EQ(cancel.quantity, 100);
 }
 
+TEST_F(FillListenerTest, CancelAfterPartialFillUsesRemainingQty) {
+  const auto update = parse(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "canceled",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "100",
+        "filled_qty": "60"
+      }
+    }
+  })");
+
+  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
+  EXPECT_EQ(std::get<CancelEvent>(update).quantity, 40);
+}
+
 TEST_F(FillListenerTest, ParsesExpiredEvent) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "expired",
       "order": {
         "symbol": "AAPL",
         "side": "sell",
-        "qty": "200"
+        "qty": "200",
+        "filled_qty": "0"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
 }
 
 TEST_F(FillListenerTest, ParsesRejectedEvent) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "rejected",
       "order": {
         "symbol": "AAPL",
         "side": "buy",
-        "qty": "50"
+        "qty": "50",
+        "filled_qty": "0"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
 }
 
 TEST_F(FillListenerTest, IgnoresNewEvent) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "new",
@@ -129,41 +154,39 @@ TEST_F(FillListenerTest, IgnoresNewEvent) {
         "qty": "100"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
 }
 
 TEST_F(FillListenerTest, IgnoresAuthorizationMessage) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "authorization",
     "data": {
       "status": "authorized"
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
 }
 
 TEST_F(FillListenerTest, HandlesMalformedJson) {
-  const TradeUpdate update = parseTradingUpdate("not valid json{{{");
+  nlohmann::json broken = {{"not", "trade_updates"}};
+  const TradeUpdate update = parseTradingUpdate(broken);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
 }
 
 TEST_F(FillListenerTest, HandlesMissingFields) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {}
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
 }
 
 TEST_F(FillListenerTest, HandlesMissingQtyOnFill) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "fill",
@@ -173,27 +196,46 @@ TEST_F(FillListenerTest, HandlesMissingQtyOnFill) {
         "side": "buy"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
 }
 
-TEST_F(FillListenerTest, FillUpdatesPositionManager) {
-  const std::string json = R"({
+TEST_F(FillListenerTest, RejectsUnknownSide) {
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "fill",
       "qty": "100",
-      "price": "150.25",
+      "price": "150.00",
+      "order": {
+        "symbol": "AAPL",
+        "side": "unknown"
+      }
+    }
+  })");
+
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
+TEST_F(FillListenerTest, RejectsInvalidQtyString) {
+  const auto update = parse(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "not_a_number",
+      "price": "150.00",
       "order": {
         "symbol": "AAPL",
         "side": "buy"
       }
     }
-  })";
+  })");
 
-  // Simulate pending order first
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
+TEST_F(FillListenerTest, FillUpdatesPositionManager) {
   Order pending{};
   pending.id = 1;
   std::memcpy(pending.symbol, "AAPL\0\0\0\0", 8);
@@ -206,7 +248,19 @@ TEST_F(FillListenerTest, FillUpdatesPositionManager) {
   EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
   EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 0);
 
-  const TradeUpdate update = parseTradingUpdate(json);
+  const auto update = parse(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy"
+      }
+    }
+  })");
+
   ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
 
   const auto &fill_event = std::get<FillEvent>(update);
@@ -235,19 +289,19 @@ TEST_F(FillListenerTest, CancelUpdatesPositionManager) {
 
   EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
 
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "canceled",
       "order": {
         "symbol": "AAPL",
         "side": "buy",
-        "qty": "100"
+        "qty": "100",
+        "filled_qty": "0"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
 
   const auto &cancel_event = std::get<CancelEvent>(update);
@@ -264,7 +318,7 @@ TEST_F(FillListenerTest, CancelUpdatesPositionManager) {
 }
 
 TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {
-  const std::string json = R"({
+  const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
       "event": "fill",
@@ -275,9 +329,8 @@ TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {
         "side": "buy"
       }
     }
-  })";
+  })");
 
-  const TradeUpdate update = parseTradingUpdate(json);
   ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
 
   const auto &fill = std::get<FillEvent>(update);

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -51,66 +51,58 @@ protected:
   std::unique_ptr<AlpacaFillListener> listener_;
 };
 
-TEST_F(FillListenerTest, ParsesFillEvent) {
-  const auto update = parse(R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "fill",
-      "qty": "100",
-      "price": "150.25",
-      "order": {
-        "symbol": "AAPL",
-        "side": "buy"
-      }
-    }
-  })");
+struct FillParseParam {
+  const char *event_type;
+  const char *symbol;
+  const char *side_str;
+  const char *qty;
+  const char *price;
+  OrderSide expected_side;
+  int64_t expected_qty;
+  double expected_price;
+};
+
+class FillParseTest : public FillListenerTest,
+                      public ::testing::WithParamInterface<FillParseParam> {};
+
+TEST_P(FillParseTest, ParsesFillFields) {
+  const auto &[event_type, symbol, side_str, qty, price, expected_side,
+               expected_qty, expected_price] = GetParam();
+  const std::string json = R"({"stream":"trade_updates","data":{"event":")" +
+                           std::string(event_type) + R"(","qty":")" + qty +
+                           R"(","price":")" + price +
+                           R"(","order":{"symbol":")" + symbol +
+                           R"(","side":")" + side_str + R"("}}})";
+  const auto update = parse(json);
 
   ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
 
   const auto &fill = std::get<FillEvent>(update);
   EXPECT_EQ(
       std::string_view(fill.symbol, strnlen(fill.symbol, sizeof(fill.symbol))),
-      "AAPL");
-  EXPECT_EQ(fill.side, OrderSide::Buy);
-  EXPECT_EQ(fill.quantity, 100);
-  EXPECT_DOUBLE_EQ(fill.price, 150.25);
+      symbol);
+  EXPECT_EQ(fill.side, expected_side);
+  EXPECT_EQ(fill.quantity, expected_qty);
+  EXPECT_DOUBLE_EQ(fill.price, expected_price);
 }
 
-TEST_F(FillListenerTest, ParsesPartialFillEvent) {
-  const auto update = parse(R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "partial_fill",
-      "qty": "50",
-      "price": "200.00",
-      "order": {
-        "symbol": "GOOGL",
-        "side": "sell"
-      }
-    }
-  })");
+INSTANTIATE_TEST_SUITE_P(
+    FillTypes, FillParseTest,
+    ::testing::Values(FillParseParam{"fill", "AAPL", "buy", "100", "150.25",
+                                     OrderSide::Buy, 100, 150.25},
+                      FillParseParam{"partial_fill", "GOOGL", "sell", "50",
+                                     "200.00", OrderSide::Sell, 50, 200.0}));
 
-  ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
+class CancelEventTypeTest : public FillListenerTest,
+                            public ::testing::WithParamInterface<const char *> {
+};
 
-  const auto &fill = std::get<FillEvent>(update);
-  EXPECT_EQ(fill.side, OrderSide::Sell);
-  EXPECT_EQ(fill.quantity, 50);
-  EXPECT_DOUBLE_EQ(fill.price, 200.0);
-}
-
-TEST_F(FillListenerTest, ParsesCanceledEvent) {
-  const auto update = parse(R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "canceled",
-      "order": {
-        "symbol": "AAPL",
-        "side": "buy",
-        "qty": "100",
-        "filled_qty": "0"
-      }
-    }
-  })");
+TEST_P(CancelEventTypeTest, ProducesCancelEvent) {
+  const std::string json =
+      R"({"stream":"trade_updates","data":{"event":")" +
+      std::string(GetParam()) +
+      R"(","order":{"symbol":"AAPL","side":"buy","qty":"100","filled_qty":"0"}}})";
+  const auto update = parse(json);
 
   ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
 
@@ -121,6 +113,9 @@ TEST_F(FillListenerTest, ParsesCanceledEvent) {
   EXPECT_EQ(cancel.side, OrderSide::Buy);
   EXPECT_EQ(cancel.quantity, 100);
 }
+
+INSTANTIATE_TEST_SUITE_P(EventTypes, CancelEventTypeTest,
+                         ::testing::Values("canceled", "expired", "rejected"));
 
 TEST_F(FillListenerTest, CancelAfterPartialFillUsesRemainingQty) {
   const auto update = parse(R"({
@@ -138,40 +133,6 @@ TEST_F(FillListenerTest, CancelAfterPartialFillUsesRemainingQty) {
 
   ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
   EXPECT_EQ(std::get<CancelEvent>(update).quantity, 40);
-}
-
-TEST_F(FillListenerTest, ParsesExpiredEvent) {
-  const auto update = parse(R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "expired",
-      "order": {
-        "symbol": "AAPL",
-        "side": "sell",
-        "qty": "200",
-        "filled_qty": "0"
-      }
-    }
-  })");
-
-  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
-}
-
-TEST_F(FillListenerTest, ParsesRejectedEvent) {
-  const auto update = parse(R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "rejected",
-      "order": {
-        "symbol": "AAPL",
-        "side": "buy",
-        "qty": "50",
-        "filled_qty": "0"
-      }
-    }
-  })");
-
-  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
 }
 
 TEST_F(FillListenerTest, IgnoresNewEvent) {
@@ -264,88 +225,6 @@ TEST_F(FillListenerTest, RejectsInvalidQtyString) {
   })");
 
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
-}
-
-TEST_F(FillListenerTest, FillUpdatesPositionManager) {
-  Order pending{};
-  pending.id = 1;
-  std::memcpy(pending.symbol, "AAPL\0\0\0\0", 8);
-  pending.quantity = 100;
-  pending.price = 1502500;
-  pending.side = OrderSide::Buy;
-  pending.type = OrderType::Limit;
-  position_manager_->onOrderSent(pending);
-
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
-  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 0);
-
-  const auto update = parse(R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "fill",
-      "qty": "100",
-      "price": "150.25",
-      "order": {
-        "symbol": "AAPL",
-        "side": "buy"
-      }
-    }
-  })");
-
-  ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
-
-  const auto &fill_event = std::get<FillEvent>(update);
-  Fill fill{};
-  std::memcpy(fill.symbol, fill_event.symbol, 8);
-  fill.executionId = 0;
-  fill.orderId = 0;
-  fill.side = fill_event.side;
-  fill.quantity = fill_event.quantity;
-  fill.price = fill_event.price;
-  position_manager_->onFill(fill);
-
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
-  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
-}
-
-TEST_F(FillListenerTest, CancelUpdatesPositionManager) {
-  Order pending{};
-  pending.id = 1;
-  std::memcpy(pending.symbol, "AAPL\0\0\0\0", 8);
-  pending.quantity = 100;
-  pending.price = 1502500;
-  pending.side = OrderSide::Buy;
-  pending.type = OrderType::Limit;
-  position_manager_->onOrderSent(pending);
-
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
-
-  const auto update = parse(R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "canceled",
-      "order": {
-        "symbol": "AAPL",
-        "side": "buy",
-        "qty": "100",
-        "filled_qty": "0"
-      }
-    }
-  })");
-
-  ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
-
-  const auto &cancel_event = std::get<CancelEvent>(update);
-  Order cancel_order{};
-  cancel_order.id = 0;
-  std::memcpy(cancel_order.symbol, cancel_event.symbol, 8);
-  cancel_order.quantity = cancel_event.quantity;
-  cancel_order.price = 0;
-  cancel_order.side = cancel_event.side;
-  cancel_order.type = OrderType::Market;
-  position_manager_->onOrderCancelled(cancel_order);
-
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
 }
 
 TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {
@@ -483,25 +362,6 @@ TEST_F(FillListenerTest, OnMessageIgnoresWhenNotRunning) {
 
   EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
   EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 0);
-}
-
-TEST_F(FillListenerTest, OnMessageDispatchesFillEvent) {
-  addPendingOrder("AAPL", 50, OrderSide::Buy);
-
-  std::string body = R"({
-    "stream": "trade_updates",
-    "data": {
-      "event": "fill",
-      "qty": "50",
-      "price": "200.00",
-      "order": {"symbol": "AAPL", "side": "buy"}
-    }
-  })";
-  auto msg = makeMessage(ix::WebSocketMessageType::Message, body);
-  callOnMessage(msg);
-
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
-  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 50);
 }
 
 TEST_F(FillListenerTest, OnMessageHandlesOpenType) {

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -1,5 +1,6 @@
 #include "AlpacaFillListener.hpp"
 #include "PositionManager.hpp"
+#include "TestHelpers.hpp"
 #include <cstring>
 #include <gtest/gtest.h>
 #include <memory>
@@ -21,13 +22,8 @@ protected:
   }
 
   void addPendingOrder(const char *symbol, int64_t qty, OrderSide side) {
-    Order order{};
+    Order order = test_helpers::createOrder(symbol, side, qty, 1000000);
     order.id = 1;
-    std::memcpy(order.symbol, symbol, strnlen(symbol, 8));
-    order.quantity = qty;
-    order.price = 1000000;
-    order.side = side;
-    order.type = OrderType::Limit;
     position_manager_->onOrderSent(order);
   }
 
@@ -248,8 +244,6 @@ TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {
   EXPECT_DOUBLE_EQ(fill.price, 99.50);
 }
 
-// --- handleTradeUpdate tests (full dispatch pipeline) ---
-
 TEST_F(FillListenerTest, HandleTradeUpdateRejectsInvalidJson) {
   addPendingOrder("AAPL", 100, OrderSide::Buy);
   callHandleTradeUpdate("not valid json{{{");
@@ -261,7 +255,6 @@ TEST_F(FillListenerTest, HandleTradeUpdateProcessesAuthSuccess) {
     "stream": "authorization",
     "data": {"status": "authorized"}
   })");
-  // sendSubscribe calls ws_.send on non-connected socket — no crash
 }
 
 TEST_F(FillListenerTest, HandleTradeUpdateProcessesAuthFailure) {
@@ -342,8 +335,6 @@ TEST_F(FillListenerTest, HandleTradeUpdateIgnoresUnknownEvent) {
   EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
 }
 
-// --- onMessage tests (WebSocket dispatch) ---
-
 TEST_F(FillListenerTest, OnMessageIgnoresWhenNotRunning) {
   addPendingOrder("AAPL", 100, OrderSide::Buy);
   is_running_.store(false);
@@ -368,7 +359,6 @@ TEST_F(FillListenerTest, OnMessageHandlesOpenType) {
   std::string body;
   auto msg = makeMessage(ix::WebSocketMessageType::Open, body);
   callOnMessage(msg);
-  // sendAuth calls ws_.send on non-connected socket — no crash
 }
 
 TEST_F(FillListenerTest, OnMessageHandlesErrorType) {
@@ -406,7 +396,6 @@ TEST_F(FillListenerTest, StopDuringActiveProcessingCompletesCorrectly) {
     }
   });
 
-  // Wait until processing has started, then stop
   while (processed.load(std::memory_order_relaxed) < 5) {
     std::this_thread::yield();
   }
@@ -414,8 +403,6 @@ TEST_F(FillListenerTest, StopDuringActiveProcessingCompletesCorrectly) {
 
   processor.join();
 
-  // All fills that were dispatched must have completed atomically —
-  // no partial state corruption
   const int64_t filled = position_manager_->getFilledPosition("AAPL");
   const int64_t pending = position_manager_->getPendingPosition("AAPL");
   EXPECT_EQ(filled + pending, num_fills);

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -117,7 +117,6 @@ TEST_F(MarketEventConsumerTest, HandlesRiskManagerRejection) {
     GTEST_SKIP() << "ZMQ connection failed: " << e.what();
   }
 
-  // Callback should not be called if risk manager rejects orders
   EXPECT_EQ(callback_count, 0);
 }
 

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -98,13 +98,22 @@ private:
 
 } // namespace
 
-TEST(OrderGatewayTest, CatchesStdExceptionInMainLoop) {
+struct MainLoopExceptionParam {
+  std::function<std::unique_ptr<IRestClient>(std::promise<void> *)> factory;
+  const char *expected_substr;
+};
+
+class GatewayMainLoopExceptionTest
+    : public ::testing::TestWithParam<MainLoopExceptionParam> {};
+
+TEST_P(GatewayMainLoopExceptionTest, LogsCorrectError) {
+  const auto &[factory, expected_substr] = GetParam();
   std::atomic is_running(true);
   const auto order_queue = std::make_shared<ThreadSafeQueue<Order>>();
   std::promise<void> promise;
   auto future = promise.get_future();
 
-  auto client = std::make_unique<ThrowingRestClient>(&promise);
+  auto client = factory(&promise);
   OrderGateway gateway(is_running, order_queue, std::move(client));
 
   std::stringstream captured;
@@ -123,50 +132,40 @@ TEST(OrderGatewayTest, CatchesStdExceptionInMainLoop) {
   guard.t.join();
   std::cerr.rdbuf(original);
 
-  EXPECT_TRUE(captured.str().find("OrderGateway: Error placing order:") !=
-              std::string::npos);
-  EXPECT_TRUE(captured.str().find("simulated rest error") != std::string::npos);
+  EXPECT_TRUE(captured.str().find(expected_substr) != std::string::npos);
 }
 
-TEST(OrderGatewayTest, CatchesUnknownExceptionInMainLoop) {
-  std::atomic is_running(true);
-  const auto order_queue = std::make_shared<ThreadSafeQueue<Order>>();
-  std::promise<void> promise;
-  auto future = promise.get_future();
+INSTANTIATE_TEST_SUITE_P(
+    ExceptionTypes, GatewayMainLoopExceptionTest,
+    ::testing::Values(
+        MainLoopExceptionParam{[](std::promise<void> *p) {
+                                 return std::make_unique<ThrowingRestClient>(p);
+                               },
+                               "OrderGateway: Error placing order:"},
+        MainLoopExceptionParam{
+            [](std::promise<void> *p) {
+              return std::make_unique<WildThrowingRestClient>(p);
+            },
+            "OrderGateway: Unknown error placing order"}));
 
-  auto client = std::make_unique<WildThrowingRestClient>(&promise);
-  OrderGateway gateway(is_running, order_queue, std::move(client));
+struct ShutdownExceptionParam {
+  std::function<std::unique_ptr<IRestClient>()> factory;
+  const char *expected_substr;
+};
 
-  std::stringstream captured;
-  auto *original = std::cerr.rdbuf(captured.rdbuf());
+class GatewayShutdownExceptionTest
+    : public ::testing::TestWithParam<ShutdownExceptionParam> {};
 
-  ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
-
-  Order order{};
-  order.id = 2;
-  order_queue->push(order);
-
-  const auto status = future.wait_for(std::chrono::seconds(2));
-  ASSERT_EQ(status, std::future_status::ready);
-  is_running.store(false);
-
-  guard.t.join();
-  std::cerr.rdbuf(original);
-
-  EXPECT_TRUE(
-      captured.str().find("OrderGateway: Unknown error placing order") !=
-      std::string::npos);
-}
-
-TEST(OrderGatewayTest, CatchesStdExceptionDuringShutdownDrain) {
+TEST_P(GatewayShutdownExceptionTest, LogsCorrectError) {
+  const auto &[factory, expected_substr] = GetParam();
   std::atomic is_running(false);
   const auto order_queue = std::make_shared<ThreadSafeQueue<Order>>();
 
   Order order{};
-  order.id = 3;
+  order.id = 1;
   order_queue->push(order);
 
-  auto client = std::make_unique<ThrowingRestClient>();
+  auto client = factory();
   OrderGateway gateway(is_running, order_queue, std::move(client));
 
   std::stringstream captured;
@@ -176,32 +175,15 @@ TEST(OrderGatewayTest, CatchesStdExceptionDuringShutdownDrain) {
 
   std::cerr.rdbuf(original);
 
-  EXPECT_TRUE(captured.str().find(
-                  "OrderGateway: Error placing order during shutdown:") !=
-              std::string::npos);
-  EXPECT_TRUE(captured.str().find("simulated rest error") != std::string::npos);
+  EXPECT_TRUE(captured.str().find(expected_substr) != std::string::npos);
 }
 
-TEST(OrderGatewayTest, CatchesUnknownExceptionDuringShutdownDrain) {
-  std::atomic is_running(false);
-  const auto order_queue = std::make_shared<ThreadSafeQueue<Order>>();
-
-  Order order{};
-  order.id = 4;
-  order_queue->push(order);
-
-  auto client = std::make_unique<WildThrowingRestClient>();
-  OrderGateway gateway(is_running, order_queue, std::move(client));
-
-  std::stringstream captured;
-  auto *original = std::cerr.rdbuf(captured.rdbuf());
-
-  gateway.run();
-
-  std::cerr.rdbuf(original);
-
-  EXPECT_TRUE(
-      captured.str().find(
-          "OrderGateway: Unknown error placing order during shutdown") !=
-      std::string::npos);
-}
+INSTANTIATE_TEST_SUITE_P(
+    ExceptionTypes, GatewayShutdownExceptionTest,
+    ::testing::Values(
+        ShutdownExceptionParam{
+            []() { return std::make_unique<ThrowingRestClient>(); },
+            "OrderGateway: Error placing order during shutdown:"},
+        ShutdownExceptionParam{
+            []() { return std::make_unique<WildThrowingRestClient>(); },
+            "OrderGateway: Unknown error placing order during shutdown"}));

--- a/tests/test_position_manager.cpp
+++ b/tests/test_position_manager.cpp
@@ -1,39 +1,16 @@
-#include "Fill.hpp"
 #include "PositionManager.hpp"
+#include "TestHelpers.hpp"
 #include "Utils.hpp"
-#include <cstring>
 #include <gtest/gtest.h>
 #include <thread>
 #include <vector>
 
+using test_helpers::createFill;
+using test_helpers::createOrder;
+
 class PositionManagerTest : public ::testing::Test {
 protected:
   PositionManager pm;
-
-  static Order createOrder(const char *symbol, const OrderSide side,
-                           const int64_t qty, const uint64_t price) {
-    Order order{};
-    std::memset(order.symbol, 0, sizeof(order.symbol));
-    const std::size_t copy_len =
-        (std::min)(std::strlen(symbol), sizeof(order.symbol));
-    std::memcpy(order.symbol, symbol, copy_len);
-    order.side = side;
-    order.quantity = qty;
-    order.price = price;
-    return order;
-  }
-
-  static Fill createFill(const char *symbol, const OrderSide side,
-                         const int64_t qty) {
-    Fill fill{};
-    std::memset(fill.symbol, 0, sizeof(fill.symbol));
-    const std::size_t copy_len =
-        (std::min)(std::strlen(symbol), sizeof(fill.symbol));
-    std::memcpy(fill.symbol, symbol, copy_len);
-    fill.side = side;
-    fill.quantity = qty;
-    return fill;
-  }
 };
 
 TEST_F(PositionManagerTest, NewPositionIsZero) {
@@ -45,6 +22,7 @@ TEST_F(PositionManagerTest, NewPositionIsZero) {
 struct FillTestParam {
   OrderSide side;
   int64_t quantity;
+  int64_t expected_pending;
   int64_t expected_filled;
   int64_t expected_exposure;
 };
@@ -54,19 +32,21 @@ class PositionManagerFillTest
       public ::testing::WithParamInterface<FillTestParam> {};
 
 TEST_P(PositionManagerFillTest, ProcessFillUpdatesPosition) {
-  const auto &[side, quantity, expected_filled, expected_exposure] = GetParam();
+  const auto &[side, quantity, expected_pending, expected_filled,
+               expected_exposure] = GetParam();
   const Order order = createOrder("AAPL", side, quantity, 1000);
   pm.onOrderSent(order);
   pm.onFill(createFill("AAPL", side, quantity));
 
+  EXPECT_EQ(pm.getPendingPosition("AAPL"), expected_pending);
   EXPECT_EQ(pm.getFilledPosition("AAPL"), expected_filled);
   EXPECT_EQ(pm.getTotalExposure("AAPL"), expected_exposure);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     BuySell, PositionManagerFillTest,
-    ::testing::Values(FillTestParam{OrderSide::Buy, 100, 100, 100},
-                      FillTestParam{OrderSide::Sell, 75, -75, -75}));
+    ::testing::Values(FillTestParam{OrderSide::Buy, 100, 0, 100, 100},
+                      FillTestParam{OrderSide::Sell, 75, 0, -75, -75}));
 
 TEST_F(PositionManagerTest, HandlesMultipleSymbolsAndFills) {
   pm.onFill(createFill("AAPL", OrderSide::Buy, 200));
@@ -126,16 +106,6 @@ INSTANTIATE_TEST_SUITE_P(
     BuySell, PositionManagerOrderSentTest,
     ::testing::Values(OrderSentTestParam{OrderSide::Buy, 100, 100, 100},
                       OrderSentTestParam{OrderSide::Sell, 100, -100, -100}));
-
-TEST_F(PositionManagerTest, OnFillMovesFromPendingToFilled) {
-  const Order buy_order = createOrder("AAPL", OrderSide::Buy, 100, 1000);
-  pm.onOrderSent(buy_order);
-  pm.onFill(createFill("AAPL", OrderSide::Buy, 100));
-
-  EXPECT_EQ(pm.getPendingPosition("AAPL"), 0);
-  EXPECT_EQ(pm.getFilledPosition("AAPL"), 100);
-  EXPECT_EQ(pm.getTotalExposure("AAPL"), 100);
-}
 
 TEST_F(PositionManagerTest, PartialFillHandledCorrectly) {
   const Order buy_order = createOrder("AAPL", OrderSide::Buy, 100, 1000);

--- a/tests/test_risk_manager.cpp
+++ b/tests/test_risk_manager.cpp
@@ -1,43 +1,19 @@
-#include "Order.hpp"
 #include "PositionManager.hpp"
 #include "RiskManager.hpp"
+#include "TestHelpers.hpp"
 #include "Utils.hpp"
-#include <algorithm>
-#include <cstring>
 #include <gtest/gtest.h>
 #include <limits>
 #include <memory>
+
+using test_helpers::createFill;
+using test_helpers::createOrder;
 
 class RiskManagerTest : public ::testing::Test {
 protected:
   void SetUp() override {
     pos_manager_ = std::make_shared<PositionManager>();
     risk_manager_ = std::make_unique<RiskManager>(pos_manager_);
-  }
-
-  static Order createOrder(const char *symbol, const OrderSide side,
-                           const int64_t qty, const uint64_t price) {
-    Order order{};
-    std::memset(order.symbol, 0, sizeof(order.symbol));
-    const std::size_t copy_len =
-        std::min(std::strlen(symbol), sizeof(order.symbol));
-    std::memcpy(order.symbol, symbol, copy_len);
-    order.side = side;
-    order.quantity = qty;
-    order.price = price;
-    return order;
-  }
-
-  static Fill createFill(const char *symbol, const OrderSide side,
-                         const int64_t qty) {
-    Fill fill{};
-    std::memset(fill.symbol, 0, sizeof(fill.symbol));
-    const std::size_t copy_len =
-        (std::min)(std::strlen(symbol), sizeof(fill.symbol));
-    std::memcpy(fill.symbol, symbol, copy_len);
-    fill.side = side;
-    fill.quantity = qty;
-    return fill;
   }
 
   std::shared_ptr<PositionManager> pos_manager_;

--- a/tests/test_risk_manager.cpp
+++ b/tests/test_risk_manager.cpp
@@ -72,12 +72,10 @@ TEST_F(RiskManagerTest, HandlesMaximumAllowedPosition) {
   pos_manager_->onOrderSent(existing_order);
   pos_manager_->onFill(createFill("AAPL", OrderSide::Buy, 999));
 
-  // Order that would reach exactly the limit should be approved
   Order order = createOrder("AAPL", OrderSide::Buy, 1,
                             100 * static_cast<uint64_t>(SCALING_FACTOR));
   EXPECT_TRUE(risk_manager_->onNewOrder(order));
 
-  // Order that would exceed the limit should be rejected
   Order over_limit_order = createOrder(
       "AAPL", OrderSide::Buy, 2, 100 * static_cast<uint64_t>(SCALING_FACTOR));
   EXPECT_FALSE(risk_manager_->onNewOrder(over_limit_order));

--- a/tests/test_simple_market_making_strategy.cpp
+++ b/tests/test_simple_market_making_strategy.cpp
@@ -75,7 +75,7 @@ TEST_F(SimpleMarketMakingStrategyTest, HandlesZeroPrice) {
 TEST_F(SimpleMarketMakingStrategyTest, SkipsOrdersWhenBuyPriceUnderflows) {
   MarketEvent trade_event{};
   trade_event.eventType = 2;
-  trade_event.p1 = 50; // less than offset_ticks
+  trade_event.p1 = 50;
 
   const auto orders = strategy.onMarketEvent(trade_event);
   EXPECT_TRUE(orders.empty());

--- a/tests/test_thread_safe_queue.cpp
+++ b/tests/test_thread_safe_queue.cpp
@@ -11,17 +11,6 @@ protected:
   ThreadSafeQueue<Order> queue;
 };
 
-TEST_F(ThreadSafeQueueTest, SingleThreadedPushAndPop) {
-  Order order_to_push{};
-  order_to_push.id = 123;
-  queue.push(order_to_push);
-
-  Order popped_order{};
-  queue.wait_and_pop(popped_order);
-
-  EXPECT_EQ(popped_order.id, 123);
-}
-
 TEST_F(ThreadSafeQueueTest, TryPopBehavesCorrectly) {
   Order temp_order{};
   EXPECT_FALSE(queue.try_pop(temp_order));

--- a/tests/test_trading_engine.cpp
+++ b/tests/test_trading_engine.cpp
@@ -45,7 +45,7 @@ TEST_F(TradingEngineTest, ShutdownIsIdempotent) {
   TradingEngine engine(symbols, std::move(mock_client));
 
   engine.stop();
-  EXPECT_NO_THROW(engine.stop()); // Should handle multiple stops gracefully
+  EXPECT_NO_THROW(engine.stop());
 }
 
 TEST_F(TradingEngineTest, ThrowsWhenApiCredentialsMissing) {

--- a/tests/test_trading_engine.cpp
+++ b/tests/test_trading_engine.cpp
@@ -1,5 +1,6 @@
 #include "IRestClient.hpp"
 #include "TradingEngine.hpp"
+#include "Utils.hpp"
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -45,4 +46,15 @@ TEST_F(TradingEngineTest, ShutdownIsIdempotent) {
 
   engine.stop();
   EXPECT_NO_THROW(engine.stop()); // Should handle multiple stops gracefully
+}
+
+TEST_F(TradingEngineTest, ThrowsWhenApiCredentialsMissing) {
+  unsetenv("APCA_API_KEY_ID");
+  unsetenv("APCA_API_SECRET_KEY");
+
+  std::vector<std::string> symbols = {"AAPL"};
+  auto mock_client = std::make_unique<MockRestClientForEngine>();
+
+  EXPECT_THROW(TradingEngine(symbols, std::move(mock_client)),
+               std::runtime_error);
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,8 @@
     "cpr",
     "nlohmann-json",
     "gtest",
-    "tbb"
+    "tbb",
+    "ixwebsocket"
   ],
   "builtin-baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1"
 }


### PR DESCRIPTION
## Summary

Closes the open-loop gap where orders sent via REST never got
fill/cancel feedback, causing `PositionManager.pending` to grow
forever until `RiskManager` rejected all orders.

- Add IXWebSocket dependency for WebSocket connectivity to
  `wss://paper-api.alpaca.markets/stream`
- `AlpacaFillListener` handles auth, subscribes to `trade_updates`,
  dispatches fill/partial_fill/canceled/expired/rejected events to
  `PositionManager::onFill()` and `onOrderCancelled()`
- `TradingEngine` creates the fill listener internally using its own
  `PositionManager` and `is_running_` -- cold path, IXWebSocket
  manages its own background thread
- `IRestClient` remains the only injected dependency (real system
  boundary needed for OrderGateway tests and future backtest venue)
- `parseTradingUpdate()` extracted as a free function returning
  `std::variant<monostate, FillEvent, CancelEvent>` for unit
  testing without a WebSocket connection

Closes #37
Closes #38

## Files

New:
- `include/IFillListener.hpp` -- interface
- `include/AlpacaFillListener.hpp` -- header + event types
- `src/AlpacaFillListener.cpp` -- JSON parsing, WS protocol, PM dispatch
- `tests/test_fill_listener.cpp` -- 24 tests
- `tests/TestHelpers.hpp` -- shared test factory helpers

Modified:
- `vcpkg.json` -- add ixwebsocket
- `CMakeLists.txt` -- find_package + link
- `include/TradingEngine.hpp` -- add fill_listener_ member
- `src/TradingEngine.cpp` -- create, start, stop fill listener
- `tests/test_trading_engine.cpp` -- add missing-credentials test
- `.github/workflows/build.yml` -- exclude tests/ from CodeQL SARIF
- `.codecov.yml` -- exclude TradingEngine.cpp from coverage