### PR TITLE
Fix unbounded string_view from char[8] in AlpacaRestClient

### DIFF
--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaRestClient.hpp"
+#include <cstring>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
 #include <string_view>
@@ -26,7 +27,8 @@ AlpacaRestClient::AlpacaRestClient() {
 std::expected<OrderAck, OrderError>
 AlpacaRestClient::placeOrder(const Order &order) {
   nlohmann::json payload;
-  payload["symbol"] = std::string_view(order.symbol);
+  payload["symbol"] = std::string_view(
+      order.symbol, strnlen(order.symbol, sizeof(order.symbol)));
   payload["qty"] = std::to_string(order.quantity);
   payload["side"] = (order.side == OrderSide::Buy) ? "buy" : "sell";
   payload["type"] = (order.type == OrderType::Market) ? "market" : "limit";


### PR DESCRIPTION
## Summary

- Add `strnlen` bound to `std::string_view(order.symbol)` in
  `AlpacaRestClient::placeOrder` to prevent reading past the
  8-byte buffer when the symbol fills all bytes
- Only unbounded call site in the codebase; all others already
  used explicit lengths

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of order placement with better handling of order symbol data to prevent potential processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->