### PR TITLE
Fix ownership model: unique_ptr RiskManager, member PositionManager

### DIFF
--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -18,8 +18,7 @@ public:
 
   MarketEventConsumer(zmq::context_t &context, std::string address,
                       std::string symbol, std::atomic<bool> &is_running,
-                      OrderCallback order_callback,
-                      const std::shared_ptr<RiskManager> &risk_manager)
+                      OrderCallback order_callback, RiskManager *risk_manager)
       : subscriber_(context, zmq::socket_type::sub),
         address_(std::move(address)), symbol_(std::move(symbol)),
         is_running_(is_running), order_callback_(std::move(order_callback)),
@@ -73,5 +72,5 @@ private:
   std::atomic<bool> &is_running_;
   OrderCallback order_callback_;
   std::unique_ptr<StrategyType> strategy_;
-  std::shared_ptr<RiskManager> risk_manager_;
+  RiskManager *risk_manager_;
 };

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -4,6 +4,7 @@
 #include "LockFreeMPSCQueue.hpp"
 #include "MarketEventConsumer.hpp"
 #include "OrderGateway.hpp"
+#include "PositionManager.hpp"
 #include "SimpleMarketMakingStrategy.hpp"
 #include <atomic>
 #include <memory>
@@ -40,7 +41,8 @@ private:
   std::atomic<bool> is_running_;
   std::string ipc_address_;
   std::vector<std::string> symbols_;
-  std::shared_ptr<RiskManager> risk_manager_;
+  std::shared_ptr<PositionManager> position_manager_;
+  std::unique_ptr<RiskManager> risk_manager_;
   zmq::context_t context_{1};
   std::shared_ptr<LockFreeMPSCQueue<Order>> order_queue_;
   std::unique_ptr<OrderGateway> order_gateway_;

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -61,14 +61,14 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
                              std::unique_ptr<IRestClient> rest_client)
     : is_running_(true), symbols_(symbols) {
   setup_signal_handler();
-  auto position_manager = std::make_shared<PositionManager>();
+  position_manager_ = std::make_shared<PositionManager>();
   for (const auto &symbol : symbols_) {
-    position_manager->registerSymbol(symbol);
+    position_manager_->registerSymbol(symbol);
   }
-  risk_manager_ = std::make_shared<RiskManager>(position_manager);
+  risk_manager_ = std::make_unique<RiskManager>(position_manager_);
   order_queue_ = std::make_shared<LockFreeMPSCQueue<Order>>();
   order_gateway_ = std::make_unique<OrderGateway>(
-      is_running_, order_queue_, std::move(rest_client), position_manager);
+      is_running_, order_queue_, std::move(rest_client), position_manager_);
 
   const char *api_key = std::getenv("APCA_API_KEY_ID");
   const char *api_secret = std::getenv("APCA_API_SECRET_KEY");
@@ -77,7 +77,7 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
         "APCA_API_KEY_ID and APCA_API_SECRET_KEY must be set");
   }
   fill_listener_ = std::make_unique<AlpacaFillListener>(
-      position_manager, is_running_, api_key, api_secret);
+      position_manager_, is_running_, api_key, api_secret);
 
 #ifdef _WIN32
   ipc_address_ = "tcp://127.0.0.1:5555";
@@ -120,7 +120,7 @@ void TradingEngine::launch_consumers() {
     auto consumer =
         std::make_unique<MarketEventConsumer<SimpleMarketMakingStrategy>>(
             context_, ipc_address_, symbol, is_running_, callback,
-            risk_manager_);
+            risk_manager_.get());
 
     consumer_threads_.push_back(
         {std::thread(&MarketEventConsumer<SimpleMarketMakingStrategy>::run,

--- a/tests/test_error_scenarios.cpp
+++ b/tests/test_error_scenarios.cpp
@@ -18,15 +18,15 @@ TEST(MarketEventConsumerErrorTest, HandlesStrategyException) {
   publisher.bind("tcp://127.0.0.1:5556");
 
   std::atomic is_running(true);
-  const auto risk_manager =
-      std::make_shared<RiskManager>(std::make_shared<PositionManager>());
+  auto position_manager = std::make_shared<PositionManager>();
+  auto risk_manager = std::make_unique<RiskManager>(position_manager);
 
   bool callback_called = false;
   auto callback = [&](const Order &) { callback_called = true; };
 
   MarketEventConsumer<ThrowingStrategy> consumer(
       context, "tcp://127.0.0.1:5556", "TEST", is_running, callback,
-      risk_manager);
+      risk_manager.get());
 
   std::thread consumer_thread(&MarketEventConsumer<ThrowingStrategy>::run,
                               &consumer);

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -41,12 +41,13 @@ protected:
     std::filesystem::path socket_path = temp_dir / ("test_market_data.sock");
     ipc_address = "ipc:///" + socket_path.string();
 #endif
-    risk_manager_ =
-        std::make_shared<RiskManager>(std::make_shared<PositionManager>());
+    position_manager_ = std::make_shared<PositionManager>();
+    risk_manager_ = std::make_unique<RiskManager>(position_manager_);
   }
 
   std::string ipc_address;
-  std::shared_ptr<RiskManager> risk_manager_;
+  std::shared_ptr<PositionManager> position_manager_;
+  std::unique_ptr<RiskManager> risk_manager_;
 };
 
 class EmptyStrategy {
@@ -91,8 +92,9 @@ TEST_F(MarketEventConsumerTest, HandlesStrategyReturningNoOrders) {
   auto callback = [&](const Order & /*order*/) { callback_count++; };
 
   try {
-    MarketEventConsumer<EmptyStrategy> consumer(
-        context, ipc_address, "TEST", is_running, callback, risk_manager_);
+    MarketEventConsumer<EmptyStrategy> consumer(context, ipc_address, "TEST",
+                                                is_running, callback,
+                                                risk_manager_.get());
 
     SUCCEED();
   } catch (const std::exception &e) {
@@ -109,7 +111,8 @@ TEST_F(MarketEventConsumerTest, HandlesRiskManagerRejection) {
 
   try {
     MarketEventConsumer<RejectedOrderStrategy> consumer(
-        context, ipc_address, "TEST", is_running, callback, risk_manager_);
+        context, ipc_address, "TEST", is_running, callback,
+        risk_manager_.get());
 
     SUCCEED();
   } catch (const std::exception &e) {
@@ -126,7 +129,7 @@ TEST_F(MarketEventConsumerTest, ConstructorThrowsOnInvalidAddress) {
 
   EXPECT_THROW(MarketEventConsumer<EmptyStrategy>(context, "invalid://address",
                                                   "TEST", is_running, callback,
-                                                  risk_manager_),
+                                                  risk_manager_.get()),
                zmq::error_t);
 }
 
@@ -141,7 +144,7 @@ TEST_F(MarketEventConsumerTest, CallsStrategyAndReceivesOrders) {
   auto test_callback = [&](const Order &order) { promise.set_value(order); };
   MarketEventConsumer<MockStrategy> consumer(context, ipc_address, "TEST",
                                              is_test_running, test_callback,
-                                             risk_manager_);
+                                             risk_manager_.get());
 
   ThreadGuard consumer_thread_guard{
       std::thread(&MarketEventConsumer<MockStrategy>::run, &consumer)};
@@ -185,7 +188,7 @@ TEST_F(MarketEventConsumerTest, SkipsMismatchedPayloadSize) {
   auto callback = [](const Order &) {};
 
   MarketEventConsumer<CountingStrategy> consumer(
-      context, ipc_address, "TEST", is_running, callback, risk_manager_);
+      context, ipc_address, "TEST", is_running, callback, risk_manager_.get());
 
   ThreadGuard consumer_thread_guard{
       std::thread(&MarketEventConsumer<CountingStrategy>::run, &consumer)};


### PR DESCRIPTION
## Summary

- RiskManager changed from `shared_ptr` to `unique_ptr` in TradingEngine — it has a single owner, shared_ptr was adding unnecessary atomic ref-count overhead on the hot path
- MarketEventConsumer now takes `RiskManager*` (raw pointer) instead of `shared_ptr<RiskManager>` — documents the borrowing relationship, zero overhead
- PositionManager promoted from constructor local variable to `shared_ptr` member of TradingEngine — it is genuinely shared across OrderGateway, FillListener, and RiskManager
- Tests updated to match new ownership semantics

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal memory management and component ownership models across the trading engine and market event consumer.
  * Restructured dependency wiring to enhance system reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->