### PR TITLE
Log parse errors in parseQty/parsePrice catch blocks

### DIFF
--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -41,7 +41,8 @@ void copySymbol(char (&dest)[8], const std::string &src) {
     if (val.is_number_integer()) {
       return val.get<int64_t>();
     }
-  } catch (const std::exception &) {
+  } catch (const std::exception &e) {
+    std::cerr << "FillListener: parseQty failed: " << e.what() << std::endl;
   }
   return std::nullopt;
 }
@@ -54,7 +55,8 @@ void copySymbol(char (&dest)[8], const std::string &src) {
     if (val.is_number()) {
       return val.get<double>();
     }
-  } catch (const std::exception &) {
+  } catch (const std::exception &e) {
+    std::cerr << "FillListener: parsePrice failed: " << e.what() << std::endl;
   }
   return std::nullopt;
 }

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -223,6 +223,23 @@ TEST_F(FillListenerTest, RejectsInvalidQtyString) {
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
 }
 
+TEST_F(FillListenerTest, RejectsInvalidPriceString) {
+  const auto update = parse(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "not_a_price",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy"
+      }
+    }
+  })");
+
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+}
+
 TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {
   const auto update = parse(R"({
     "stream": "trade_updates",

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <sstream>
 #include <string>
 
 class FillListenerTest : public ::testing::Test {
@@ -207,6 +208,9 @@ TEST_F(FillListenerTest, RejectsUnknownSide) {
 }
 
 TEST_F(FillListenerTest, RejectsInvalidQtyString) {
+  std::ostringstream captured;
+  auto *old_buf = std::cerr.rdbuf(captured.rdbuf());
+
   const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
@@ -220,10 +224,16 @@ TEST_F(FillListenerTest, RejectsInvalidQtyString) {
     }
   })");
 
+  std::cerr.rdbuf(old_buf);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+  EXPECT_NE(captured.str().find("FillListener: parseQty failed:"),
+            std::string::npos);
 }
 
 TEST_F(FillListenerTest, RejectsInvalidPriceString) {
+  std::ostringstream captured;
+  auto *old_buf = std::cerr.rdbuf(captured.rdbuf());
+
   const auto update = parse(R"({
     "stream": "trade_updates",
     "data": {
@@ -237,7 +247,10 @@ TEST_F(FillListenerTest, RejectsInvalidPriceString) {
     }
   })");
 
+  std::cerr.rdbuf(old_buf);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
+  EXPECT_NE(captured.str().find("FillListener: parsePrice failed:"),
+            std::string::npos);
 }
 
 TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {


### PR DESCRIPTION
## Summary

- `parseQty` and `parsePrice` catch blocks now log `e.what()` with
  component context via std::cerr instead of silently returning nullopt
- Both are cold-path (fill processing), so stderr logging is acceptable
- Added `RejectsInvalidPriceString` test covering the parsePrice catch
  path (existing `RejectsInvalidQtyString` already covers parseQty)

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics for invalid price and quantity values in fill events: failures now emit clearer parse error messages to aid troubleshooting while preserving existing failure behavior.
* **Tests**
  * Added tests to validate parse-failure handling and to ensure the new error messages are produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->