### PR TITLE
Replace std::vector<Order> with std::optional<Order>

### DIFF
--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -57,11 +57,9 @@ public:
 
       auto event = static_cast<const MarketEvent *>(payload.data());
       try {
-        auto batch = strategy_->onMarketEvent(*event);
-        for (uint8_t i = 0; i < batch.count; ++i) {
-          if (risk_manager_->onNewOrder(batch.orders[i])) {
-            order_callback_(batch.orders[i]);
-          }
+        auto order = strategy_->onMarketEvent(*event);
+        if (order && risk_manager_->onNewOrder(*order)) {
+          order_callback_(*order);
         }
       } catch (...) {
       }

--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -57,10 +57,10 @@ public:
 
       auto event = static_cast<const MarketEvent *>(payload.data());
       try {
-        auto orders = strategy_->onMarketEvent(*event);
-        for (const auto &order : orders) {
-          if (risk_manager_->onNewOrder(order)) {
-            order_callback_(order);
+        auto batch = strategy_->onMarketEvent(*event);
+        for (uint8_t i = 0; i < batch.count; ++i) {
+          if (risk_manager_->onNewOrder(batch.orders[i])) {
+            order_callback_(batch.orders[i]);
           }
         }
       } catch (...) {

--- a/include/Order.hpp
+++ b/include/Order.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <type_traits>
 
@@ -22,3 +23,13 @@ static_assert(sizeof(Order) == 40, "Expected size is 40 bytes");
 static_assert(alignof(Order) == 8, "Order must be 8-byte aligned");
 static_assert(std::is_trivially_copyable_v<Order>,
               "Order must be trivially copyable for lock-free queues");
+
+constexpr std::size_t kMaxOrdersPerEvent = 8;
+
+struct OrderBatch {
+  std::array<Order, kMaxOrdersPerEvent> orders{};
+  uint8_t count{0};
+};
+
+static_assert(std::is_trivially_copyable_v<OrderBatch>,
+              "OrderBatch must be trivially copyable");

--- a/include/Order.hpp
+++ b/include/Order.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <type_traits>
 
@@ -23,13 +22,3 @@ static_assert(sizeof(Order) == 40, "Expected size is 40 bytes");
 static_assert(alignof(Order) == 8, "Order must be 8-byte aligned");
 static_assert(std::is_trivially_copyable_v<Order>,
               "Order must be trivially copyable for lock-free queues");
-
-constexpr std::size_t kMaxOrdersPerEvent = 8;
-
-struct OrderBatch {
-  std::array<Order, kMaxOrdersPerEvent> orders{};
-  uint8_t count{0};
-};
-
-static_assert(std::is_trivially_copyable_v<OrderBatch>,
-              "OrderBatch must be trivially copyable");

--- a/include/SimpleMarketMakingStrategy.hpp
+++ b/include/SimpleMarketMakingStrategy.hpp
@@ -6,48 +6,45 @@
 
 #include <cstring>
 #include <limits>
-#include <vector>
 
 class SimpleMarketMakingStrategy {
 public:
   SimpleMarketMakingStrategy() : last_trade_price_(0), order_id_counter_(0) {}
 
-  std::vector<Order> onMarketEvent(const MarketEvent &event) {
-    std::vector<Order> orders;
+  OrderBatch onMarketEvent(const MarketEvent &event) {
+    OrderBatch batch{};
 
     if (event.eventType == 2) {
       last_trade_price_ = event.p1;
 
       constexpr uint64_t offset_ticks = 100;
       if (last_trade_price_ == 0) {
-        return orders;
+        return batch;
       }
 
       const uint64_t max_price = (std::numeric_limits<uint64_t>::max)();
       if (last_trade_price_ < offset_ticks ||
           last_trade_price_ > max_price - offset_ticks) {
-        return orders;
+        return batch;
       }
 
-      Order buy_order{};
+      Order &buy_order = batch.orders[batch.count++];
       buy_order.id = ++order_id_counter_;
       std::memcpy(buy_order.symbol, event.symbol, sizeof(buy_order.symbol));
       buy_order.side = OrderSide::Buy;
       buy_order.type = OrderType::Limit;
       buy_order.quantity = 100;
       buy_order.price = last_trade_price_ - offset_ticks;
-      orders.push_back(buy_order);
 
-      Order sell_order{};
+      Order &sell_order = batch.orders[batch.count++];
       sell_order.id = ++order_id_counter_;
       std::memcpy(sell_order.symbol, event.symbol, sizeof(sell_order.symbol));
       sell_order.side = OrderSide::Sell;
       sell_order.type = OrderType::Limit;
       sell_order.quantity = 100;
       sell_order.price = last_trade_price_ + offset_ticks;
-      orders.push_back(sell_order);
     }
-    return orders;
+    return batch;
   }
 
 private:

--- a/include/SimpleMarketMakingStrategy.hpp
+++ b/include/SimpleMarketMakingStrategy.hpp
@@ -5,46 +5,32 @@
 #include "Utils.hpp"
 
 #include <cstring>
-#include <limits>
+#include <optional>
 
 class SimpleMarketMakingStrategy {
 public:
   SimpleMarketMakingStrategy() : last_trade_price_(0), order_id_counter_(0) {}
 
-  OrderBatch onMarketEvent(const MarketEvent &event) {
-    OrderBatch batch{};
-
-    if (event.eventType == 2) {
-      last_trade_price_ = event.p1;
-
-      constexpr uint64_t offset_ticks = 100;
-      if (last_trade_price_ == 0) {
-        return batch;
-      }
-
-      const uint64_t max_price = (std::numeric_limits<uint64_t>::max)();
-      if (last_trade_price_ < offset_ticks ||
-          last_trade_price_ > max_price - offset_ticks) {
-        return batch;
-      }
-
-      Order &buy_order = batch.orders[batch.count++];
-      buy_order.id = ++order_id_counter_;
-      std::memcpy(buy_order.symbol, event.symbol, sizeof(buy_order.symbol));
-      buy_order.side = OrderSide::Buy;
-      buy_order.type = OrderType::Limit;
-      buy_order.quantity = 100;
-      buy_order.price = last_trade_price_ - offset_ticks;
-
-      Order &sell_order = batch.orders[batch.count++];
-      sell_order.id = ++order_id_counter_;
-      std::memcpy(sell_order.symbol, event.symbol, sizeof(sell_order.symbol));
-      sell_order.side = OrderSide::Sell;
-      sell_order.type = OrderType::Limit;
-      sell_order.quantity = 100;
-      sell_order.price = last_trade_price_ + offset_ticks;
+  std::optional<Order> onMarketEvent(const MarketEvent &event) {
+    if (event.eventType != 2) {
+      return std::nullopt;
     }
-    return batch;
+
+    last_trade_price_ = event.p1;
+
+    constexpr uint64_t offset_ticks = 100;
+    if (last_trade_price_ < offset_ticks) {
+      return std::nullopt;
+    }
+
+    Order order{};
+    order.id = ++order_id_counter_;
+    std::memcpy(order.symbol, event.symbol, sizeof(order.symbol));
+    order.side = OrderSide::Buy;
+    order.type = OrderType::Limit;
+    order.quantity = 100;
+    order.price = last_trade_price_ - offset_ticks;
+    return order;
   }
 
 private:

--- a/include/Strategy.hpp
+++ b/include/Strategy.hpp
@@ -3,8 +3,9 @@
 #include "MarketEvent.hpp"
 #include "Order.hpp"
 #include <concepts>
+#include <optional>
 
 template <typename T>
 concept StrategyLike = requires(T t, const MarketEvent &e) {
-  { t.onMarketEvent(e) } -> std::same_as<OrderBatch>;
+  { t.onMarketEvent(e) } -> std::same_as<std::optional<Order>>;
 };

--- a/include/Strategy.hpp
+++ b/include/Strategy.hpp
@@ -3,9 +3,8 @@
 #include "MarketEvent.hpp"
 #include "Order.hpp"
 #include <concepts>
-#include <vector>
 
 template <typename T>
 concept StrategyLike = requires(T t, const MarketEvent &e) {
-  { t.onMarketEvent(e) } -> std::same_as<std::vector<Order>>;
+  { t.onMarketEvent(e) } -> std::same_as<OrderBatch>;
 };

--- a/tests/test_error_scenarios.cpp
+++ b/tests/test_error_scenarios.cpp
@@ -6,7 +6,7 @@
 
 class ThrowingStrategy {
 public:
-  std::vector<Order> onMarketEvent(const MarketEvent &) {
+  OrderBatch onMarketEvent(const MarketEvent &) {
     throw std::runtime_error("Strategy error");
   }
 };

--- a/tests/test_error_scenarios.cpp
+++ b/tests/test_error_scenarios.cpp
@@ -2,11 +2,12 @@
 #include "RiskManager.hpp"
 #include <cstring>
 #include <gtest/gtest.h>
+#include <optional>
 #include <thread>
 
 class ThrowingStrategy {
 public:
-  OrderBatch onMarketEvent(const MarketEvent &) {
+  std::optional<Order> onMarketEvent(const MarketEvent &) {
     throw std::runtime_error("Strategy error");
   }
 };

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <future>
 #include <gtest/gtest.h>
+#include <optional>
 #include <thread>
 #ifdef _WIN32
 #include <windows.h>
@@ -17,16 +18,16 @@
 
 class MockStrategy {
 public:
-  OrderBatch onMarketEvent(const MarketEvent &event) {
-    OrderBatch batch{};
+  std::optional<Order> onMarketEvent(const MarketEvent &event) {
     if (event.eventType == 2) {
-      Order &buy_order = batch.orders[batch.count++];
-      buy_order.id = 1;
-      buy_order.side = OrderSide::Buy;
-      buy_order.type = OrderType::Market;
-      buy_order.quantity = 100;
+      Order order{};
+      order.id = 1;
+      order.side = OrderSide::Buy;
+      order.type = OrderType::Market;
+      order.quantity = 100;
+      return order;
     }
-    return batch;
+    return std::nullopt;
   }
 };
 
@@ -50,21 +51,23 @@ protected:
 
 class EmptyStrategy {
 public:
-  OrderBatch onMarketEvent(const MarketEvent & /*event*/) { return {}; }
+  std::optional<Order> onMarketEvent(const MarketEvent & /*event*/) {
+    return std::nullopt;
+  }
 };
 
 class RejectedOrderStrategy {
 public:
-  OrderBatch onMarketEvent(const MarketEvent &event) {
-    OrderBatch batch{};
+  std::optional<Order> onMarketEvent(const MarketEvent &event) {
     if (event.eventType == 2) {
-      Order &order = batch.orders[batch.count++];
+      Order order{};
       order.id = 1;
       order.side = OrderSide::Buy;
       order.quantity = 2000;
       order.price = 1000000;
+      return order;
     }
-    return batch;
+    return std::nullopt;
   }
 };
 
@@ -72,9 +75,9 @@ class CountingStrategy {
 public:
   static std::atomic<int> invocation_count;
 
-  OrderBatch onMarketEvent(const MarketEvent & /*event*/) {
+  std::optional<Order> onMarketEvent(const MarketEvent & /*event*/) {
     invocation_count.fetch_add(1, std::memory_order_relaxed);
-    return {};
+    return std::nullopt;
   }
 };
 

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -17,17 +17,16 @@
 
 class MockStrategy {
 public:
-  std::vector<Order> onMarketEvent(const MarketEvent &event) {
-    std::vector<Order> orders;
+  OrderBatch onMarketEvent(const MarketEvent &event) {
+    OrderBatch batch{};
     if (event.eventType == 2) {
-      Order buy_order{};
+      Order &buy_order = batch.orders[batch.count++];
       buy_order.id = 1;
       buy_order.side = OrderSide::Buy;
       buy_order.type = OrderType::Market;
       buy_order.quantity = 100;
-      orders.push_back(buy_order);
     }
-    return orders;
+    return batch;
   }
 };
 
@@ -51,21 +50,21 @@ protected:
 
 class EmptyStrategy {
 public:
-  std::vector<Order> onMarketEvent(const MarketEvent & /*event*/) { return {}; }
+  OrderBatch onMarketEvent(const MarketEvent & /*event*/) { return {}; }
 };
 
 class RejectedOrderStrategy {
 public:
-  std::vector<Order> onMarketEvent(const MarketEvent &event) {
+  OrderBatch onMarketEvent(const MarketEvent &event) {
+    OrderBatch batch{};
     if (event.eventType == 2) {
-      Order order{};
+      Order &order = batch.orders[batch.count++];
       order.id = 1;
       order.side = OrderSide::Buy;
       order.quantity = 2000;
       order.price = 1000000;
-      return {order};
     }
-    return {};
+    return batch;
   }
 };
 
@@ -73,7 +72,7 @@ class CountingStrategy {
 public:
   static std::atomic<int> invocation_count;
 
-  std::vector<Order> onMarketEvent(const MarketEvent & /*event*/) {
+  OrderBatch onMarketEvent(const MarketEvent & /*event*/) {
     invocation_count.fetch_add(1, std::memory_order_relaxed);
     return {};
   }

--- a/tests/test_simple_market_making_strategy.cpp
+++ b/tests/test_simple_market_making_strategy.cpp
@@ -3,7 +3,6 @@
 #include "SimpleMarketMakingStrategy.hpp"
 #include <gtest/gtest.h>
 #include <limits>
-#include <vector>
 
 class SimpleMarketMakingStrategyTest : public ::testing::Test {
 protected:
@@ -15,12 +14,11 @@ TEST_F(SimpleMarketMakingStrategyTest, GeneratesOrdersOnTradeEvent) {
   trade_event.eventType = 2;
   trade_event.p1 = 1500000;
 
-  const std::vector<Order> generated_orders =
-      strategy.onMarketEvent(trade_event);
+  const auto batch = strategy.onMarketEvent(trade_event);
 
-  ASSERT_EQ(generated_orders.size(), 2);
-  const auto &buy_order = generated_orders[0];
-  const auto &sell_order = generated_orders[1];
+  ASSERT_EQ(batch.count, 2);
+  const auto &buy_order = batch.orders[0];
+  const auto &sell_order = batch.orders[1];
   EXPECT_EQ(buy_order.side, OrderSide::Buy);
   EXPECT_EQ(buy_order.type, OrderType::Limit);
   EXPECT_EQ(buy_order.quantity, 100);
@@ -37,10 +35,9 @@ TEST_F(SimpleMarketMakingStrategyTest, IgnoresQuoteEvent) {
   quote_event.p1 = 1500000;
   quote_event.p2 = 1500200;
 
-  const std::vector<Order> generated_orders =
-      strategy.onMarketEvent(quote_event);
+  const auto batch = strategy.onMarketEvent(quote_event);
 
-  EXPECT_TRUE(generated_orders.empty());
+  EXPECT_EQ(batch.count, 0);
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, OrderIdIncrements) {
@@ -52,15 +49,15 @@ TEST_F(SimpleMarketMakingStrategyTest, OrderIdIncrements) {
   trade2.eventType = 2;
   trade2.p1 = 1010000;
 
-  const std::vector<Order> orders1 = strategy.onMarketEvent(trade1);
-  ASSERT_EQ(orders1.size(), 2);
-  EXPECT_EQ(orders1[0].id, 1);
-  EXPECT_EQ(orders1[1].id, 2);
+  const auto batch1 = strategy.onMarketEvent(trade1);
+  ASSERT_EQ(batch1.count, 2);
+  EXPECT_EQ(batch1.orders[0].id, 1);
+  EXPECT_EQ(batch1.orders[1].id, 2);
 
-  const std::vector<Order> orders2 = strategy.onMarketEvent(trade2);
-  ASSERT_EQ(orders2.size(), 2);
-  EXPECT_EQ(orders2[0].id, 3);
-  EXPECT_EQ(orders2[1].id, 4);
+  const auto batch2 = strategy.onMarketEvent(trade2);
+  ASSERT_EQ(batch2.count, 2);
+  EXPECT_EQ(batch2.orders[0].id, 3);
+  EXPECT_EQ(batch2.orders[1].id, 4);
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, HandlesZeroPrice) {
@@ -68,8 +65,8 @@ TEST_F(SimpleMarketMakingStrategyTest, HandlesZeroPrice) {
   trade_event.eventType = 2;
   trade_event.p1 = 0;
 
-  const auto orders = strategy.onMarketEvent(trade_event);
-  EXPECT_TRUE(orders.empty());
+  const auto batch = strategy.onMarketEvent(trade_event);
+  EXPECT_EQ(batch.count, 0);
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, SkipsOrdersWhenBuyPriceUnderflows) {
@@ -77,8 +74,8 @@ TEST_F(SimpleMarketMakingStrategyTest, SkipsOrdersWhenBuyPriceUnderflows) {
   trade_event.eventType = 2;
   trade_event.p1 = 50;
 
-  const auto orders = strategy.onMarketEvent(trade_event);
-  EXPECT_TRUE(orders.empty());
+  const auto batch = strategy.onMarketEvent(trade_event);
+  EXPECT_EQ(batch.count, 0);
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, SkipsOrdersWhenSellPriceOverflows) {
@@ -86,6 +83,6 @@ TEST_F(SimpleMarketMakingStrategyTest, SkipsOrdersWhenSellPriceOverflows) {
   trade_event.eventType = 2;
   trade_event.p1 = std::numeric_limits<uint64_t>::max() - 50;
 
-  const auto orders = strategy.onMarketEvent(trade_event);
-  EXPECT_TRUE(orders.empty());
+  const auto batch = strategy.onMarketEvent(trade_event);
+  EXPECT_EQ(batch.count, 0);
 }

--- a/tests/test_simple_market_making_strategy.cpp
+++ b/tests/test_simple_market_making_strategy.cpp
@@ -2,31 +2,24 @@
 #include "Order.hpp"
 #include "SimpleMarketMakingStrategy.hpp"
 #include <gtest/gtest.h>
-#include <limits>
 
 class SimpleMarketMakingStrategyTest : public ::testing::Test {
 protected:
   SimpleMarketMakingStrategy strategy;
 };
 
-TEST_F(SimpleMarketMakingStrategyTest, GeneratesOrdersOnTradeEvent) {
+TEST_F(SimpleMarketMakingStrategyTest, GeneratesBuyOrderOnTradeEvent) {
   MarketEvent trade_event{};
   trade_event.eventType = 2;
   trade_event.p1 = 1500000;
 
-  const auto batch = strategy.onMarketEvent(trade_event);
+  const auto order = strategy.onMarketEvent(trade_event);
 
-  ASSERT_EQ(batch.count, 2);
-  const auto &buy_order = batch.orders[0];
-  const auto &sell_order = batch.orders[1];
-  EXPECT_EQ(buy_order.side, OrderSide::Buy);
-  EXPECT_EQ(buy_order.type, OrderType::Limit);
-  EXPECT_EQ(buy_order.quantity, 100);
-  EXPECT_EQ(buy_order.price, 1499900);
-  EXPECT_EQ(sell_order.side, OrderSide::Sell);
-  EXPECT_EQ(sell_order.type, OrderType::Limit);
-  EXPECT_EQ(sell_order.quantity, 100);
-  EXPECT_EQ(sell_order.price, 1500100);
+  ASSERT_TRUE(order.has_value());
+  EXPECT_EQ(order->side, OrderSide::Buy);
+  EXPECT_EQ(order->type, OrderType::Limit);
+  EXPECT_EQ(order->quantity, 100);
+  EXPECT_EQ(order->price, 1499900);
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, IgnoresQuoteEvent) {
@@ -35,9 +28,7 @@ TEST_F(SimpleMarketMakingStrategyTest, IgnoresQuoteEvent) {
   quote_event.p1 = 1500000;
   quote_event.p2 = 1500200;
 
-  const auto batch = strategy.onMarketEvent(quote_event);
-
-  EXPECT_EQ(batch.count, 0);
+  EXPECT_FALSE(strategy.onMarketEvent(quote_event).has_value());
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, OrderIdIncrements) {
@@ -49,15 +40,13 @@ TEST_F(SimpleMarketMakingStrategyTest, OrderIdIncrements) {
   trade2.eventType = 2;
   trade2.p1 = 1010000;
 
-  const auto batch1 = strategy.onMarketEvent(trade1);
-  ASSERT_EQ(batch1.count, 2);
-  EXPECT_EQ(batch1.orders[0].id, 1);
-  EXPECT_EQ(batch1.orders[1].id, 2);
+  const auto order1 = strategy.onMarketEvent(trade1);
+  ASSERT_TRUE(order1.has_value());
+  EXPECT_EQ(order1->id, 1);
 
-  const auto batch2 = strategy.onMarketEvent(trade2);
-  ASSERT_EQ(batch2.count, 2);
-  EXPECT_EQ(batch2.orders[0].id, 3);
-  EXPECT_EQ(batch2.orders[1].id, 4);
+  const auto order2 = strategy.onMarketEvent(trade2);
+  ASSERT_TRUE(order2.has_value());
+  EXPECT_EQ(order2->id, 2);
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, HandlesZeroPrice) {
@@ -65,24 +54,13 @@ TEST_F(SimpleMarketMakingStrategyTest, HandlesZeroPrice) {
   trade_event.eventType = 2;
   trade_event.p1 = 0;
 
-  const auto batch = strategy.onMarketEvent(trade_event);
-  EXPECT_EQ(batch.count, 0);
+  EXPECT_FALSE(strategy.onMarketEvent(trade_event).has_value());
 }
 
-TEST_F(SimpleMarketMakingStrategyTest, SkipsOrdersWhenBuyPriceUnderflows) {
+TEST_F(SimpleMarketMakingStrategyTest, SkipsOrderWhenBuyPriceUnderflows) {
   MarketEvent trade_event{};
   trade_event.eventType = 2;
   trade_event.p1 = 50;
 
-  const auto batch = strategy.onMarketEvent(trade_event);
-  EXPECT_EQ(batch.count, 0);
-}
-
-TEST_F(SimpleMarketMakingStrategyTest, SkipsOrdersWhenSellPriceOverflows) {
-  MarketEvent trade_event{};
-  trade_event.eventType = 2;
-  trade_event.p1 = std::numeric_limits<uint64_t>::max() - 50;
-
-  const auto batch = strategy.onMarketEvent(trade_event);
-  EXPECT_EQ(batch.count, 0);
+  EXPECT_FALSE(strategy.onMarketEvent(trade_event).has_value());
 }


### PR DESCRIPTION
## Summary

- Remove `std::vector<Order>` from the strategy return type — eliminates heap allocation on the hot path
- Add `std::optional<Order>` as the single-signal return: one event produces at most one order
- Update `StrategyLike` concept to require `std::optional<Order>` return
- Simplify `SimpleMarketMakingStrategy` to emit a single buy-side limit order per trade event
- Update `MarketEventConsumer::run()` — no batch iteration, just check optional and forward

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified market event processing to handle single orders instead of batches, improving efficiency in order generation workflows.
  * Market making strategy now generates individual buy orders rather than paired buy-sell orders, streamlining position management.
  * Enhanced error handling with cleaner null-state management for scenarios where no order should be generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->