### PR TITLE
OrderGateway cleanup: wait_and_pop, order ID ownership, drop uWebSockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ find_package(cppzmq CONFIG REQUIRED)
 find_package(cpr CONFIG REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(GTest REQUIRED)
-find_package(unofficial-uwebsockets CONFIG REQUIRED)
 find_package(TBB CONFIG REQUIRED)
 find_package(ixwebsocket CONFIG REQUIRED)
 
@@ -98,7 +97,6 @@ target_link_libraries(
             cppzmq
             nlohmann_json::nlohmann_json
             cpr::cpr
-            unofficial::uwebsockets::uwebsockets
             TBB::tbb
             ixwebsocket::ixwebsocket)
 

--- a/include/LockFreeMPSCQueue.hpp
+++ b/include/LockFreeMPSCQueue.hpp
@@ -78,4 +78,24 @@ public:
       delete tail;
     }
   }
+
+  [[nodiscard]] bool wait_and_pop(T &result, const std::atomic<bool> &running) {
+    Node *tail = tail_;
+    Node *next = tail->next.load(std::memory_order_acquire);
+
+    while (next == nullptr) {
+      if (!running.load(std::memory_order_relaxed)) {
+        return false;
+      }
+      next = tail->next.load(std::memory_order_acquire);
+    }
+
+    result = next->data;
+    tail_ = next;
+
+    if (tail != &stub_) {
+      delete tail;
+    }
+    return true;
+  }
 };

--- a/include/LockFreeMPSCQueue.hpp
+++ b/include/LockFreeMPSCQueue.hpp
@@ -84,7 +84,8 @@ public:
     Node *next = tail->next.load(std::memory_order_acquire);
 
     while (next == nullptr) {
-      if (!running.load(std::memory_order_relaxed)) {
+      if (!running.load(std::memory_order_relaxed) &&
+          tail == head_.load(std::memory_order_acquire)) {
         return false;
       }
       next = tail->next.load(std::memory_order_acquire);

--- a/include/OrderGateway.hpp
+++ b/include/OrderGateway.hpp
@@ -14,7 +14,7 @@ public:
                std::unique_ptr<IRestClient> rest_client,
                std::shared_ptr<PositionManager> position_manager);
 
-  void run() const;
+  void run();
 
 private:
   void executeOrder(const Order &order) const;
@@ -23,4 +23,5 @@ private:
   std::shared_ptr<LockFreeMPSCQueue<Order>> order_queue_;
   std::unique_ptr<IRestClient> rest_client_;
   std::shared_ptr<PositionManager> position_manager_;
+  uint64_t order_id_counter_ = 0;
 };

--- a/include/SimpleMarketMakingStrategy.hpp
+++ b/include/SimpleMarketMakingStrategy.hpp
@@ -9,7 +9,7 @@
 
 class SimpleMarketMakingStrategy {
 public:
-  SimpleMarketMakingStrategy() : last_trade_price_(0), order_id_counter_(0) {}
+  SimpleMarketMakingStrategy() : last_trade_price_(0) {}
 
   [[nodiscard]] std::optional<Order> onMarketEvent(const MarketEvent &event) {
     if (event.eventType != 2) [[unlikely]] {
@@ -24,7 +24,6 @@ public:
     }
 
     Order order{};
-    order.id = ++order_id_counter_;
     std::memcpy(order.symbol, event.symbol, sizeof(order.symbol));
     order.side = OrderSide::Buy;
     order.type = OrderType::Limit;
@@ -35,5 +34,4 @@ public:
 
 private:
   uint64_t last_trade_price_;
-  uint64_t order_id_counter_;
 };

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -1,7 +1,5 @@
 #include "OrderGateway.hpp"
-#include <chrono>
 #include <iostream>
-#include <thread>
 
 OrderGateway::OrderGateway(
     std::atomic<bool> &is_running,
@@ -33,17 +31,16 @@ void OrderGateway::executeOrder(const Order &order) const {
   }
 }
 
-void OrderGateway::run() const {
-  while (is_running_.load()) {
-    if (Order order_to_execute{}; order_queue_->try_pop(order_to_execute)) {
-      executeOrder(order_to_execute);
-    } else {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+void OrderGateway::run() {
+  Order order_to_execute{};
+  while (order_queue_->wait_and_pop(order_to_execute, is_running_)) {
+    order_to_execute.id = ++order_id_counter_;
+    executeOrder(order_to_execute);
   }
 
   Order remaining_order{};
   while (order_queue_->try_pop(remaining_order)) {
+    remaining_order.id = ++order_id_counter_;
     executeOrder(remaining_order);
   }
 }

--- a/tests/test_lockfree_mpsc_queue.cpp
+++ b/tests/test_lockfree_mpsc_queue.cpp
@@ -102,10 +102,11 @@ TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopReturnsOnData) {
 TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopExitsOnStop) {
   std::atomic<bool> running{true};
   std::atomic<bool> consumer_exited{false};
+  bool got = true;
   int value = 0;
 
   std::thread consumer([&]() {
-    [[maybe_unused]] bool got = queue.wait_and_pop(value, running);
+    got = queue.wait_and_pop(value, running);
     consumer_exited.store(true);
   });
 
@@ -115,6 +116,7 @@ TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopExitsOnStop) {
   running.store(false);
   consumer.join();
   EXPECT_TRUE(consumer_exited.load());
+  EXPECT_FALSE(got);
 }
 
 TEST_F(LockFreeMPSCQueueTest, MultiProducerSingleConsumer) {

--- a/tests/test_lockfree_mpsc_queue.cpp
+++ b/tests/test_lockfree_mpsc_queue.cpp
@@ -84,6 +84,39 @@ TEST_F(LockFreeMPSCQueueTest, WaitAndPopBlocks) {
   EXPECT_EQ(consumed_value, 999);
 }
 
+TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopReturnsOnData) {
+  std::atomic<bool> running{true};
+  int value = 0;
+
+  std::thread producer([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    queue.push(42);
+  });
+
+  EXPECT_TRUE(queue.wait_and_pop(value, running));
+  EXPECT_EQ(value, 42);
+
+  producer.join();
+}
+
+TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopExitsOnStop) {
+  std::atomic<bool> running{true};
+  std::atomic<bool> consumer_exited{false};
+  int value = 0;
+
+  std::thread consumer([&]() {
+    [[maybe_unused]] bool got = queue.wait_and_pop(value, running);
+    consumer_exited.store(true);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  EXPECT_FALSE(consumer_exited.load());
+
+  running.store(false);
+  consumer.join();
+  EXPECT_TRUE(consumer_exited.load());
+}
+
 TEST_F(LockFreeMPSCQueueTest, MultiProducerSingleConsumer) {
   constexpr int num_producers = 8;
   constexpr int items_per_producer = 1000;

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -77,6 +77,39 @@ TEST_F(OrderGatewayTest, DrainsPendingOrdersWhenStopping) {
   ASSERT_EQ(status, std::future_status::ready);
 }
 
+TEST_F(OrderGatewayTest, AssignsSequentialOrderIds) {
+  std::atomic is_running(false);
+  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+
+  std::vector<uint64_t> received_ids;
+  class CapturingClient final : public IRestClient {
+  public:
+    explicit CapturingClient(std::vector<uint64_t> &ids) : ids_(ids) {}
+    std::expected<OrderAck, OrderError>
+    placeOrder(const Order &order) override {
+      ids_.push_back(order.id);
+      return OrderAck{"ord-" + std::to_string(order.id), "accepted"};
+    }
+
+  private:
+    std::vector<uint64_t> &ids_;
+  };
+
+  Order order1{};
+  Order order2{};
+  order_queue->push(order1);
+  order_queue->push(order2);
+
+  OrderGateway gateway(is_running, order_queue,
+                       std::make_unique<CapturingClient>(received_ids),
+                       position_manager_);
+  gateway.run();
+
+  ASSERT_EQ(received_ids.size(), 2);
+  EXPECT_EQ(received_ids[0], 1);
+  EXPECT_EQ(received_ids[1], 2);
+}
+
 TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
   std::atomic is_running(false);
   const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -121,61 +121,6 @@ TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
   EXPECT_EQ(received_ids[1], 2);
 }
 
-TEST_F(OrderGatewayTest, DrainLoopAssignsIds) {
-  std::atomic is_running(true);
-  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
-
-  std::vector<uint64_t> received_ids;
-  std::promise<void> first_order_started;
-  std::promise<void> shutdown_done;
-
-  class BlockingClient final : public IRestClient {
-  public:
-    BlockingClient(std::vector<uint64_t> &ids, std::promise<void> &started,
-                   std::future<void> shutdown)
-        : ids_(ids), started_(started), shutdown_(std::move(shutdown)),
-          first_(true) {}
-    std::expected<OrderAck, OrderError>
-    placeOrder(const Order &order) override {
-      ids_.push_back(order.id);
-      if (first_) {
-        first_ = false;
-        started_.set_value();
-        shutdown_.wait();
-      }
-      return OrderAck{"ord-" + std::to_string(order.id), "accepted"};
-    }
-
-  private:
-    std::vector<uint64_t> &ids_;
-    std::promise<void> &started_;
-    std::future<void> shutdown_;
-    bool first_;
-  };
-
-  auto shutdown_future = shutdown_done.get_future();
-  OrderGateway gateway(
-      is_running, order_queue,
-      std::make_unique<BlockingClient>(received_ids, first_order_started,
-                                       std::move(shutdown_future)),
-      position_manager_);
-  ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
-
-  order_queue->push(Order{});
-
-  first_order_started.get_future().wait();
-
-  order_queue->push(Order{});
-  is_running.store(false);
-  shutdown_done.set_value();
-
-  guard.t.join();
-
-  ASSERT_EQ(received_ids.size(), 2);
-  EXPECT_EQ(received_ids[0], 1);
-  EXPECT_EQ(received_ids[1], 2);
-}
-
 TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
   std::atomic is_running(false);
   const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -77,33 +77,99 @@ TEST_F(OrderGatewayTest, DrainsPendingOrdersWhenStopping) {
   ASSERT_EQ(status, std::future_status::ready);
 }
 
-TEST_F(OrderGatewayTest, AssignsSequentialOrderIds) {
-  std::atomic is_running(false);
+TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
+  std::atomic is_running(true);
   const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
 
   std::vector<uint64_t> received_ids;
+  std::atomic<int> call_count{0};
+
   class CapturingClient final : public IRestClient {
   public:
-    explicit CapturingClient(std::vector<uint64_t> &ids) : ids_(ids) {}
+    CapturingClient(std::vector<uint64_t> &ids, std::atomic<int> &count)
+        : ids_(ids), count_(count) {}
     std::expected<OrderAck, OrderError>
     placeOrder(const Order &order) override {
       ids_.push_back(order.id);
+      count_.fetch_add(1, std::memory_order_release);
       return OrderAck{"ord-" + std::to_string(order.id), "accepted"};
     }
 
   private:
     std::vector<uint64_t> &ids_;
+    std::atomic<int> &count_;
   };
+
+  OrderGateway gateway(
+      is_running, order_queue,
+      std::make_unique<CapturingClient>(received_ids, call_count),
+      position_manager_);
+  ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
 
   Order order1{};
   Order order2{};
   order_queue->push(order1);
   order_queue->push(order2);
 
-  OrderGateway gateway(is_running, order_queue,
-                       std::make_unique<CapturingClient>(received_ids),
-                       position_manager_);
-  gateway.run();
+  while (call_count.load(std::memory_order_acquire) < 2) {
+  }
+  is_running.store(false);
+  guard.t.join();
+
+  ASSERT_EQ(received_ids.size(), 2);
+  EXPECT_EQ(received_ids[0], 1);
+  EXPECT_EQ(received_ids[1], 2);
+}
+
+TEST_F(OrderGatewayTest, DrainLoopAssignsIds) {
+  std::atomic is_running(true);
+  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+
+  std::vector<uint64_t> received_ids;
+  std::promise<void> first_order_started;
+  std::promise<void> shutdown_done;
+
+  class BlockingClient final : public IRestClient {
+  public:
+    BlockingClient(std::vector<uint64_t> &ids, std::promise<void> &started,
+                   std::future<void> shutdown)
+        : ids_(ids), started_(started), shutdown_(std::move(shutdown)),
+          first_(true) {}
+    std::expected<OrderAck, OrderError>
+    placeOrder(const Order &order) override {
+      ids_.push_back(order.id);
+      if (first_) {
+        first_ = false;
+        started_.set_value();
+        shutdown_.wait();
+      }
+      return OrderAck{"ord-" + std::to_string(order.id), "accepted"};
+    }
+
+  private:
+    std::vector<uint64_t> &ids_;
+    std::promise<void> &started_;
+    std::future<void> shutdown_;
+    bool first_;
+  };
+
+  auto shutdown_future = shutdown_done.get_future();
+  OrderGateway gateway(
+      is_running, order_queue,
+      std::make_unique<BlockingClient>(received_ids, first_order_started,
+                                       std::move(shutdown_future)),
+      position_manager_);
+  ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
+
+  order_queue->push(Order{});
+
+  first_order_started.get_future().wait();
+
+  order_queue->push(Order{});
+  is_running.store(false);
+  shutdown_done.set_value();
+
+  guard.t.join();
 
   ASSERT_EQ(received_ids.size(), 2);
   EXPECT_EQ(received_ids[0], 1);

--- a/tests/test_simple_market_making_strategy.cpp
+++ b/tests/test_simple_market_making_strategy.cpp
@@ -31,22 +31,14 @@ TEST_F(SimpleMarketMakingStrategyTest, IgnoresQuoteEvent) {
   EXPECT_FALSE(strategy.onMarketEvent(quote_event).has_value());
 }
 
-TEST_F(SimpleMarketMakingStrategyTest, OrderIdIncrements) {
-  MarketEvent trade1{};
-  trade1.eventType = 2;
-  trade1.p1 = 1000000;
+TEST_F(SimpleMarketMakingStrategyTest, LeavesOrderIdUnset) {
+  MarketEvent trade{};
+  trade.eventType = 2;
+  trade.p1 = 1000000;
 
-  MarketEvent trade2{};
-  trade2.eventType = 2;
-  trade2.p1 = 1010000;
-
-  const auto order1 = strategy.onMarketEvent(trade1);
-  ASSERT_TRUE(order1.has_value());
-  EXPECT_EQ(order1->id, 1);
-
-  const auto order2 = strategy.onMarketEvent(trade2);
-  ASSERT_TRUE(order2.has_value());
-  EXPECT_EQ(order2->id, 2);
+  const auto order = strategy.onMarketEvent(trade);
+  ASSERT_TRUE(order.has_value());
+  EXPECT_EQ(order->id, 0);
 }
 
 TEST_F(SimpleMarketMakingStrategyTest, HandlesZeroPrice) {

--- a/tests/test_simple_market_making_strategy.cpp
+++ b/tests/test_simple_market_making_strategy.cpp
@@ -22,15 +22,6 @@ TEST_F(SimpleMarketMakingStrategyTest, GeneratesBuyOrderOnTradeEvent) {
   EXPECT_EQ(order->price, 1499900);
 }
 
-TEST_F(SimpleMarketMakingStrategyTest, IgnoresQuoteEvent) {
-  MarketEvent quote_event{};
-  quote_event.eventType = 1;
-  quote_event.p1 = 1500000;
-  quote_event.p2 = 1500200;
-
-  EXPECT_FALSE(strategy.onMarketEvent(quote_event).has_value());
-}
-
 TEST_F(SimpleMarketMakingStrategyTest, LeavesOrderIdUnset) {
   MarketEvent trade{};
   trade.eventType = 2;
@@ -41,18 +32,28 @@ TEST_F(SimpleMarketMakingStrategyTest, LeavesOrderIdUnset) {
   EXPECT_EQ(order->id, 0);
 }
 
-TEST_F(SimpleMarketMakingStrategyTest, HandlesZeroPrice) {
-  MarketEvent trade_event{};
-  trade_event.eventType = 2;
-  trade_event.p1 = 0;
+struct RejectParam {
+  uint8_t event_type;
+  uint64_t p1;
+  const char *name;
+};
 
-  EXPECT_FALSE(strategy.onMarketEvent(trade_event).has_value());
+class StrategyRejectsInputTest : public ::testing::TestWithParam<RejectParam> {
+protected:
+  SimpleMarketMakingStrategy strategy;
+};
+
+TEST_P(StrategyRejectsInputTest, ReturnsNullopt) {
+  const auto &[event_type, p1, name] = GetParam();
+  MarketEvent event{};
+  event.eventType = event_type;
+  event.p1 = p1;
+
+  EXPECT_FALSE(strategy.onMarketEvent(event).has_value()) << name;
 }
 
-TEST_F(SimpleMarketMakingStrategyTest, SkipsOrderWhenBuyPriceUnderflows) {
-  MarketEvent trade_event{};
-  trade_event.eventType = 2;
-  trade_event.p1 = 50;
-
-  EXPECT_FALSE(strategy.onMarketEvent(trade_event).has_value());
-}
+INSTANTIATE_TEST_SUITE_P(
+    InvalidInputs, StrategyRejectsInputTest,
+    ::testing::Values(RejectParam{1, 1500000, "quote event (non-trade)"},
+                      RejectParam{2, 0, "zero price"},
+                      RejectParam{2, 50, "price below offset"}));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,6 @@
   "version": "0.0.2",
   "dependencies": [
     "boost-lockfree",
-    "uwebsockets",
     "zeromq",
     "cppzmq",
     "cpr",


### PR DESCRIPTION
## Summary

- Replace `sleep_for(10ms)` polling in OrderGateway with `wait_and_pop` on the lock-free queue, eliminating up to 10ms order submission latency. Added a stoppable overload `wait_and_pop(T&, const atomic<bool>&)` that exits cleanly on shutdown.
- Move `order_id_counter_` from `SimpleMarketMakingStrategy` to `OrderGateway` -- order IDs are a gateway concern, not a strategy concern.
- Remove phantom `uwebsockets` dependency from vcpkg.json and CMakeLists.txt (never used; fill listener uses ixwebsocket).
- Refactor strategy rejection tests into `TEST_P` and add branch-coverage tests for both the main loop and drain loop ID assignment paths.

Closes #54
Closes #55
Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved order processing with a blocking wait mechanism for faster, more efficient execution and graceful shutdown.

* **Bug Fixes**
  * Ensured sequential order ID assignment during execution.

* **Chores**
  * Removed an unused external dependency to reduce application footprint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->