### PR TITLE
Standards sweep: [[nodiscard]], [[unlikely]], (std::min), fixed-width integers

### DIFF
--- a/include/LockFreeMPSCQueue.hpp
+++ b/include/LockFreeMPSCQueue.hpp
@@ -45,7 +45,7 @@ public:
     prev_head->next.store(node, std::memory_order_release);
   }
 
-  bool try_pop(T &result) {
+  [[nodiscard]] bool try_pop(T &result) {
     Node *tail = tail_;
     Node *next = tail->next.load(std::memory_order_acquire);
 

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -10,7 +10,7 @@
 struct SymbolKey {
   char value[8] = {};
 
-  bool operator==(const SymbolKey &other) const {
+  [[nodiscard]] bool operator==(const SymbolKey &other) const {
     return strncmp(value, other.value, sizeof(value)) == 0;
   }
 };
@@ -18,12 +18,12 @@ struct SymbolKey {
 static_assert(sizeof(SymbolKey) == 8, "SymbolKey must be exactly 8 bytes");
 
 struct SymbolKeyHashCompare {
-  static std::size_t hash(const SymbolKey &k) {
+  [[nodiscard]] static std::size_t hash(const SymbolKey &k) {
     return std::hash<std::string_view>{}(
         std::string_view(k.value, sizeof(k.value)));
   }
 
-  static bool equal(const SymbolKey &lhs, const SymbolKey &rhs) {
+  [[nodiscard]] static bool equal(const SymbolKey &lhs, const SymbolKey &rhs) {
     return std::memcmp(lhs.value, rhs.value, sizeof(lhs.value)) == 0;
   }
 };
@@ -54,8 +54,8 @@ private:
   using PositionMap =
       tbb::concurrent_hash_map<SymbolKey, PositionState, SymbolKeyHashCompare>;
 
-  static SymbolKey makeKey(std::string_view symbol);
-  static SymbolKey makeKeyFromBuffer(const char *symbol_buffer);
+  [[nodiscard]] static SymbolKey makeKey(std::string_view symbol);
+  [[nodiscard]] static SymbolKey makeKeyFromBuffer(const char *symbol_buffer);
 
   mutable PositionMap positions_;
 };

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -11,7 +11,7 @@ struct SymbolKey {
   char value[8] = {};
 
   [[nodiscard]] bool operator==(const SymbolKey &other) const {
-    return strncmp(value, other.value, sizeof(value)) == 0;
+    return std::memcmp(value, other.value, sizeof(value)) == 0;
   }
 };
 

--- a/include/SimpleMarketMakingStrategy.hpp
+++ b/include/SimpleMarketMakingStrategy.hpp
@@ -11,15 +11,15 @@ class SimpleMarketMakingStrategy {
 public:
   SimpleMarketMakingStrategy() : last_trade_price_(0), order_id_counter_(0) {}
 
-  std::optional<Order> onMarketEvent(const MarketEvent &event) {
-    if (event.eventType != 2) {
+  [[nodiscard]] std::optional<Order> onMarketEvent(const MarketEvent &event) {
+    if (event.eventType != 2) [[unlikely]] {
       return std::nullopt;
     }
 
     last_trade_price_ = event.p1;
 
     constexpr uint64_t offset_ticks = 100;
-    if (last_trade_price_ < offset_ticks) {
+    if (last_trade_price_ < offset_ticks) [[unlikely]] {
       return std::nullopt;
     }
 

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -7,6 +7,7 @@
 #include "PositionManager.hpp"
 #include "SimpleMarketMakingStrategy.hpp"
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <thread>
@@ -14,7 +15,7 @@
 
 class IFillListener;
 
-void pin_thread_to_core(std::thread &t, size_t core_id);
+void pin_thread_to_core(std::thread &t, uint32_t core_id);
 
 class TradingEngine {
 public:

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -6,7 +6,7 @@
 #include <optional>
 #include <thread>
 
-void pin_thread_to_core(std::thread &t, size_t core_id);
+void pin_thread_to_core(std::thread &t, uint32_t core_id);
 
 namespace {
 

--- a/src/PositionManager.cpp
+++ b/src/PositionManager.cpp
@@ -12,7 +12,7 @@ constexpr std::size_t kSymbolCapacity = sizeof(SymbolKey{}.value);
 
 SymbolKey PositionManager::makeKey(std::string_view symbol) {
   SymbolKey key{};
-  const auto copy_len = std::min(symbol.size(), kSymbolCapacity);
+  const auto copy_len = (std::min)(symbol.size(), kSymbolCapacity);
   if (copy_len > 0) {
     std::memcpy(key.value, symbol.data(), copy_len);
   }

--- a/src/RiskManager.cpp
+++ b/src/RiskManager.cpp
@@ -8,7 +8,7 @@ RiskManager::RiskManager(
 }
 
 bool RiskManager::onNewOrder(const Order &order) {
-  if (!position_manager_) {
+  if (!position_manager_) [[unlikely]] {
     return false;
   }
 
@@ -21,7 +21,7 @@ bool RiskManager::onNewOrder(const Order &order) {
     new_exposure -= order.quantity;
   }
 
-  if (std::llabs(new_exposure) > max_position_per_symbol_) {
+  if (std::llabs(new_exposure) > max_position_per_symbol_) [[unlikely]] {
     return false;
   }
 
@@ -31,7 +31,7 @@ bool RiskManager::onNewOrder(const Order &order) {
         static_cast<long double>(std::llabs(order.quantity));
     const long double limit = static_cast<long double>(max_order_value_) *
                               static_cast<long double>(SCALING_FACTOR);
-    if (notional > limit) {
+    if (notional > limit) [[unlikely]] {
       return false;
     }
   }

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -26,7 +26,7 @@ void signal_handler(const int signum) {
 }
 } // namespace
 
-void pin_thread_to_core(std::thread &t, size_t core_id) {
+void pin_thread_to_core(std::thread &t, uint32_t core_id) {
 #if defined(__linux__) || defined(__gnu_linux__)
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
@@ -111,7 +111,7 @@ void TradingEngine::launch_gateway() {
 }
 
 void TradingEngine::launch_consumers() {
-  for (size_t i = 0; i < symbols_.size(); ++i) {
+  for (uint32_t i = 0; i < symbols_.size(); ++i) {
     const auto &symbol = symbols_[i];
     auto callback = [this](const Order &order) {
       this->order_queue_->push(order);

--- a/tests/test_lockfree_mpsc_queue.cpp
+++ b/tests/test_lockfree_mpsc_queue.cpp
@@ -27,7 +27,7 @@ TEST_F(LockFreeMPSCQueueTest, SinglePushPop) {
 TEST_F(LockFreeMPSCQueueTest, PopAfterPushLeavesEmpty) {
   queue.push(100);
   int value;
-  queue.try_pop(value);
+  EXPECT_TRUE(queue.try_pop(value));
   EXPECT_FALSE(queue.try_pop(value));
 }
 


### PR DESCRIPTION
## Summary

- Add `[[nodiscard]]` to 7 value-returning functions missing the attribute
  (SymbolKey ops, PositionManager key factories, onMarketEvent, try_pop)
- Add `[[unlikely]]` to 5 error/guard branches in RiskManager and
  SimpleMarketMakingStrategy to keep trade-processing code in L1-hot layout
- Parenthesize `(std::min)` in PositionManager.cpp for MSVC `<windows.h>`
  macro compatibility
- Replace `size_t` with `uint32_t` in `pin_thread_to_core` signature and
  `launch_consumers` loop index
- Fix test discarding `try_pop` return value (now caught by `[[nodiscard]]`)

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal type annotations and signatures for consistency and clarity.
  * Added compiler hints to improve branch prediction and enforce return-value usage.

* **Tests**
  * Strengthened queue test assertions to ensure items are consumed as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->