### PR TITLE
Remove shared_ptr from hot path and cache-line align structs

### DIFF
--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -42,7 +42,7 @@ class AlpacaFillListener : public IFillListener {
   friend class FillListenerTest;
 
 public:
-  AlpacaFillListener(std::shared_ptr<PositionManager> position_manager,
+  AlpacaFillListener(PositionManager *position_manager,
                      std::atomic<bool> &is_running, const std::string &api_key,
                      const std::string &api_secret);
 
@@ -57,7 +57,7 @@ private:
   void sendSubscribe();
   void handleTradeUpdate(const std::string &json);
 
-  std::shared_ptr<PositionManager> position_manager_;
+  PositionManager *position_manager_;
   std::atomic<bool> &is_running_;
   std::string api_key_;
   std::string api_secret_;

--- a/include/LockFreeMPSCQueue.hpp
+++ b/include/LockFreeMPSCQueue.hpp
@@ -12,10 +12,9 @@ private:
 
     explicit Node(const T &value) : next(nullptr), data(value) {}
     Node() : next(nullptr), data() {}
-
-    static_assert(sizeof(T) <= 64,
-                  "Queue element must fit in a single cache line");
   };
+
+  static_assert(sizeof(Node) <= 128, "Node must fit within two cache lines");
 
   alignas(64) std::atomic<Node *> head_;
   alignas(64) Node *tail_;

--- a/include/LockFreeMPSCQueue.hpp
+++ b/include/LockFreeMPSCQueue.hpp
@@ -12,6 +12,9 @@ private:
 
     explicit Node(const T &value) : next(nullptr), data(value) {}
     Node() : next(nullptr), data() {}
+
+    static_assert(sizeof(T) <= 64,
+                  "Queue element must fit in a single cache line");
   };
 
   alignas(64) std::atomic<Node *> head_;

--- a/include/MarketEvent.hpp
+++ b/include/MarketEvent.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <type_traits>
 
-struct MarketEvent {
+struct alignas(64) MarketEvent {
   uint64_t eventType;
   char symbol[8];
   uint64_t timestamp;
@@ -15,6 +15,7 @@ struct MarketEvent {
 };
 
 static_assert(sizeof(MarketEvent) == 64, "Struct size mismatch");
-static_assert(alignof(MarketEvent) == 8, "MarketEvent must be 8-byte aligned");
+static_assert(alignof(MarketEvent) == 64,
+              "MarketEvent must be cache-line aligned");
 static_assert(std::is_trivially_copyable_v<MarketEvent>,
               "MarketEvent must be trivially copyable for lock-free queues");

--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -4,6 +4,7 @@
 #include "RiskManager.hpp"
 #include "Strategy.hpp"
 #include <atomic>
+#include <cstring>
 #include <exception>
 #include <functional>
 #include <iostream>
@@ -54,9 +55,10 @@ public:
         continue;
       }
 
-      auto event = static_cast<const MarketEvent *>(payload.data());
+      MarketEvent event{};
+      std::memcpy(&event, payload.data(), sizeof(MarketEvent));
       try {
-        auto order = strategy_->onMarketEvent(*event);
+        auto order = strategy_->onMarketEvent(event);
         if (order && risk_manager_->onNewOrder(*order)) {
           order_callback_(*order);
         }

--- a/include/Order.hpp
+++ b/include/Order.hpp
@@ -9,7 +9,7 @@ enum class OrderType : uint8_t { Market, Limit };
 
 constexpr int64_t SCALING_FACTOR = 10000;
 
-struct Order {
+struct alignas(64) Order {
   uint64_t id;
   char symbol[8];
   int64_t quantity;
@@ -18,7 +18,7 @@ struct Order {
   OrderType type;
 };
 
-static_assert(sizeof(Order) == 40, "Expected size is 40 bytes");
-static_assert(alignof(Order) == 8, "Order must be 8-byte aligned");
+static_assert(sizeof(Order) == 64, "Order must be exactly one cache line");
+static_assert(alignof(Order) == 64, "Order must be cache-line aligned");
 static_assert(std::is_trivially_copyable_v<Order>,
               "Order must be trivially copyable for lock-free queues");

--- a/include/OrderGateway.hpp
+++ b/include/OrderGateway.hpp
@@ -3,16 +3,17 @@
 #include "IRestClient.hpp"
 #include "LockFreeMPSCQueue.hpp"
 #include "Order.hpp"
-#include "PositionManager.hpp"
 #include <atomic>
 #include <memory>
+
+class PositionManager;
 
 class OrderGateway {
 public:
   OrderGateway(std::atomic<bool> &is_running,
-               const std::shared_ptr<LockFreeMPSCQueue<Order>> &order_queue,
+               LockFreeMPSCQueue<Order> *order_queue,
                std::unique_ptr<IRestClient> rest_client,
-               std::shared_ptr<PositionManager> position_manager);
+               PositionManager *position_manager);
 
   void run();
 
@@ -20,8 +21,8 @@ private:
   void executeOrder(const Order &order) const;
 
   std::atomic<bool> &is_running_;
-  std::shared_ptr<LockFreeMPSCQueue<Order>> order_queue_;
+  LockFreeMPSCQueue<Order> *order_queue_;
   std::unique_ptr<IRestClient> rest_client_;
-  std::shared_ptr<PositionManager> position_manager_;
+  PositionManager *position_manager_;
   uint64_t order_id_counter_ = 0;
 };

--- a/include/RiskManager.hpp
+++ b/include/RiskManager.hpp
@@ -1,18 +1,17 @@
 #pragma once
 
 #include "Order.hpp"
-#include "PositionManager.hpp"
-#include <memory>
+
+class PositionManager;
 
 class RiskManager {
 public:
-  explicit RiskManager(
-      const std::shared_ptr<PositionManager> &position_manager);
+  explicit RiskManager(PositionManager *position_manager);
 
   [[nodiscard]] bool onNewOrder(const Order &order);
 
 private:
-  std::shared_ptr<PositionManager> position_manager_;
+  PositionManager *position_manager_;
   const int64_t max_position_per_symbol_ = 1000;
   const double max_order_value_ = 10000.00;
 };

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -42,10 +42,10 @@ private:
   std::atomic<bool> is_running_;
   std::string ipc_address_;
   std::vector<std::string> symbols_;
-  std::shared_ptr<PositionManager> position_manager_;
+  std::unique_ptr<PositionManager> position_manager_;
   std::unique_ptr<RiskManager> risk_manager_;
   zmq::context_t context_{1};
-  std::shared_ptr<LockFreeMPSCQueue<Order>> order_queue_;
+  std::unique_ptr<LockFreeMPSCQueue<Order>> order_queue_;
   std::unique_ptr<OrderGateway> order_gateway_;
   std::thread order_gateway_thread_;
   std::vector<ConsumerThread> consumer_threads_;

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <stdexcept>
 #include <thread>
 
 void pin_thread_to_core(std::thread &t, uint32_t core_id);
@@ -147,7 +148,12 @@ AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
                                        const std::string &api_key,
                                        const std::string &api_secret)
     : position_manager_(position_manager), is_running_(is_running),
-      api_key_(api_key), api_secret_(api_secret) {}
+      api_key_(api_key), api_secret_(api_secret) {
+  if (position_manager_ == nullptr) {
+    throw std::invalid_argument(
+        "AlpacaFillListener: position_manager must not be null");
+  }
+}
 
 AlpacaFillListener::~AlpacaFillListener() { stop(); }
 

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -142,11 +142,11 @@ TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
   return std::monostate{};
 }
 
-AlpacaFillListener::AlpacaFillListener(
-    std::shared_ptr<PositionManager> position_manager,
-    std::atomic<bool> &is_running, const std::string &api_key,
-    const std::string &api_secret)
-    : position_manager_(std::move(position_manager)), is_running_(is_running),
+AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
+                                       std::atomic<bool> &is_running,
+                                       const std::string &api_key,
+                                       const std::string &api_secret)
+    : position_manager_(position_manager), is_running_(is_running),
       api_key_(api_key), api_secret_(api_secret) {}
 
 AlpacaFillListener::~AlpacaFillListener() { stop(); }

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -1,6 +1,7 @@
 #include "OrderGateway.hpp"
 #include "PositionManager.hpp"
 #include <iostream>
+#include <stdexcept>
 
 OrderGateway::OrderGateway(std::atomic<bool> &is_running,
                            LockFreeMPSCQueue<Order> *order_queue,
@@ -8,7 +9,18 @@ OrderGateway::OrderGateway(std::atomic<bool> &is_running,
                            PositionManager *position_manager)
     : is_running_(is_running), order_queue_(order_queue),
       rest_client_(std::move(rest_client)),
-      position_manager_(position_manager) {}
+      position_manager_(position_manager) {
+  if (order_queue_ == nullptr) {
+    throw std::invalid_argument("OrderGateway: order_queue must not be null");
+  }
+  if (rest_client_ == nullptr) {
+    throw std::invalid_argument("OrderGateway: rest_client must not be null");
+  }
+  if (position_manager_ == nullptr) {
+    throw std::invalid_argument(
+        "OrderGateway: position_manager must not be null");
+  }
+}
 
 void OrderGateway::executeOrder(const Order &order) const {
   try {

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -1,14 +1,14 @@
 #include "OrderGateway.hpp"
+#include "PositionManager.hpp"
 #include <iostream>
 
-OrderGateway::OrderGateway(
-    std::atomic<bool> &is_running,
-    const std::shared_ptr<LockFreeMPSCQueue<Order>> &order_queue,
-    std::unique_ptr<IRestClient> rest_client,
-    std::shared_ptr<PositionManager> position_manager)
+OrderGateway::OrderGateway(std::atomic<bool> &is_running,
+                           LockFreeMPSCQueue<Order> *order_queue,
+                           std::unique_ptr<IRestClient> rest_client,
+                           PositionManager *position_manager)
     : is_running_(is_running), order_queue_(order_queue),
       rest_client_(std::move(rest_client)),
-      position_manager_(std::move(position_manager)) {}
+      position_manager_(position_manager) {}
 
 void OrderGateway::executeOrder(const Order &order) const {
   try {

--- a/src/RiskManager.cpp
+++ b/src/RiskManager.cpp
@@ -1,8 +1,8 @@
 #include "RiskManager.hpp"
+#include "PositionManager.hpp"
 #include <cstdlib>
 
-RiskManager::RiskManager(
-    const std::shared_ptr<PositionManager> &position_manager)
+RiskManager::RiskManager(PositionManager *position_manager)
     : position_manager_(position_manager) {
   // TODO: Load parameters from some config.
 }

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -61,14 +61,15 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
                              std::unique_ptr<IRestClient> rest_client)
     : is_running_(true), symbols_(symbols) {
   setup_signal_handler();
-  position_manager_ = std::make_shared<PositionManager>();
+  position_manager_ = std::make_unique<PositionManager>();
   for (const auto &symbol : symbols_) {
     position_manager_->registerSymbol(symbol);
   }
-  risk_manager_ = std::make_unique<RiskManager>(position_manager_);
-  order_queue_ = std::make_shared<LockFreeMPSCQueue<Order>>();
+  risk_manager_ = std::make_unique<RiskManager>(position_manager_.get());
+  order_queue_ = std::make_unique<LockFreeMPSCQueue<Order>>();
   order_gateway_ = std::make_unique<OrderGateway>(
-      is_running_, order_queue_, std::move(rest_client), position_manager_);
+      is_running_, order_queue_.get(), std::move(rest_client),
+      position_manager_.get());
 
   const char *api_key = std::getenv("APCA_API_KEY_ID");
   const char *api_secret = std::getenv("APCA_API_SECRET_KEY");
@@ -77,7 +78,7 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
         "APCA_API_KEY_ID and APCA_API_SECRET_KEY must be set");
   }
   fill_listener_ = std::make_unique<AlpacaFillListener>(
-      position_manager_, is_running_, api_key, api_secret);
+      position_manager_.get(), is_running_, api_key, api_secret);
 
 #ifdef _WIN32
   ipc_address_ = "tcp://127.0.0.1:5555";

--- a/tests/test_error_scenarios.cpp
+++ b/tests/test_error_scenarios.cpp
@@ -1,4 +1,5 @@
 #include "MarketEventConsumer.hpp"
+#include "PositionManager.hpp"
 #include "RiskManager.hpp"
 #include <cstring>
 #include <gtest/gtest.h>
@@ -25,8 +26,8 @@ TEST(MarketEventConsumerErrorTest, HandlesStrategyException) {
   publisher.bind("tcp://127.0.0.1:5556");
 
   std::atomic is_running(true);
-  auto position_manager = std::make_shared<PositionManager>();
-  auto risk_manager = std::make_unique<RiskManager>(position_manager);
+  auto position_manager = std::make_unique<PositionManager>();
+  auto risk_manager = std::make_unique<RiskManager>(position_manager.get());
 
   bool callback_called = false;
   auto callback = [&](const Order &) { callback_called = true; };
@@ -66,8 +67,8 @@ TEST(MarketEventConsumerErrorTest, HandlesNonStdException) {
   publisher.bind("tcp://127.0.0.1:5557");
 
   std::atomic is_running(true);
-  auto position_manager = std::make_shared<PositionManager>();
-  auto risk_manager = std::make_unique<RiskManager>(position_manager);
+  auto position_manager = std::make_unique<PositionManager>();
+  auto risk_manager = std::make_unique<RiskManager>(position_manager.get());
 
   bool callback_called = false;
   auto callback = [&](const Order &) { callback_called = true; };

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -48,6 +48,12 @@ protected:
   std::unique_ptr<AlpacaFillListener> listener_;
 };
 
+TEST(AlpacaFillListenerConstructionTest, ThrowsOnNullPositionManager) {
+  std::atomic<bool> is_running{true};
+  EXPECT_THROW(AlpacaFillListener(nullptr, is_running, "key", "secret"),
+               std::invalid_argument);
+}
+
 struct FillParseParam {
   const char *event_type;
   const char *symbol;

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -11,11 +11,11 @@
 class FillListenerTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    position_manager_ = std::make_shared<PositionManager>();
+    position_manager_ = std::make_unique<PositionManager>();
     position_manager_->registerSymbol("AAPL");
     position_manager_->registerSymbol("GOOGL");
     listener_ = std::make_unique<AlpacaFillListener>(
-        position_manager_, is_running_, "test_key", "test_secret");
+        position_manager_.get(), is_running_, "test_key", "test_secret");
   }
 
   static TradeUpdate parse(const std::string &json_str) {
@@ -43,7 +43,7 @@ protected:
     listener_->onMessage(msg);
   }
 
-  std::shared_ptr<PositionManager> position_manager_;
+  std::unique_ptr<PositionManager> position_manager_;
   std::atomic<bool> is_running_{true};
   std::unique_ptr<AlpacaFillListener> listener_;
 };

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -1,6 +1,7 @@
 #include "MarketEvent.hpp"
 #include "MarketEventConsumer.hpp"
 #include "Order.hpp"
+#include "PositionManager.hpp"
 #include "ThreadGuard.hpp"
 #include <atomic>
 #include <chrono>
@@ -41,12 +42,12 @@ protected:
     std::filesystem::path socket_path = temp_dir / ("test_market_data.sock");
     ipc_address = "ipc:///" + socket_path.string();
 #endif
-    position_manager_ = std::make_shared<PositionManager>();
-    risk_manager_ = std::make_unique<RiskManager>(position_manager_);
+    position_manager_ = std::make_unique<PositionManager>();
+    risk_manager_ = std::make_unique<RiskManager>(position_manager_.get());
   }
 
   std::string ipc_address;
-  std::shared_ptr<PositionManager> position_manager_;
+  std::unique_ptr<PositionManager> position_manager_;
   std::unique_ptr<RiskManager> risk_manager_;
 };
 

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -29,25 +29,24 @@ public:
 
 class OrderGatewayTest : public ::testing::Test {
 protected:
-  std::shared_ptr<PositionManager> position_manager_ =
-      std::make_shared<PositionManager>();
+  PositionManager position_manager_;
 };
 
 TEST_F(OrderGatewayTest, ProcessesOrderAndCallsRestClient) {
   std::atomic is_running(true);
-  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+  LockFreeMPSCQueue<Order> order_queue;
   std::promise<void> promise;
   const auto future = promise.get_future();
 
   auto mock_client = std::make_unique<MockRestClient>(&promise);
-  OrderGateway gateway(is_running, order_queue, std::move(mock_client),
-                       position_manager_);
+  OrderGateway gateway(is_running, &order_queue, std::move(mock_client),
+                       &position_manager_);
 
   ThreadGuard gateway_thread_guard{std::thread(&OrderGateway::run, &gateway)};
 
   Order test_order{};
   test_order.id = 999;
-  order_queue->push(test_order);
+  order_queue.push(test_order);
 
   const auto status = future.wait_for(std::chrono::seconds(2));
   ASSERT_EQ(status, std::future_status::ready);
@@ -57,19 +56,19 @@ TEST_F(OrderGatewayTest, ProcessesOrderAndCallsRestClient) {
 
 TEST_F(OrderGatewayTest, DrainsPendingOrdersWhenStopping) {
   std::atomic is_running(true);
-  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+  LockFreeMPSCQueue<Order> order_queue;
   std::promise<void> promise;
   auto future = promise.get_future();
 
   auto mock_client = std::make_unique<MockRestClient>(&promise);
-  OrderGateway gateway(is_running, order_queue, std::move(mock_client),
-                       position_manager_);
+  OrderGateway gateway(is_running, &order_queue, std::move(mock_client),
+                       &position_manager_);
 
   ThreadGuard gateway_thread_guard{std::thread(&OrderGateway::run, &gateway)};
 
   Order test_order{};
   test_order.id = 1234;
-  order_queue->push(test_order);
+  order_queue.push(test_order);
 
   is_running.store(false);
 
@@ -79,7 +78,7 @@ TEST_F(OrderGatewayTest, DrainsPendingOrdersWhenStopping) {
 
 TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
   std::atomic is_running(true);
-  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+  LockFreeMPSCQueue<Order> order_queue;
 
   std::vector<uint64_t> received_ids;
   std::atomic<int> call_count{0};
@@ -101,15 +100,15 @@ TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
   };
 
   OrderGateway gateway(
-      is_running, order_queue,
+      is_running, &order_queue,
       std::make_unique<CapturingClient>(received_ids, call_count),
-      position_manager_);
+      &position_manager_);
   ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
 
   Order order1{};
   Order order2{};
-  order_queue->push(order1);
-  order_queue->push(order2);
+  order_queue.push(order1);
+  order_queue.push(order2);
 
   while (call_count.load(std::memory_order_acquire) < 2) {
   }
@@ -123,9 +122,9 @@ TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
 
 TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
   std::atomic is_running(false);
-  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+  LockFreeMPSCQueue<Order> order_queue;
 
-  position_manager_->registerSymbol("AAPL");
+  position_manager_.registerSymbol("AAPL");
 
   Order order{};
   order.id = 1;
@@ -133,10 +132,10 @@ TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
   order.side = OrderSide::Buy;
   order.quantity = 100;
 
-  position_manager_->onOrderSent(order);
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 100);
+  position_manager_.onOrderSent(order);
+  EXPECT_EQ(position_manager_.getPendingPosition("AAPL"), 100);
 
-  order_queue->push(order);
+  order_queue.push(order);
 
   class RejectingClient final : public IRestClient {
   public:
@@ -146,11 +145,11 @@ TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
     }
   };
 
-  OrderGateway gateway(is_running, order_queue,
-                       std::make_unique<RejectingClient>(), position_manager_);
+  OrderGateway gateway(is_running, &order_queue,
+                       std::make_unique<RejectingClient>(), &position_manager_);
   gateway.run();
 
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+  EXPECT_EQ(position_manager_.getPendingPosition("AAPL"), 0);
 }
 
 namespace {
@@ -196,20 +195,19 @@ struct MainLoopExceptionParam {
 class GatewayMainLoopExceptionTest
     : public ::testing::TestWithParam<MainLoopExceptionParam> {
 protected:
-  std::shared_ptr<PositionManager> position_manager_ =
-      std::make_shared<PositionManager>();
+  PositionManager position_manager_;
 };
 
 TEST_P(GatewayMainLoopExceptionTest, LogsCorrectError) {
   const auto &[factory, expected_substr] = GetParam();
   std::atomic is_running(true);
-  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+  LockFreeMPSCQueue<Order> order_queue;
   std::promise<void> promise;
   auto future = promise.get_future();
 
   auto client = factory(&promise);
-  OrderGateway gateway(is_running, order_queue, std::move(client),
-                       position_manager_);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_);
 
   std::stringstream captured;
   auto *original = std::cerr.rdbuf(captured.rdbuf());
@@ -218,7 +216,7 @@ TEST_P(GatewayMainLoopExceptionTest, LogsCorrectError) {
 
   Order order{};
   order.id = 1;
-  order_queue->push(order);
+  order_queue.push(order);
 
   const auto status = future.wait_for(std::chrono::seconds(2));
   ASSERT_EQ(status, std::future_status::ready);
@@ -251,22 +249,21 @@ struct ShutdownExceptionParam {
 class GatewayShutdownExceptionTest
     : public ::testing::TestWithParam<ShutdownExceptionParam> {
 protected:
-  std::shared_ptr<PositionManager> position_manager_ =
-      std::make_shared<PositionManager>();
+  PositionManager position_manager_;
 };
 
 TEST_P(GatewayShutdownExceptionTest, LogsCorrectError) {
   const auto &[factory, expected_substr] = GetParam();
   std::atomic is_running(false);
-  const auto order_queue = std::make_shared<LockFreeMPSCQueue<Order>>();
+  LockFreeMPSCQueue<Order> order_queue;
 
   Order order{};
   order.id = 1;
-  order_queue->push(order);
+  order_queue.push(order);
 
   auto client = factory();
-  OrderGateway gateway(is_running, order_queue, std::move(client),
-                       position_manager_);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_);
 
   std::stringstream captured;
   auto *original = std::cerr.rdbuf(captured.rdbuf());

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -32,6 +32,30 @@ protected:
   PositionManager position_manager_;
 };
 
+TEST_F(OrderGatewayTest, ThrowsOnNullOrderQueue) {
+  std::atomic is_running(true);
+  EXPECT_THROW(OrderGateway(is_running, nullptr,
+                            std::make_unique<MockRestClient>(),
+                            &position_manager_),
+               std::invalid_argument);
+}
+
+TEST_F(OrderGatewayTest, ThrowsOnNullRestClient) {
+  std::atomic is_running(true);
+  LockFreeMPSCQueue<Order> order_queue;
+  EXPECT_THROW(
+      OrderGateway(is_running, &order_queue, nullptr, &position_manager_),
+      std::invalid_argument);
+}
+
+TEST_F(OrderGatewayTest, ThrowsOnNullPositionManager) {
+  std::atomic is_running(true);
+  LockFreeMPSCQueue<Order> order_queue;
+  EXPECT_THROW(OrderGateway(is_running, &order_queue,
+                            std::make_unique<MockRestClient>(), nullptr),
+               std::invalid_argument);
+}
+
 TEST_F(OrderGatewayTest, ProcessesOrderAndCallsRestClient) {
   std::atomic is_running(true);
   LockFreeMPSCQueue<Order> order_queue;

--- a/tests/test_risk_manager.cpp
+++ b/tests/test_risk_manager.cpp
@@ -12,11 +12,11 @@ using test_helpers::createOrder;
 class RiskManagerTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    pos_manager_ = std::make_shared<PositionManager>();
-    risk_manager_ = std::make_unique<RiskManager>(pos_manager_);
+    pos_manager_ = std::make_unique<PositionManager>();
+    risk_manager_ = std::make_unique<RiskManager>(pos_manager_.get());
   }
 
-  std::shared_ptr<PositionManager> pos_manager_;
+  std::unique_ptr<PositionManager> pos_manager_;
   std::unique_ptr<RiskManager> risk_manager_;
 };
 


### PR DESCRIPTION
## Summary

- Replace all `shared_ptr<PositionManager>` with raw `PositionManager*` across RiskManager, OrderGateway, and AlpacaFillListener. TradingEngine retains sole ownership via `unique_ptr` and hands raw pointers to dependents. Eliminates atomic ref-count overhead (~10-20ns per copy) on the hot path.
- Replace `shared_ptr<LockFreeMPSCQueue<Order>>` with `unique_ptr` in TradingEngine, raw pointer in OrderGateway.
- Add `alignas(64)` to MarketEvent (already 64 bytes, no padding change) and Order (padded from 40 to 64 bytes) to prevent false sharing between per-symbol consumer threads.
- Add `static_assert(sizeof(T) <= 64)` to `LockFreeMPSCQueue::Node` ensuring queue elements fit in a single cache line.

Closes #32
Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted core ownership and initialization patterns to improve performance and lifecycle safety.
  * Improved data structure alignment for better cache efficiency.

* **Bug Fixes**
  * Added runtime validation for invalid constructor arguments, producing clearer startup errors.

* **Tests**
  * Added and updated tests to cover constructor validation and lifecycle/queue behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->