### PR TITLE
Add static_assert for FillEvent and CancelEvent structs

### DIFF
--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json_fwd.hpp>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <variant>
 
 struct FillEvent {
@@ -17,11 +18,21 @@ struct FillEvent {
   double price;
 };
 
+static_assert(sizeof(FillEvent) == 32, "FillEvent must be 32 bytes");
+static_assert(alignof(FillEvent) == 8, "FillEvent must be 8-byte aligned");
+static_assert(std::is_trivially_copyable_v<FillEvent>,
+              "FillEvent must be trivially copyable");
+
 struct CancelEvent {
   char symbol[8];
   OrderSide side;
   int64_t quantity;
 };
+
+static_assert(sizeof(CancelEvent) == 24, "CancelEvent must be 24 bytes");
+static_assert(alignof(CancelEvent) == 8, "CancelEvent must be 8-byte aligned");
+static_assert(std::is_trivially_copyable_v<CancelEvent>,
+              "CancelEvent must be trivially copyable");
 
 using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 


### PR DESCRIPTION
## Summary

- Add static_assert for size (32/24 bytes), alignment (8-byte),
  and trivial copyability on FillEvent and CancelEvent
- Matches existing pattern used by MarketEvent, Order, Fill,
  and PositionState

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added compile-time validation checks to enforce data structure consistency, memory layout requirements, and copyability constraints. No changes to public interfaces or existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->