### PR TITLE
Replace Strategy base class with StrategyLike concept

### DIFF
--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -2,6 +2,7 @@
 
 #include "MarketEvent.hpp"
 #include "RiskManager.hpp"
+#include "Strategy.hpp"
 #include <atomic>
 #include <exception>
 #include <functional>
@@ -11,7 +12,7 @@
 #include <utility>
 #include <zmq.hpp>
 
-template <typename StrategyType> class MarketEventConsumer {
+template <StrategyLike StrategyType> class MarketEventConsumer {
 public:
   using OrderCallback = std::function<void(const Order &)>;
 

--- a/include/SimpleMarketMakingStrategy.hpp
+++ b/include/SimpleMarketMakingStrategy.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
-#include "Strategy.hpp"
+#include "MarketEvent.hpp"
+#include "Order.hpp"
 #include "Utils.hpp"
 
 #include <cstring>
 #include <limits>
+#include <vector>
 
-class SimpleMarketMakingStrategy : public Strategy {
+class SimpleMarketMakingStrategy {
 public:
   SimpleMarketMakingStrategy() : last_trade_price_(0), order_id_counter_(0) {}
 

--- a/include/Strategy.hpp
+++ b/include/Strategy.hpp
@@ -2,11 +2,10 @@
 
 #include "MarketEvent.hpp"
 #include "Order.hpp"
+#include <concepts>
 #include <vector>
 
-class Strategy {
-public:
-  ~Strategy() = default;
-
-  std::vector<Order> onMarketEvent(const MarketEvent &event);
+template <typename T>
+concept StrategyLike = requires(T t, const MarketEvent &e) {
+  { t.onMarketEvent(e) } -> std::same_as<std::vector<Order>>;
 };

--- a/tests/test_error_scenarios.cpp
+++ b/tests/test_error_scenarios.cpp
@@ -1,13 +1,12 @@
 #include "MarketEventConsumer.hpp"
 #include "RiskManager.hpp"
-#include "Strategy.hpp"
 #include <cstring>
 #include <gtest/gtest.h>
 #include <thread>
 
-class ThrowingStrategy final : public Strategy {
+class ThrowingStrategy {
 public:
-  static std::vector<Order> onMarketEvent(const MarketEvent &) {
+  std::vector<Order> onMarketEvent(const MarketEvent &) {
     throw std::runtime_error("Strategy error");
   }
 };

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -1,7 +1,6 @@
 #include "MarketEvent.hpp"
 #include "MarketEventConsumer.hpp"
 #include "Order.hpp"
-#include "Strategy.hpp"
 #include "ThreadGuard.hpp"
 #include <atomic>
 #include <chrono>
@@ -16,9 +15,9 @@
 #include <unistd.h>
 #endif
 
-class MockStrategy : public Strategy {
+class MockStrategy {
 public:
-  static std::vector<Order> onMarketEvent(const MarketEvent &event) {
+  std::vector<Order> onMarketEvent(const MarketEvent &event) {
     std::vector<Order> orders;
     if (event.eventType == 2) {
       Order buy_order{};
@@ -50,16 +49,14 @@ protected:
   std::shared_ptr<RiskManager> risk_manager_;
 };
 
-class EmptyStrategy : public Strategy {
+class EmptyStrategy {
 public:
-  static std::vector<Order> onMarketEvent(const MarketEvent & /*event*/) {
-    return {};
-  }
+  std::vector<Order> onMarketEvent(const MarketEvent & /*event*/) { return {}; }
 };
 
-class RejectedOrderStrategy : public Strategy {
+class RejectedOrderStrategy {
 public:
-  static std::vector<Order> onMarketEvent(const MarketEvent &event) {
+  std::vector<Order> onMarketEvent(const MarketEvent &event) {
     if (event.eventType == 2) {
       Order order{};
       order.id = 1;
@@ -72,11 +69,11 @@ public:
   }
 };
 
-class CountingStrategy : public Strategy {
+class CountingStrategy {
 public:
   static std::atomic<int> invocation_count;
 
-  static std::vector<Order> onMarketEvent(const MarketEvent & /*event*/) {
+  std::vector<Order> onMarketEvent(const MarketEvent & /*event*/) {
     invocation_count.fetch_add(1, std::memory_order_relaxed);
     return {};
   }


### PR DESCRIPTION
## Summary

- Replace non-virtual `Strategy` base class with a `StrategyLike` C++20 concept
- `MarketEventConsumer` template parameter now constrained: `template <StrategyLike StrategyType>`
- Remove inheritance from `SimpleMarketMakingStrategy` and all test mock strategies
- No runtime behavior change — compile-time dispatch was already in use

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal strategy framework to improve type safety and compile-time validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->