### PR TITLE
Implement cancel-before-replace in OrderGateway

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -10,11 +10,14 @@ Sources: [Alpaca WebSocket streaming docs][1], [Alpaca trading API docs][2], [ix
 
 ## Thread Model
 
-- Core 0 (housekeeping): OrderGateway, FillListener, OS interrupts, main thread — all cold-path I/O-bound work
-- Core 1 (data path): MarketDataPipeline thread (AlpacaWebSocketSource → AlpacaMsgpackDecoder → ZmqMarketEventSink) —
-  receives market data from Alpaca WebSocket, decodes msgpack via SAX-style visitor, publishes MarketEvent structs via
-  ZMQ
-- Cores 2+ (hot path): per-symbol MarketEventConsumer threads, one per core, pinned at startup
+The hot path is **network-to-network** — from WebSocket market data reception to REST order submission. See
+`low-latency.md` for the full 8-step pipeline definition.
+
+- Core 0 (outer hot path + cold path): OrderGateway (order execution), FillListener (fill processing — cold path), OS
+  interrupts, main thread
+- Core 1 (inner hot path — ingestion): MarketDataPipeline thread (AlpacaWebSocketSource -> AlpacaMsgpackDecoder ->
+  ZmqMarketEventSink) — receives market data, decodes msgpack, publishes MarketEvent structs via ZMQ
+- Cores 2+ (inner hot path — strategy): per-symbol MarketEventConsumer threads, one per core, pinned at startup
 - No thread may block another thread on the hot path
 
 ## Alpaca Integration
@@ -61,10 +64,11 @@ Sources: [Alpaca WebSocket streaming docs][1], [Alpaca trading API docs][2], [ix
 
 ## Component Ownership
 
-- `TradingEngine` owns everything via `std::unique_ptr` / `std::shared_ptr`
+- `TradingEngine` owns everything via `std::unique_ptr`
 - `PositionManager` is shared (read by hot path, written by fill listener) — use TBB `concurrent_hash_map` (current
   approach is correct)
-- `RiskManager` holds `shared_ptr<PositionManager>` for read access
+- `RiskManager` holds raw `PositionManager *` for read access — non-owning, lifetime guaranteed by TradingEngine.
+  `std::shared_ptr` is **banned on the hot path** (10-20ns atomic refcount overhead per access)
 - Order queue is shared between consumer threads (producers) and OrderGateway (consumer)
 
 ## Dependency Direction

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -29,7 +29,8 @@ the **outer hot path** — network I/O is unavoidable but everything up to and a
 - No virtual function dispatch — use templates/CRTP/concepts for compile-time polymorphism (see Static Polymorphism
   section)
 - No `std::shared_ptr` — atomic refcount is 10-20ns per access. Use raw non-owning pointers with documented lifetime.
-- No mutex locks — use atomics, lock-free structures, or `const_accessor` reads
+- No mutex locks — use atomics and lock-free structures. Note: oneTBB `concurrent_hash_map::const_accessor` holds a
+  shared reader lock (blocks writers until released) — acceptable for cold-path reads but not truly lock-free
 - No syscalls (no logging, no I/O, no `std::cout`)
 - No exceptions on the normal path — exceptions add 10-20% overhead. Use error codes or `std::expected`
 - All functions should be `noexcept` where they do not use exceptions internally
@@ -54,7 +55,8 @@ C++23 introduced "deducing this" (explicit object parameters) which modernizes t
 - **Concepts** are preferred over CRTP for constraining template parameters — cleaner syntax, identical runtime
   performance, better error messages
 - **Deducing this** eliminates the need for `static_cast` in CRTP and removes the templated base class requirement
-- **CRTP** remains valid but is considered legacy when C++23 is available
+- **CRTP** remains valid but is considered legacy when full C++23 support is available. Minimum compiler versions for
+  deducing this: GCC 14+, Clang 18+, MSVC 17.2+ (partial). Verify toolchain support before migrating from CRTP.
 
 For this project, use **concepts to constrain** + **templates for injection**:
 
@@ -123,8 +125,8 @@ TLB misses can consume 20% of execution cycles (Meta measurement). For large wor
 - **1GB pages**: For very large datasets. Kernel param: `hugepagesz=1G hugepages=4`
 - **Custom allocator**: Only for `std::vector`, flat hash maps — containers that make few large allocations. Round to
   page boundary.
-- **mimalloc**: Set `MIMALLOC_LARGE_OS_PAGES=1` for automatic huge page usage. Reduced TLB misses from ~19.4M to ~6K in
-  benchmarks.
+- **mimalloc**: Set `MIMALLOC_ALLOW_LARGE_OS_PAGES=1` for automatic huge page usage. Reduced TLB misses from ~19.4M to
+  ~6K in benchmarks.
 
 Source: [rigtorp huge pages guide][6], [HRT huge pages blog][10]
 

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -97,7 +97,7 @@ Sources: [Deducing this for static polymorphism][7], [Concepts vs CRTP][8]
 
 ## Cache Efficiency
 
-- All hot-path structs: `alignas(64)` + `static_assert(sizeof(T))`
+- All hot-path structs: `alignas(64)` + `static_assert(sizeof(T) == expected_size)` + `static_assert(alignof(T) == 64)`
 - Keep related data together — avoid pointer chasing
 - Use fixed-width symbol keys (`char[8]`) not `std::string`
 - Pad between independent atomic variables to avoid false sharing
@@ -167,7 +167,9 @@ For wire formats:
 
 - **SBE (Simple Binary Encoding)**: 13x faster than FlatBuffers (80 msgs/μs vs 5 msgs/μs). Best for HFT but verbose XML
   schemas.
-- **Raw struct casting**: Current approach (64-byte MarketEvent) is correct and fastest — zero overhead. Keep it.
+- **Raw struct casting**: Current approach (64-byte MarketEvent) is correct and fastest for internal same-build IPC —
+  zero overhead. Only safe when producer and consumer share the same compiler, ABI, and endianness (true for our
+  single-process ZMQ pipeline). Not safe across network or cross-build boundaries — use explicit serialization there.
 - **simdjson**: 4x faster than RapidJSON, 25x faster than nlohmann/json. Use for parsing Alpaca REST responses.
   Gigabytes/sec throughput. Zero-copy via on-demand API.
 - **nlohmann/json** (current): Fine for cold path order placement. Replace with simdjson only if REST response parsing

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -56,7 +56,7 @@ C++23 introduced "deducing this" (explicit object parameters) which modernizes t
   performance, better error messages
 - **Deducing this** eliminates the need for `static_cast` in CRTP and removes the templated base class requirement
 - **CRTP** remains valid but is considered legacy when full C++23 support is available. Minimum compiler versions for
-  deducing this: GCC 14+, Clang 18+, MSVC 17.2+ (partial). Verify toolchain support before migrating from CRTP.
+  deducing this: GCC 14+, Clang 18+, MSVC 17.2+ (partial). This project uses Clang 19 in CI, which has full support.
 
 For this project, use **concepts to constrain** + **templates for injection**:
 

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -56,7 +56,7 @@ C++23 introduced "deducing this" (explicit object parameters) which modernizes t
   performance, better error messages
 - **Deducing this** eliminates the need for `static_cast` in CRTP and removes the templated base class requirement
 - **CRTP** remains valid but is considered legacy when full C++23 support is available. Minimum compiler versions for
-  deducing this: GCC 14+, Clang 18+, MSVC 17.2+ (partial). This project uses Clang 19 in CI, which has full support.
+  deducing this: GCC 14+, Clang 19+, MSVC 17.2+ (partial).
 
 For this project, use **concepts to constrain** + **templates for injection**:
 

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -1,84 +1,62 @@
 # Low-Latency Engineering Rules
 
-Sources: [CppCon 2024 David Gross keynote][1], [C++ Design Patterns for
-Low-Latency (arxiv 2309.04259)][2], [Electronic Trading Hub HFT best
-practices][3], [Semi-static conditions paper][4],
+Sources: [CppCon 2024 David Gross keynote][1], [C++ Design Patterns for Low-Latency (arxiv 2309.04259)][2],
+[Electronic Trading Hub HFT best practices][3], [Semi-static conditions paper][4],
 [rigtorp ring buffer optimization][5], [rigtorp huge pages][6]
-
-[1]: https://cppcon.org/2024-keynote-david-gross/
-[2]: https://arxiv.org/abs/2309.04259
-[3]: https://electronictradinghub.com/best-practices-on-hft-low-latency-software/
-[4]: https://arxiv.org/abs/2308.14185
-[5]: https://rigtorp.se/ringbuffer/
-[6]: https://rigtorp.se/hugepages/
 
 ## Hot Path vs Cold Path
 
-The hot path is **network-to-network**: from WebSocket market data
-ingestion through to REST order submission. This spans the full
-latency-critical pipeline:
+The hot path is **network-to-network**: from WebSocket market data ingestion through to REST order submission. This
+spans the full latency-critical pipeline:
 
 1. **Ingestion**: AlpacaWebSocketSource receives market data
-2. **Decode**: AlpacaMsgpackDecoder parses msgpack to MarketEvent
-3. **Transport**: ZmqMarketEventSink publishes via ZMQ
-4. **Consume**: MarketEventConsumer receives from ZMQ
-5. **Strategy**: generates order signal
-6. **Risk**: RiskManager validates
-7. **Queue**: order pushed to MPSC queue
-8. **Execute**: OrderGateway dequeues and sends REST order
+1. **Decode**: AlpacaMsgpackDecoder parses msgpack to MarketEvent
+1. **Transport**: ZmqMarketEventSink publishes via ZMQ
+1. **Consume**: MarketEventConsumer receives from ZMQ
+1. **Strategy**: generates order signal
+1. **Risk**: RiskManager validates
+1. **Queue**: order pushed to MPSC queue
+1. **Execute**: OrderGateway dequeues and sends REST order
 
-Steps 1-7 are the **inner hot path** — zero-allocation,
-zero-syscall, exception-free. Step 8 (OrderGateway REST call)
-is the **outer hot path** — network I/O is unavoidable but
-everything up to and after the syscall must be optimized
+Steps 1-7 are the **inner hot path** — zero-allocation, zero-syscall, exception-free. Step 8 (OrderGateway REST call) is
+the **outer hot path** — network I/O is unavoidable but everything up to and after the syscall must be optimized
 (pre-built payloads, connection reuse, TCP_NODELAY).
 
 **Inner hot path rules** (steps 1-7):
-- No heap allocation (no `new`, no `std::vector::push_back` that
-  may reallocate, no `std::string` construction). Pre-allocate
-  all containers at startup.
-- No virtual function dispatch — use templates/CRTP/concepts for
-  compile-time polymorphism (see Static Polymorphism section)
-- No `std::shared_ptr` — atomic refcount is 10-20ns per access.
-  Use raw non-owning pointers with documented lifetime.
-- No mutex locks — use atomics, lock-free structures, or
-  `const_accessor` reads
+
+- No heap allocation (no `new`, no `std::vector::push_back` that may reallocate, no `std::string` construction).
+  Pre-allocate all containers at startup.
+- No virtual function dispatch — use templates/CRTP/concepts for compile-time polymorphism (see Static Polymorphism
+  section)
+- No `std::shared_ptr` — atomic refcount is 10-20ns per access. Use raw non-owning pointers with documented lifetime.
+- No mutex locks — use atomics, lock-free structures, or `const_accessor` reads
 - No syscalls (no logging, no I/O, no `std::cout`)
-- No exceptions on the normal path — exceptions add 10-20%
-  overhead. Use error codes or `std::expected`
-- All functions should be `noexcept` where they do not use
-  exceptions internally
-- No `std::string`, `std::map`, `std::unordered_map` — use
-  fixed-width buffers and flat containers
-- Accept code duplication over abstraction when latency is
-  critical
+- No exceptions on the normal path — exceptions add 10-20% overhead. Use error codes or `std::expected`
+- All functions should be `noexcept` where they do not use exceptions internally
+- No `std::string`, `std::map`, `std::unordered_map` — use fixed-width buffers and flat containers
+- Accept code duplication over abstraction when latency is critical
 
 **Outer hot path rules** (step 8 — OrderGateway):
-- Connection reuse: `cpr::Session` or persistent connections,
-  never per-request TCP+TLS setup
+
+- Connection reuse: `cpr::Session` or persistent connections, never per-request TCP+TLS setup
 - `TCP_NODELAY` always, `TCP_QUICKACK` on Linux
 - Pre-built JSON payloads where possible (snprintf templates)
 - Rate limit tracking (`X-Ratelimit-Remaining` header)
 - Minimize allocations in order serialization
 
-**Cold path** (fill processing, logging, startup/shutdown,
-reconciliation): normal C++ OK.
+**Cold path** (fill processing, logging, startup/shutdown, reconciliation): normal C++ OK.
 
 ## Static Polymorphism — CRTP vs Concepts vs Deducing This
 
-C++23 introduced "deducing this" (explicit object parameters) which
-modernizes the CRTP pattern. Current best practice (2025):
+C++23 introduced "deducing this" (explicit object parameters) which modernizes the CRTP pattern. Current best practice
+(2025):
 
-- **Concepts** are preferred over CRTP for constraining template
-  parameters — cleaner syntax, identical runtime performance, better
-  error messages
-- **Deducing this** eliminates the need for `static_cast` in CRTP and
-  removes the templated base class requirement
-- **CRTP** remains valid but is considered legacy when C++23 is
-  available
+- **Concepts** are preferred over CRTP for constraining template parameters — cleaner syntax, identical runtime
+  performance, better error messages
+- **Deducing this** eliminates the need for `static_cast` in CRTP and removes the templated base class requirement
+- **CRTP** remains valid but is considered legacy when C++23 is available
 
-For this project, use **concepts to constrain** + **templates for
-injection**:
+For this project, use **concepts to constrain** + **templates for injection**:
 
 ```cpp
 template <typename T>
@@ -92,35 +70,28 @@ class MarketEventConsumer { ... };
 
 Never add `virtual` to any class used on the hot path.
 
-Sources: [Deducing this for static polymorphism][7],
-[Concepts vs CRTP][8]
-
-[7]: https://medium.com/@rogerbooth/using-c-23-deducing-this-to-implement-static-polymorphism-11dd72e124a4
-[8]: https://www.devgem.io/posts/exploring-c-23-crtp-and-deducing-this-for-static-polymorphism
+Sources: [Deducing this for static polymorphism][7], [Concepts vs CRTP][8]
 
 ## Lock-Free Data Structures
 
 **SPSC Queue** (single-producer single-consumer):
+
 - Use [rigtorp/SPSCQueue][9] pattern: bounded ring buffer, wait-free
-- Cache the opposing index locally — only refresh when buffer
-  appears full/empty. This reduces cache coherency misses 20x
-  (from ~300M to ~15M for 100M operations)
+- Cache the opposing index locally — only refresh when buffer appears full/empty. This reduces cache coherency misses
+  20x (from ~300M to ~15M for 100M operations)
 - Align head/tail indices to separate cache lines: `alignas(64)`
-- Use `memory_order_acquire` for reading opposing index,
-  `memory_order_release` for updating own index,
+- Use `memory_order_acquire` for reading opposing index, `memory_order_release` for updating own index,
   `memory_order_relaxed` for local index reads
 
 **MPSC Queue** (multi-producer single-consumer):
-- Current implementation (Vyukov-style) is correct but allocates
-  per-push (`new Node`). For hot path, prefer bounded ring buffer
-  with atomic CAS on head index
+
+- Current implementation (Vyukov-style) is correct but allocates per-push (`new Node`). For hot path, prefer bounded
+  ring buffer with atomic CAS on head index
 
 **Disruptor pattern** (LMAX):
-- For highest throughput: sequence barriers, cache-line padded
-  sequence counters, multiple wait strategies
-- Consider when throughput > 10M msgs/sec is needed
 
-[9]: https://github.com/rigtorp/SPSCQueue
+- For highest throughput: sequence barriers, cache-line padded sequence counters, multiple wait strategies
+- Consider when throughput > 10M msgs/sec is needed
 
 ## Cache Efficiency
 
@@ -128,121 +99,100 @@ Sources: [Deducing this for static polymorphism][7],
 - Keep related data together — avoid pointer chasing
 - Use fixed-width symbol keys (`char[8]`) not `std::string`
 - Pad between independent atomic variables to avoid false sharing
-- Use `std::hardware_destructive_interference_size` (C++17) when
-  available, fall back to 64
+- Use `std::hardware_destructive_interference_size` (C++17) when available, fall back to 64
 - Exploit L1 cache (5ns) vs main memory (100ns) — design for L1
 
 ## Branch Prediction
 
 - Use `[[likely]]` / `[[unlikely]]` (C++20) for cold error paths
-- **Semi-static conditions**: For branches that change rarely at
-  runtime (e.g., risk limit changes, trading state transitions),
-  consider the semi-static branch technique — dynamically rewriting
-  branch instructions. This outperforms `[[likely]]` hints for
-  branches where the "hot" path is executed infrequently but must
-  be fast when it is. [Paper: arxiv 2308.14185][4]
+- **Semi-static conditions**: For branches that change rarely at runtime (e.g., risk limit changes, trading state
+  transitions), consider the semi-static branch technique — dynamically rewriting branch instructions. This outperforms
+  `[[likely]]` hints for branches where the "hot" path is executed infrequently but must be fast when it is.
+  [Paper: arxiv 2308.14185][4]
 - Use `if constexpr` for compile-time type-dependent branching
-- Avoid data-dependent branches — prefer branchless arithmetic
-  (conditional moves) where possible
+- Avoid data-dependent branches — prefer branchless arithmetic (conditional moves) where possible
 
 ## Huge Pages & TLB Optimization
 
-TLB misses can consume 20% of execution cycles (Meta measurement).
-For large working sets:
+TLB misses can consume 20% of execution cycles (Meta measurement). For large working sets:
 
-- **Transparent Huge Pages (THP)**: Use `madvise(ptr, n,
-  MADV_HUGEPAGE)` after aligned allocation. Set system-wide:
+- **Transparent Huge Pages (THP)**: Use `madvise(ptr, n, MADV_HUGEPAGE)` after aligned allocation. Set system-wide:
   `echo madvise > /sys/kernel/mm/transparent_hugepage/enabled`
-- **Explicit huge pages**: `mmap()` with `MAP_HUGETLB` for
-  guaranteed 2MB pages. Reserve with:
+- **Explicit huge pages**: `mmap()` with `MAP_HUGETLB` for guaranteed 2MB pages. Reserve with:
   `echo N > /proc/sys/vm/nr_hugepages`
-- **1GB pages**: For very large datasets. Kernel param:
-  `hugepagesz=1G hugepages=4`
-- **Custom allocator**: Only for `std::vector`, flat hash maps —
-  containers that make few large allocations. Round to page boundary.
-- **mimalloc**: Set `MIMALLOC_LARGE_OS_PAGES=1` for automatic huge
-  page usage. Reduced TLB misses from ~19.4M to ~6K in benchmarks.
+- **1GB pages**: For very large datasets. Kernel param: `hugepagesz=1G hugepages=4`
+- **Custom allocator**: Only for `std::vector`, flat hash maps — containers that make few large allocations. Round to
+  page boundary.
+- **mimalloc**: Set `MIMALLOC_LARGE_OS_PAGES=1` for automatic huge page usage. Reduced TLB misses from ~19.4M to ~6K in
+  benchmarks.
 
-Source: [rigtorp huge pages guide][6],
-[HRT huge pages blog][10]
-
-[10]: https://www.hudsonrivertrading.com/hrtbeat/low-latency-optimization-part-1/
+Source: [rigtorp huge pages guide][6], [HRT huge pages blog][10]
 
 ## Kernel & OS Tuning (Linux)
 
 For production deployment:
 
-- **CPU isolation**: `isolcpus=2-7 nohz_full=2-7 rcu_nocbs=2-7`
-  in kernel cmdline — removes scheduler ticks and RCU callbacks
-  from trading cores
+- **CPU isolation**: `isolcpus=2-7 nohz_full=2-7 rcu_nocbs=2-7` in kernel cmdline — removes scheduler ticks and RCU
+  callbacks from trading cores
 - **IRQ affinity**: Pin NIC interrupts to core 0 (non-trading core)
 - **Kernel bypass** (future):
-  - **DPDK**: Highest performance, polls NIC directly, bypasses
-    kernel entirely. Best for dedicated trading boxes.
-  - **AF_XDP**: Works within kernel via eBPF, easier deployment,
-    good for mixed workloads.
-  - **io_uring**: General-purpose async I/O, not true kernel bypass
-    but reduces syscall overhead significantly.
-  - **Solarflare OpenOnload**: Drop-in kernel bypass for standard
-    socket apps. Common in HFT.
-- **TCP tuning**: `TCP_NODELAY` always, `TCP_QUICKACK`,
-  `SO_BUSY_POLL` for polling-mode socket reads
+  - **DPDK**: Highest performance, polls NIC directly, bypasses kernel entirely. Best for dedicated trading boxes.
+  - **AF_XDP**: Works within kernel via eBPF, easier deployment, good for mixed workloads.
+  - **io_uring**: General-purpose async I/O, not true kernel bypass but reduces syscall overhead significantly.
+  - **Solarflare OpenOnload**: Drop-in kernel bypass for standard socket apps. Common in HFT.
+- **TCP tuning**: `TCP_NODELAY` always, `TCP_QUICKACK`, `SO_BUSY_POLL` for polling-mode socket reads
 
-Source: [QuantVPS kernel bypass guide][11],
-[Databento kernel bypass guide][12]
-
-[11]: https://www.quantvps.com/blog/kernel-bypass-in-hft
-[12]: https://databento.com/microstructure/kernel-bypass
+Source: [QuantVPS kernel bypass guide][11], [Databento kernel bypass guide][12]
 
 ## Zero-Copy Architecture (target)
 
-The long-term goal is a zero-copy pipeline where data flows
-from network to strategy without any memcpy or allocation:
+The long-term goal is a zero-copy pipeline where data flows from network to strategy without any memcpy or allocation:
 
-- **Ingestion**: Receive directly into aligned shared-memory
-  ring buffer (io_uring or mmap'd region)
-- **Decode**: SAX-style in-place parsing — write fields
-  directly into pre-allocated MarketEvent slots
-- **Transport**: Replace ZMQ IPC with shared-memory SPSC ring
-  buffer — consumer reads the same memory the publisher wrote
-- **Order serialization**: Pre-built JSON templates with
-  `snprintf` into fixed buffers — no `std::string`, no
+- **Ingestion**: Receive directly into aligned shared-memory ring buffer (io_uring or mmap'd region)
+- **Decode**: SAX-style in-place parsing — write fields directly into pre-allocated MarketEvent slots
+- **Transport**: Replace ZMQ IPC with shared-memory SPSC ring buffer — consumer reads the same memory the publisher
+  wrote
+- **Order serialization**: Pre-built JSON templates with `snprintf` into fixed buffers — no `std::string`, no
   nlohmann/json on the hot path
-- **REST submission**: `writev()` / scatter-gather I/O to send
-  pre-built buffers without concatenation
+- **REST submission**: `writev()` / scatter-gather I/O to send pre-built buffers without concatenation
 
-When writing new code, prefer designs that move toward
-zero-copy: use `std::span` / `std::string_view` for non-owning
-references, write into caller-provided buffers, avoid returning
-`std::string` from hot-path functions.
+When writing new code, prefer designs that move toward zero-copy: use `std::span` / `std::string_view` for non-owning
+references, write into caller-provided buffers, avoid returning `std::string` from hot-path functions.
 
 ## Serialization
 
 For wire formats:
-- **SBE (Simple Binary Encoding)**: 13x faster than FlatBuffers
-  (80 msgs/μs vs 5 msgs/μs). Best for HFT but verbose XML schemas.
-- **Raw struct casting**: Current approach (64-byte MarketEvent) is
-  correct and fastest — zero overhead. Keep it.
-- **simdjson**: 4x faster than RapidJSON, 25x faster than
-  nlohmann/json. Use for parsing Alpaca REST responses.
+
+- **SBE (Simple Binary Encoding)**: 13x faster than FlatBuffers (80 msgs/μs vs 5 msgs/μs). Best for HFT but verbose XML
+  schemas.
+- **Raw struct casting**: Current approach (64-byte MarketEvent) is correct and fastest — zero overhead. Keep it.
+- **simdjson**: 4x faster than RapidJSON, 25x faster than nlohmann/json. Use for parsing Alpaca REST responses.
   Gigabytes/sec throughput. Zero-copy via on-demand API.
-- **nlohmann/json** (current): Fine for cold path order placement.
-  Replace with simdjson only if REST response parsing is on hot path.
+- **nlohmann/json** (current): Fine for cold path order placement. Replace with simdjson only if REST response parsing
+  is on hot path.
 
-Source: [simdjson.org][13],
-[SBE vs FlatBuffers benchmark][14]
-
-[13]: https://simdjson.org/
-[14]: https://deeperic.wordpress.com/2024/10/27/performance-comparison-of-data-serialization-formats/
+Source: [simdjson.org][13], [SBE vs FlatBuffers benchmark][14]
 
 ## Measurement
 
 - Every optimization must be measured before and after
 - Use `std::chrono::steady_clock` or `rdtsc` for latency
-- The `arrivedAt` field in MarketEvent exists for end-to-end latency
-  tracking — use it
+- The `arrivedAt` field in MarketEvent exists for end-to-end latency tracking — use it
 - Report latency as: p50, p99, p99.9
-- Monitor with `perf stat` — focus on: dTLB-load-misses,
-  L1-dcache-load-misses, branch-misses, context-switches
-- Cache warming and `constexpr` showed "most significant gains in
-  latency reduction" per [arxiv 2309.04259][2]
+- Monitor with `perf stat` — focus on: dTLB-load-misses, L1-dcache-load-misses, branch-misses, context-switches
+- Cache warming and `constexpr` showed "most significant gains in latency reduction" per [arxiv 2309.04259][2]
+
+[1]: https://cppcon.org/2024-keynote-david-gross/
+[2]: https://arxiv.org/abs/2309.04259
+[3]: https://electronictradinghub.com/best-practices-on-hft-low-latency-software/
+[4]: https://arxiv.org/abs/2308.14185
+[5]: https://rigtorp.se/ringbuffer/
+[6]: https://rigtorp.se/hugepages/
+[7]: https://medium.com/@rogerbooth/using-c-23-deducing-this-to-implement-static-polymorphism-11dd72e124a4
+[8]: https://www.devgem.io/posts/exploring-c-23-crtp-and-deducing-this-for-static-polymorphism
+[9]: https://github.com/rigtorp/SPSCQueue
+[10]: https://www.hudsonrivertrading.com/hrtbeat/low-latency-optimization-part-1/
+[11]: https://www.quantvps.com/blog/kernel-bypass-in-hft
+[12]: https://databento.com/microstructure/kernel-bypass
+[13]: https://simdjson.org/
+[14]: https://deeperic.wordpress.com/2024/10/27/performance-comparison-of-data-serialization-formats/

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -1,0 +1,248 @@
+# Low-Latency Engineering Rules
+
+Sources: [CppCon 2024 David Gross keynote][1], [C++ Design Patterns for
+Low-Latency (arxiv 2309.04259)][2], [Electronic Trading Hub HFT best
+practices][3], [Semi-static conditions paper][4],
+[rigtorp ring buffer optimization][5], [rigtorp huge pages][6]
+
+[1]: https://cppcon.org/2024-keynote-david-gross/
+[2]: https://arxiv.org/abs/2309.04259
+[3]: https://electronictradinghub.com/best-practices-on-hft-low-latency-software/
+[4]: https://arxiv.org/abs/2308.14185
+[5]: https://rigtorp.se/ringbuffer/
+[6]: https://rigtorp.se/hugepages/
+
+## Hot Path vs Cold Path
+
+The hot path is **network-to-network**: from WebSocket market data
+ingestion through to REST order submission. This spans the full
+latency-critical pipeline:
+
+1. **Ingestion**: AlpacaWebSocketSource receives market data
+2. **Decode**: AlpacaMsgpackDecoder parses msgpack to MarketEvent
+3. **Transport**: ZmqMarketEventSink publishes via ZMQ
+4. **Consume**: MarketEventConsumer receives from ZMQ
+5. **Strategy**: generates order signal
+6. **Risk**: RiskManager validates
+7. **Queue**: order pushed to MPSC queue
+8. **Execute**: OrderGateway dequeues and sends REST order
+
+Steps 1-7 are the **inner hot path** — zero-allocation,
+zero-syscall, exception-free. Step 8 (OrderGateway REST call)
+is the **outer hot path** — network I/O is unavoidable but
+everything up to and after the syscall must be optimized
+(pre-built payloads, connection reuse, TCP_NODELAY).
+
+**Inner hot path rules** (steps 1-7):
+- No heap allocation (no `new`, no `std::vector::push_back` that
+  may reallocate, no `std::string` construction). Pre-allocate
+  all containers at startup.
+- No virtual function dispatch — use templates/CRTP/concepts for
+  compile-time polymorphism (see Static Polymorphism section)
+- No `std::shared_ptr` — atomic refcount is 10-20ns per access.
+  Use raw non-owning pointers with documented lifetime.
+- No mutex locks — use atomics, lock-free structures, or
+  `const_accessor` reads
+- No syscalls (no logging, no I/O, no `std::cout`)
+- No exceptions on the normal path — exceptions add 10-20%
+  overhead. Use error codes or `std::expected`
+- All functions should be `noexcept` where they do not use
+  exceptions internally
+- No `std::string`, `std::map`, `std::unordered_map` — use
+  fixed-width buffers and flat containers
+- Accept code duplication over abstraction when latency is
+  critical
+
+**Outer hot path rules** (step 8 — OrderGateway):
+- Connection reuse: `cpr::Session` or persistent connections,
+  never per-request TCP+TLS setup
+- `TCP_NODELAY` always, `TCP_QUICKACK` on Linux
+- Pre-built JSON payloads where possible (snprintf templates)
+- Rate limit tracking (`X-Ratelimit-Remaining` header)
+- Minimize allocations in order serialization
+
+**Cold path** (fill processing, logging, startup/shutdown,
+reconciliation): normal C++ OK.
+
+## Static Polymorphism — CRTP vs Concepts vs Deducing This
+
+C++23 introduced "deducing this" (explicit object parameters) which
+modernizes the CRTP pattern. Current best practice (2025):
+
+- **Concepts** are preferred over CRTP for constraining template
+  parameters — cleaner syntax, identical runtime performance, better
+  error messages
+- **Deducing this** eliminates the need for `static_cast` in CRTP and
+  removes the templated base class requirement
+- **CRTP** remains valid but is considered legacy when C++23 is
+  available
+
+For this project, use **concepts to constrain** + **templates for
+injection**:
+
+```cpp
+template <typename T>
+concept StrategyLike = requires(T t, const MarketEvent& e) {
+    { t.onMarketEvent(e) } -> std::same_as<std::vector<Order>>;
+};
+
+template <StrategyLike StrategyType>
+class MarketEventConsumer { ... };
+```
+
+Never add `virtual` to any class used on the hot path.
+
+Sources: [Deducing this for static polymorphism][7],
+[Concepts vs CRTP][8]
+
+[7]: https://medium.com/@rogerbooth/using-c-23-deducing-this-to-implement-static-polymorphism-11dd72e124a4
+[8]: https://www.devgem.io/posts/exploring-c-23-crtp-and-deducing-this-for-static-polymorphism
+
+## Lock-Free Data Structures
+
+**SPSC Queue** (single-producer single-consumer):
+- Use [rigtorp/SPSCQueue][9] pattern: bounded ring buffer, wait-free
+- Cache the opposing index locally — only refresh when buffer
+  appears full/empty. This reduces cache coherency misses 20x
+  (from ~300M to ~15M for 100M operations)
+- Align head/tail indices to separate cache lines: `alignas(64)`
+- Use `memory_order_acquire` for reading opposing index,
+  `memory_order_release` for updating own index,
+  `memory_order_relaxed` for local index reads
+
+**MPSC Queue** (multi-producer single-consumer):
+- Current implementation (Vyukov-style) is correct but allocates
+  per-push (`new Node`). For hot path, prefer bounded ring buffer
+  with atomic CAS on head index
+
+**Disruptor pattern** (LMAX):
+- For highest throughput: sequence barriers, cache-line padded
+  sequence counters, multiple wait strategies
+- Consider when throughput > 10M msgs/sec is needed
+
+[9]: https://github.com/rigtorp/SPSCQueue
+
+## Cache Efficiency
+
+- All hot-path structs: `alignas(64)` + `static_assert(sizeof(T))`
+- Keep related data together — avoid pointer chasing
+- Use fixed-width symbol keys (`char[8]`) not `std::string`
+- Pad between independent atomic variables to avoid false sharing
+- Use `std::hardware_destructive_interference_size` (C++17) when
+  available, fall back to 64
+- Exploit L1 cache (5ns) vs main memory (100ns) — design for L1
+
+## Branch Prediction
+
+- Use `[[likely]]` / `[[unlikely]]` (C++20) for cold error paths
+- **Semi-static conditions**: For branches that change rarely at
+  runtime (e.g., risk limit changes, trading state transitions),
+  consider the semi-static branch technique — dynamically rewriting
+  branch instructions. This outperforms `[[likely]]` hints for
+  branches where the "hot" path is executed infrequently but must
+  be fast when it is. [Paper: arxiv 2308.14185][4]
+- Use `if constexpr` for compile-time type-dependent branching
+- Avoid data-dependent branches — prefer branchless arithmetic
+  (conditional moves) where possible
+
+## Huge Pages & TLB Optimization
+
+TLB misses can consume 20% of execution cycles (Meta measurement).
+For large working sets:
+
+- **Transparent Huge Pages (THP)**: Use `madvise(ptr, n,
+  MADV_HUGEPAGE)` after aligned allocation. Set system-wide:
+  `echo madvise > /sys/kernel/mm/transparent_hugepage/enabled`
+- **Explicit huge pages**: `mmap()` with `MAP_HUGETLB` for
+  guaranteed 2MB pages. Reserve with:
+  `echo N > /proc/sys/vm/nr_hugepages`
+- **1GB pages**: For very large datasets. Kernel param:
+  `hugepagesz=1G hugepages=4`
+- **Custom allocator**: Only for `std::vector`, flat hash maps —
+  containers that make few large allocations. Round to page boundary.
+- **mimalloc**: Set `MIMALLOC_LARGE_OS_PAGES=1` for automatic huge
+  page usage. Reduced TLB misses from ~19.4M to ~6K in benchmarks.
+
+Source: [rigtorp huge pages guide][6],
+[HRT huge pages blog][10]
+
+[10]: https://www.hudsonrivertrading.com/hrtbeat/low-latency-optimization-part-1/
+
+## Kernel & OS Tuning (Linux)
+
+For production deployment:
+
+- **CPU isolation**: `isolcpus=2-7 nohz_full=2-7 rcu_nocbs=2-7`
+  in kernel cmdline — removes scheduler ticks and RCU callbacks
+  from trading cores
+- **IRQ affinity**: Pin NIC interrupts to core 0 (non-trading core)
+- **Kernel bypass** (future):
+  - **DPDK**: Highest performance, polls NIC directly, bypasses
+    kernel entirely. Best for dedicated trading boxes.
+  - **AF_XDP**: Works within kernel via eBPF, easier deployment,
+    good for mixed workloads.
+  - **io_uring**: General-purpose async I/O, not true kernel bypass
+    but reduces syscall overhead significantly.
+  - **Solarflare OpenOnload**: Drop-in kernel bypass for standard
+    socket apps. Common in HFT.
+- **TCP tuning**: `TCP_NODELAY` always, `TCP_QUICKACK`,
+  `SO_BUSY_POLL` for polling-mode socket reads
+
+Source: [QuantVPS kernel bypass guide][11],
+[Databento kernel bypass guide][12]
+
+[11]: https://www.quantvps.com/blog/kernel-bypass-in-hft
+[12]: https://databento.com/microstructure/kernel-bypass
+
+## Zero-Copy Architecture (target)
+
+The long-term goal is a zero-copy pipeline where data flows
+from network to strategy without any memcpy or allocation:
+
+- **Ingestion**: Receive directly into aligned shared-memory
+  ring buffer (io_uring or mmap'd region)
+- **Decode**: SAX-style in-place parsing — write fields
+  directly into pre-allocated MarketEvent slots
+- **Transport**: Replace ZMQ IPC with shared-memory SPSC ring
+  buffer — consumer reads the same memory the publisher wrote
+- **Order serialization**: Pre-built JSON templates with
+  `snprintf` into fixed buffers — no `std::string`, no
+  nlohmann/json on the hot path
+- **REST submission**: `writev()` / scatter-gather I/O to send
+  pre-built buffers without concatenation
+
+When writing new code, prefer designs that move toward
+zero-copy: use `std::span` / `std::string_view` for non-owning
+references, write into caller-provided buffers, avoid returning
+`std::string` from hot-path functions.
+
+## Serialization
+
+For wire formats:
+- **SBE (Simple Binary Encoding)**: 13x faster than FlatBuffers
+  (80 msgs/μs vs 5 msgs/μs). Best for HFT but verbose XML schemas.
+- **Raw struct casting**: Current approach (64-byte MarketEvent) is
+  correct and fastest — zero overhead. Keep it.
+- **simdjson**: 4x faster than RapidJSON, 25x faster than
+  nlohmann/json. Use for parsing Alpaca REST responses.
+  Gigabytes/sec throughput. Zero-copy via on-demand API.
+- **nlohmann/json** (current): Fine for cold path order placement.
+  Replace with simdjson only if REST response parsing is on hot path.
+
+Source: [simdjson.org][13],
+[SBE vs FlatBuffers benchmark][14]
+
+[13]: https://simdjson.org/
+[14]: https://deeperic.wordpress.com/2024/10/27/performance-comparison-of-data-serialization-formats/
+
+## Measurement
+
+- Every optimization must be measured before and after
+- Use `std::chrono::steady_clock` or `rdtsc` for latency
+- The `arrivedAt` field in MarketEvent exists for end-to-end latency
+  tracking — use it
+- Report latency as: p50, p99, p99.9
+- Monitor with `perf stat` — focus on: dTLB-load-misses,
+  L1-dcache-load-misses, branch-misses, context-switches
+- Cache warming and `constexpr` showed "most significant gains in
+  latency reduction" per [arxiv 2309.04259][2]

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -30,7 +30,8 @@ the **outer hot path** — network I/O is unavoidable but everything up to and a
   section)
 - No `std::shared_ptr` — atomic refcount is 10-20ns per access. Use raw non-owning pointers with documented lifetime.
 - No mutex locks — use atomics and lock-free structures. Note: oneTBB `concurrent_hash_map::const_accessor` holds a
-  shared reader lock (blocks writers until released) — acceptable for cold-path reads but not truly lock-free
+  shared reader lock (blocks writers until released) — not truly lock-free. Acceptable on the outer hot path where
+  network I/O dominates, but avoid on the inner hot path
 - No syscalls (no logging, no I/O, no `std::cout`)
 - No exceptions on the normal path — exceptions add 10-20% overhead. Use error codes or `std::expected`
 - All functions should be `noexcept` where they do not use exceptions internally

--- a/.claude/rules/low-latency.md
+++ b/.claude/rules/low-latency.md
@@ -30,8 +30,7 @@ the **outer hot path** — network I/O is unavoidable but everything up to and a
   section)
 - No `std::shared_ptr` — atomic refcount is 10-20ns per access. Use raw non-owning pointers with documented lifetime.
 - No mutex locks — use atomics and lock-free structures. Note: oneTBB `concurrent_hash_map::const_accessor` holds a
-  shared reader lock (blocks writers until released) — not truly lock-free. Acceptable on the outer hot path where
-  network I/O dominates, but avoid on the inner hot path
+  shared reader lock (blocks writers until released) — not truly lock-free, do not use on the hot path
 - No syscalls (no logging, no I/O, no `std::cout`)
 - No exceptions on the normal path — exceptions add 10-20% overhead. Use error codes or `std::expected`
 - All functions should be `noexcept` where they do not use exceptions internally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,16 +27,19 @@ cd build && ctest --output-on-failure
 Every code change must respect the hot path / cold path boundary. Before writing any C++ code, check
 `.claude/rules/low-latency.md`.
 
+The hot path is **network-to-network**: WebSocket market data ingestion through to REST order submission.
+
 Key non-negotiables:
 
-- **No virtual dispatch on the hot path** — use templates/CRTP
+- **No virtual dispatch on the hot path** — templates/CRTP
 - **No heap allocation on the hot path** — pre-allocate at startup
-- **No mutex on the hot path** — use atomics and lock-free structures
-- **No exceptions on the hot path** — use error codes
+- **No `std::shared_ptr` on the hot path** — atomic refcount overhead. Use raw non-owning pointers.
+- **No mutex on the hot path** — atomics and lock-free structures
+- **No exceptions on the hot path** — use error codes, mark functions `noexcept`
 - **Cache-line align** all hot-path structs: `alignas(64)`, `static_assert(sizeof(T) == expected)`
 - **Measure before/after** every optimization
 
-When unsure if something is hot path: if it runs between ZMQ recv and order_queue push, it's hot path.
+When unsure if something is hot path: if it runs between WebSocket recv and REST order send, it's hot path.
 
 ## C++ Conventions
 

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -16,9 +16,10 @@ struct FillEvent {
   OrderSide side;
   int64_t quantity;
   double price;
+  char alpaca_order_id[48];
 };
 
-static_assert(sizeof(FillEvent) == 32, "FillEvent must be 32 bytes");
+static_assert(sizeof(FillEvent) == 80, "FillEvent must be 80 bytes");
 static_assert(alignof(FillEvent) == 8, "FillEvent must be 8-byte aligned");
 static_assert(std::is_trivially_copyable_v<FillEvent>,
               "FillEvent must be trivially copyable");
@@ -27,9 +28,10 @@ struct CancelEvent {
   char symbol[8];
   OrderSide side;
   int64_t quantity;
+  char alpaca_order_id[48];
 };
 
-static_assert(sizeof(CancelEvent) == 24, "CancelEvent must be 24 bytes");
+static_assert(sizeof(CancelEvent) == 72, "CancelEvent must be 72 bytes");
 static_assert(alignof(CancelEvent) == 8, "CancelEvent must be 8-byte aligned");
 static_assert(std::is_trivially_copyable_v<CancelEvent>,
               "CancelEvent must be trivially copyable");

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -40,13 +40,17 @@ using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 
 [[nodiscard]] TradeUpdate parseTradingUpdate(const nlohmann::json &parsed);
 
+class PendingOrderTracker;
+
 class AlpacaFillListener : public IFillListener {
   friend class FillListenerTest;
+  friend class FillListenerTrackerTest;
 
 public:
   AlpacaFillListener(PositionManager *position_manager,
                      std::atomic<bool> &is_running, const std::string &api_key,
-                     const std::string &api_secret);
+                     const std::string &api_secret,
+                     PendingOrderTracker *pending_tracker = nullptr);
 
   ~AlpacaFillListener() override;
 
@@ -60,6 +64,7 @@ private:
   void handleTradeUpdate(const std::string &json);
 
   PositionManager *position_manager_;
+  PendingOrderTracker *pending_tracker_;
   std::atomic<bool> &is_running_;
   std::string api_key_;
   std::string api_secret_;

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -14,6 +14,7 @@
 struct FillEvent {
   char symbol[8];
   OrderSide side;
+  bool is_partial;
   int64_t quantity;
   double price;
   char alpaca_order_id[48];

--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -12,6 +12,9 @@ public:
   [[nodiscard]] std::expected<OrderAck, OrderError>
   placeOrder(const Order &order) override;
 
+  [[nodiscard]] std::expected<void, OrderError>
+  cancelOrder(std::string_view alpaca_order_id) override;
+
 private:
   std::string api_key_;
   std::string api_secret_;

--- a/include/IRestClient.hpp
+++ b/include/IRestClient.hpp
@@ -21,4 +21,7 @@ public:
 
   [[nodiscard]] virtual std::expected<OrderAck, OrderError>
   placeOrder(const Order &order) = 0;
+
+  [[nodiscard]] virtual std::expected<void, OrderError>
+  cancelOrder(std::string_view alpaca_order_id) = 0;
 };

--- a/include/OrderGateway.hpp
+++ b/include/OrderGateway.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <memory>
 
+class PendingOrderTracker;
 class PositionManager;
 
 class OrderGateway {
@@ -13,16 +14,18 @@ public:
   OrderGateway(std::atomic<bool> &is_running,
                LockFreeMPSCQueue<Order> *order_queue,
                std::unique_ptr<IRestClient> rest_client,
-               PositionManager *position_manager);
+               PositionManager *position_manager,
+               PendingOrderTracker *pending_tracker = nullptr);
 
   void run();
 
 private:
-  void executeOrder(const Order &order) const;
+  void executeOrder(const Order &order);
 
   std::atomic<bool> &is_running_;
   LockFreeMPSCQueue<Order> *order_queue_;
   std::unique_ptr<IRestClient> rest_client_;
   PositionManager *position_manager_;
+  PendingOrderTracker *pending_tracker_;
   uint64_t order_id_counter_ = 0;
 };

--- a/include/PendingOrderTracker.hpp
+++ b/include/PendingOrderTracker.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
-#include "Order.hpp"
-#include "PositionManager.hpp"
-#include <cstring>
-#include <optional>
-#include <string_view>
-#include <tbb/concurrent_hash_map.h>
-#include <type_traits>
+`#include` "Order.hpp"
+`#include` "PositionManager.hpp"
+`#include` <algorithm>
+`#include` <cstdint>
+`#include` <cstring>
+`#include` <optional>
+`#include` <string_view>
+`#include` <tbb/concurrent_hash_map.h>
+`#include` <type_traits>
 
 struct OrderSlotKey {
   SymbolKey symbol;

--- a/include/PendingOrderTracker.hpp
+++ b/include/PendingOrderTracker.hpp
@@ -2,9 +2,11 @@
 
 #include "Order.hpp"
 #include "PositionManager.hpp"
+#include <cstring>
 #include <optional>
-#include <string>
+#include <string_view>
 #include <tbb/concurrent_hash_map.h>
+#include <type_traits>
 
 struct OrderSlotKey {
   SymbolKey symbol;
@@ -14,6 +16,9 @@ struct OrderSlotKey {
     return symbol == other.symbol && side == other.side;
   }
 };
+
+static_assert(std::is_trivially_copyable_v<OrderSlotKey>,
+              "OrderSlotKey must be trivially copyable for hash map");
 
 struct OrderSlotKeyHashCompare {
   [[nodiscard]] static std::size_t hash(const OrderSlotKey &k) {
@@ -29,9 +34,33 @@ struct OrderSlotKeyHashCompare {
   }
 };
 
+struct AlpacaOrderId {
+  static constexpr std::size_t kCapacity = 48;
+  char value[kCapacity]{};
+
+  AlpacaOrderId() = default;
+
+  explicit AlpacaOrderId(std::string_view id) {
+    const auto len = (std::min)(id.size(), kCapacity);
+    std::memcpy(value, id.data(), len);
+  }
+
+  [[nodiscard]] std::string_view view() const {
+    return {value, strnlen(value, kCapacity)};
+  }
+
+  [[nodiscard]] bool operator==(std::string_view other) const {
+    return view() == other;
+  }
+};
+
+static_assert(std::is_trivially_copyable_v<AlpacaOrderId>,
+              "AlpacaOrderId must be trivially copyable");
+static_assert(sizeof(AlpacaOrderId) == 48, "AlpacaOrderId must be 48 bytes");
+
 class PendingOrderTracker {
 public:
-  [[nodiscard]] std::optional<std::string>
+  [[nodiscard]] std::optional<AlpacaOrderId>
   getExistingOrder(const SymbolKey &symbol, OrderSide side) const;
 
   void recordOrder(const SymbolKey &symbol, OrderSide side,
@@ -41,7 +70,7 @@ public:
                         std::string_view alpaca_order_id);
 
 private:
-  using SlotMap = tbb::concurrent_hash_map<OrderSlotKey, std::string,
+  using SlotMap = tbb::concurrent_hash_map<OrderSlotKey, AlpacaOrderId,
                                            OrderSlotKeyHashCompare>;
   mutable SlotMap slots_;
 };

--- a/include/PendingOrderTracker.hpp
+++ b/include/PendingOrderTracker.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "Order.hpp"
+#include "PositionManager.hpp"
+#include <optional>
+#include <string>
+#include <tbb/concurrent_hash_map.h>
+
+struct OrderSlotKey {
+  SymbolKey symbol;
+  OrderSide side;
+
+  [[nodiscard]] bool operator==(const OrderSlotKey &other) const {
+    return symbol == other.symbol && side == other.side;
+  }
+};
+
+struct OrderSlotKeyHashCompare {
+  [[nodiscard]] static std::size_t hash(const OrderSlotKey &k) {
+    auto h = SymbolKeyHashCompare::hash(k.symbol);
+    h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(k.side)) + 0x9e3779b9 +
+         (h << 6) + (h >> 2);
+    return h;
+  }
+
+  [[nodiscard]] static bool equal(const OrderSlotKey &lhs,
+                                  const OrderSlotKey &rhs) {
+    return lhs == rhs;
+  }
+};
+
+class PendingOrderTracker {
+public:
+  [[nodiscard]] std::optional<std::string>
+  getExistingOrder(const SymbolKey &symbol, OrderSide side) const;
+
+  void recordOrder(const SymbolKey &symbol, OrderSide side,
+                   std::string_view alpaca_order_id);
+
+  void onOrderCompleted(const SymbolKey &symbol, OrderSide side,
+                        std::string_view alpaca_order_id);
+
+private:
+  using SlotMap =
+      tbb::concurrent_hash_map<OrderSlotKey, std::string,
+                                OrderSlotKeyHashCompare>;
+  mutable SlotMap slots_;
+};

--- a/include/PendingOrderTracker.hpp
+++ b/include/PendingOrderTracker.hpp
@@ -41,8 +41,7 @@ public:
                         std::string_view alpaca_order_id);
 
 private:
-  using SlotMap =
-      tbb::concurrent_hash_map<OrderSlotKey, std::string,
-                                OrderSlotKeyHashCompare>;
+  using SlotMap = tbb::concurrent_hash_map<OrderSlotKey, std::string,
+                                           OrderSlotKeyHashCompare>;
   mutable SlotMap slots_;
 };

--- a/include/PendingOrderTracker.hpp
+++ b/include/PendingOrderTracker.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-`#include` "Order.hpp"
-`#include` "PositionManager.hpp"
-`#include` <algorithm>
-`#include` <cstdint>
-`#include` <cstring>
-`#include` <optional>
-`#include` <string_view>
-`#include` <tbb/concurrent_hash_map.h>
-`#include` <type_traits>
+#include "Order.hpp"
+#include "PositionManager.hpp"
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string_view>
+#include <tbb/concurrent_hash_map.h>
+#include <type_traits>
 
 struct OrderSlotKey {
   SymbolKey symbol;

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -6,10 +6,10 @@
 #include "MarketEventConsumer.hpp"
 #include "Order.hpp"
 #include "OrderGateway.hpp"
+#include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
 #include "SimpleMarketMakingStrategy.hpp"
 #include <atomic>
-#include <cstdint>
 #include <memory>
 #include <string>
 #include <thread>
@@ -64,6 +64,7 @@ private:
   std::unique_ptr<PositionManager> position_manager_;
   std::unique_ptr<RiskManager> risk_manager_;
   zmq::context_t context_{1};
+  std::unique_ptr<PendingOrderTracker> pending_tracker_;
   std::unique_ptr<LockFreeMPSCQueue<Order>> order_queue_;
   std::unique_ptr<OrderGateway> order_gateway_;
   std::thread order_gateway_thread_;

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -14,10 +14,19 @@ constexpr const char *kStreamUrl = "wss://paper-api.alpaca.markets/stream";
 constexpr int kMinReconnectMs = 100;
 constexpr int kMaxReconnectMs = 30000;
 constexpr std::size_t kSymbolCapacity = 8;
+constexpr std::size_t kOrderIdCapacity = 48;
 
 void copySymbol(char (&dest)[8], const std::string &src) {
   std::memset(dest, 0, kSymbolCapacity);
   const auto len = (std::min)(src.size(), kSymbolCapacity);
+  if (len > 0) {
+    std::memcpy(dest, src.data(), len);
+  }
+}
+
+void copyOrderId(char (&dest)[48], const std::string &src) {
+  std::memset(dest, 0, kOrderIdCapacity);
+  const auto len = (std::min)(src.size(), kOrderIdCapacity);
   if (len > 0) {
     std::memcpy(dest, src.data(), len);
   }
@@ -95,6 +104,11 @@ TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
     return std::monostate{};
   }
 
+  std::string order_id;
+  if (order.contains("id") && order["id"].is_string()) {
+    order_id = order["id"].get<std::string>();
+  }
+
   if (event == "fill" || event == "partial_fill") {
     if (!data.contains("qty") || !data.contains("price")) {
       return std::monostate{};
@@ -111,6 +125,7 @@ TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
     fill.side = *side;
     fill.quantity = *qty;
     fill.price = *price;
+    copyOrderId(fill.alpaca_order_id, order_id);
     return fill;
   }
 
@@ -118,6 +133,7 @@ TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
     CancelEvent cancel{};
     copySymbol(cancel.symbol, symbol);
     cancel.side = *side;
+    copyOrderId(cancel.alpaca_order_id, order_id);
 
     int64_t total_qty = 0;
     int64_t filled_qty = 0;

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaFillListener.hpp"
+#include "PendingOrderTracker.hpp"
 #include "ThreadPinning.hpp"
 #include <algorithm>
 #include <cstring>
@@ -161,9 +162,10 @@ TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
 AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
                                        std::atomic<bool> &is_running,
                                        const std::string &api_key,
-                                       const std::string &api_secret)
-    : position_manager_(position_manager), is_running_(is_running),
-      api_key_(api_key), api_secret_(api_secret) {
+                                       const std::string &api_secret,
+                                       PendingOrderTracker *pending_tracker)
+    : position_manager_(position_manager), pending_tracker_(pending_tracker),
+      is_running_(is_running), api_key_(api_key), api_secret_(api_secret) {
   if (position_manager_ == nullptr) {
     throw std::invalid_argument(
         "AlpacaFillListener: position_manager must not be null");
@@ -289,6 +291,14 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     fill.quantity = fill_event.quantity;
     fill.price = fill_event.price;
     position_manager_->onFill(fill);
+    if (pending_tracker_) {
+      SymbolKey key{};
+      std::memcpy(key.value, fill_event.symbol, kSymbolCapacity);
+      std::string_view order_id(
+          fill_event.alpaca_order_id,
+          strnlen(fill_event.alpaca_order_id, kOrderIdCapacity));
+      pending_tracker_->onOrderCompleted(key, fill_event.side, order_id);
+    }
     std::cout << "FillListener: Fill processed ("
               << std::string_view(fill_event.symbol,
                                   strnlen(fill_event.symbol, kSymbolCapacity))
@@ -303,6 +313,14 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     order.side = cancel_event.side;
     order.type = OrderType::Market;
     position_manager_->onOrderCancelled(order);
+    if (pending_tracker_) {
+      SymbolKey key{};
+      std::memcpy(key.value, cancel_event.symbol, kSymbolCapacity);
+      std::string_view order_id(
+          cancel_event.alpaca_order_id,
+          strnlen(cancel_event.alpaca_order_id, kOrderIdCapacity));
+      pending_tracker_->onOrderCompleted(key, cancel_event.side, order_id);
+    }
     std::cout << "FillListener: Cancel processed ("
               << std::string_view(cancel_event.symbol,
                                   strnlen(cancel_event.symbol, kSymbolCapacity))

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -124,6 +124,7 @@ TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
     FillEvent fill{};
     copySymbol(fill.symbol, symbol);
     fill.side = *side;
+    fill.is_partial = (event == "partial_fill");
     fill.quantity = *qty;
     fill.price = *price;
     copyOrderId(fill.alpaca_order_id, order_id);
@@ -291,7 +292,7 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     fill.quantity = fill_event.quantity;
     fill.price = fill_event.price;
     position_manager_->onFill(fill);
-    if (pending_tracker_) {
+    if (pending_tracker_ && !fill_event.is_partial) {
       SymbolKey key{};
       std::memcpy(key.value, fill_event.symbol, kSymbolCapacity);
       std::string_view order_id(
@@ -299,7 +300,9 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
           strnlen(fill_event.alpaca_order_id, kOrderIdCapacity));
       pending_tracker_->onOrderCompleted(key, fill_event.side, order_id);
     }
-    std::cout << "FillListener: Fill processed ("
+    std::cout << "FillListener: "
+              << (fill_event.is_partial ? "Partial fill" : "Fill")
+              << " processed ("
               << std::string_view(fill_event.symbol,
                                   strnlen(fill_event.symbol, kSymbolCapacity))
               << " qty=" << fill_event.quantity << ")" << std::endl;

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -68,7 +68,7 @@ AlpacaRestClient::cancelOrder(std::string_view alpaca_order_id) {
       cpr::Header{{"APCA-API-KEY-ID", api_key_},
                   {"APCA-API-SECRET-KEY", api_secret_}});
 
-  if (r.status_code == 204 || r.status_code == 404) {
+  if (r.status_code == 204) {
     return {};
   }
 

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -60,3 +60,18 @@ AlpacaRestClient::placeOrder(const Order &order) {
   return OrderAck{response.value("id", ""),
                   response.value("status", "unknown")};
 }
+
+std::expected<void, OrderError>
+AlpacaRestClient::cancelOrder(std::string_view alpaca_order_id) {
+  const cpr::Response r = cpr::Delete(
+      cpr::Url{base_url_ + "/v2/orders/" + std::string(alpaca_order_id)},
+      cpr::Header{{"APCA-API-KEY-ID", api_key_},
+                  {"APCA-API-SECRET-KEY", api_secret_}});
+
+  if (r.status_code == 204 || r.status_code == 404) {
+    return {};
+  }
+
+  return std::unexpected(
+      OrderError{r.status_code, "Error canceling order: " + r.text});
+}

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -1,15 +1,18 @@
 #include "OrderGateway.hpp"
+#include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 
 OrderGateway::OrderGateway(std::atomic<bool> &is_running,
                            LockFreeMPSCQueue<Order> *order_queue,
                            std::unique_ptr<IRestClient> rest_client,
-                           PositionManager *position_manager)
+                           PositionManager *position_manager,
+                           PendingOrderTracker *pending_tracker)
     : is_running_(is_running), order_queue_(order_queue),
-      rest_client_(std::move(rest_client)),
-      position_manager_(position_manager) {
+      rest_client_(std::move(rest_client)), position_manager_(position_manager),
+      pending_tracker_(pending_tracker) {
   if (order_queue_ == nullptr) {
     throw std::invalid_argument("OrderGateway: order_queue must not be null");
   }
@@ -22,12 +25,41 @@ OrderGateway::OrderGateway(std::atomic<bool> &is_running,
   }
 }
 
-void OrderGateway::executeOrder(const Order &order) const {
+void OrderGateway::executeOrder(const Order &order) {
+  SymbolKey key{};
+  std::memcpy(key.value, order.symbol, sizeof(key.value));
+
+  if (pending_tracker_) {
+    auto prev_id = pending_tracker_->getExistingOrder(key, order.side);
+    if (prev_id) {
+      try {
+        auto cancel_result = rest_client_->cancelOrder(*prev_id);
+        if (cancel_result) {
+          std::cerr << "OrderGateway: Canceled previous order " << *prev_id
+                    << std::endl;
+        } else {
+          std::cerr << "OrderGateway: Cancel returned HTTP "
+                    << cancel_result.error().status_code << " for " << *prev_id
+                    << ": " << cancel_result.error().message << std::endl;
+        }
+      } catch (const std::exception &e) {
+        std::cerr << "OrderGateway: Exception canceling order " << *prev_id
+                  << ": " << e.what() << std::endl;
+      } catch (...) {
+        std::cerr << "OrderGateway: Unknown error canceling order " << *prev_id
+                  << std::endl;
+      }
+    }
+  }
+
   try {
     auto result = rest_client_->placeOrder(order);
     if (result) {
       std::cerr << "OrderGateway: Placed order " << result->client_order_id
                 << " status=" << result->status << std::endl;
+      if (pending_tracker_) {
+        pending_tracker_->recordOrder(key, order.side, result->client_order_id);
+      }
     } else {
       std::cerr << "OrderGateway: Rejected (HTTP " << result.error().status_code
                 << "): " << result.error().message << std::endl;

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -40,11 +40,13 @@ void OrderGateway::executeOrder(const Order &order) {
                     << prev_id->view() << std::endl;
           cancel_accepted = true;
         } else {
-          cancel_accepted = true;
-          std::cerr << "OrderGateway: Cancel returned HTTP "
-                    << cancel_result.error().status_code << " for "
+          const auto code = cancel_result.error().status_code;
+          std::cerr << "OrderGateway: Cancel returned HTTP " << code << " for "
                     << prev_id->view() << ": " << cancel_result.error().message
                     << std::endl;
+          if (code == 422) {
+            cancel_accepted = true;
+          }
         }
       } catch (const std::exception &e) {
         std::cerr << "OrderGateway: Exception canceling order "

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -32,12 +32,15 @@ void OrderGateway::executeOrder(const Order &order) {
   if (pending_tracker_) {
     auto prev_id = pending_tracker_->getExistingOrder(key, order.side);
     if (prev_id) {
+      bool cancel_accepted = false;
       try {
         auto cancel_result = rest_client_->cancelOrder(prev_id->view());
         if (cancel_result) {
           std::cerr << "OrderGateway: Canceled previous order "
                     << prev_id->view() << std::endl;
+          cancel_accepted = true;
         } else {
+          cancel_accepted = true;
           std::cerr << "OrderGateway: Cancel returned HTTP "
                     << cancel_result.error().status_code << " for "
                     << prev_id->view() << ": " << cancel_result.error().message
@@ -49,6 +52,12 @@ void OrderGateway::executeOrder(const Order &order) {
       } catch (...) {
         std::cerr << "OrderGateway: Unknown error canceling order "
                   << prev_id->view() << std::endl;
+      }
+      if (!cancel_accepted) {
+        std::cerr << "OrderGateway: Skipping new order — cancel for "
+                  << prev_id->view() << " did not reach Alpaca" << std::endl;
+        position_manager_->onOrderCancelled(order);
+        return;
       }
     }
   }

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -33,21 +33,22 @@ void OrderGateway::executeOrder(const Order &order) {
     auto prev_id = pending_tracker_->getExistingOrder(key, order.side);
     if (prev_id) {
       try {
-        auto cancel_result = rest_client_->cancelOrder(*prev_id);
+        auto cancel_result = rest_client_->cancelOrder(prev_id->view());
         if (cancel_result) {
-          std::cerr << "OrderGateway: Canceled previous order " << *prev_id
-                    << std::endl;
+          std::cerr << "OrderGateway: Canceled previous order "
+                    << prev_id->view() << std::endl;
         } else {
           std::cerr << "OrderGateway: Cancel returned HTTP "
-                    << cancel_result.error().status_code << " for " << *prev_id
-                    << ": " << cancel_result.error().message << std::endl;
+                    << cancel_result.error().status_code << " for "
+                    << prev_id->view() << ": " << cancel_result.error().message
+                    << std::endl;
         }
       } catch (const std::exception &e) {
-        std::cerr << "OrderGateway: Exception canceling order " << *prev_id
-                  << ": " << e.what() << std::endl;
+        std::cerr << "OrderGateway: Exception canceling order "
+                  << prev_id->view() << ": " << e.what() << std::endl;
       } catch (...) {
-        std::cerr << "OrderGateway: Unknown error canceling order " << *prev_id
-                  << std::endl;
+        std::cerr << "OrderGateway: Unknown error canceling order "
+                  << prev_id->view() << std::endl;
       }
     }
   }

--- a/src/PendingOrderTracker.cpp
+++ b/src/PendingOrderTracker.cpp
@@ -1,0 +1,30 @@
+#include "PendingOrderTracker.hpp"
+
+std::optional<std::string>
+PendingOrderTracker::getExistingOrder(const SymbolKey &symbol,
+                                      OrderSide side) const {
+  OrderSlotKey key{symbol, side};
+  SlotMap::const_accessor acc;
+  if (slots_.find(acc, key)) {
+    return acc->second;
+  }
+  return std::nullopt;
+}
+
+void PendingOrderTracker::recordOrder(const SymbolKey &symbol, OrderSide side,
+                                      std::string_view alpaca_order_id) {
+  OrderSlotKey key{symbol, side};
+  SlotMap::accessor acc;
+  slots_.insert(acc, key);
+  acc->second = std::string(alpaca_order_id);
+}
+
+void PendingOrderTracker::onOrderCompleted(const SymbolKey &symbol,
+                                           OrderSide side,
+                                           std::string_view alpaca_order_id) {
+  OrderSlotKey key{symbol, side};
+  SlotMap::accessor acc;
+  if (slots_.find(acc, key) && acc->second == alpaca_order_id) {
+    slots_.erase(acc);
+  }
+}

--- a/src/PendingOrderTracker.cpp
+++ b/src/PendingOrderTracker.cpp
@@ -1,6 +1,6 @@
 #include "PendingOrderTracker.hpp"
 
-std::optional<std::string>
+std::optional<AlpacaOrderId>
 PendingOrderTracker::getExistingOrder(const SymbolKey &symbol,
                                       OrderSide side) const {
   OrderSlotKey key{symbol, side};
@@ -16,7 +16,7 @@ void PendingOrderTracker::recordOrder(const SymbolKey &symbol, OrderSide side,
   OrderSlotKey key{symbol, side};
   SlotMap::accessor acc;
   slots_.insert(acc, key);
-  acc->second = std::string(alpaca_order_id);
+  acc->second = AlpacaOrderId(alpaca_order_id);
 }
 
 void PendingOrderTracker::onOrderCompleted(const SymbolKey &symbol,

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -26,10 +26,11 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
     position_manager_->registerSymbol(symbol);
   }
   risk_manager_ = std::make_unique<RiskManager>(position_manager_.get());
+  pending_tracker_ = std::make_unique<PendingOrderTracker>();
   order_queue_ = std::make_unique<LockFreeMPSCQueue<Order>>();
   order_gateway_ = std::make_unique<OrderGateway>(
       is_running_, order_queue_.get(), std::move(rest_client),
-      position_manager_.get());
+      position_manager_.get(), pending_tracker_.get());
 
   const char *api_key = std::getenv("APCA_API_KEY_ID");
   const char *api_secret = std::getenv("APCA_API_SECRET_KEY");
@@ -38,7 +39,8 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
         "APCA_API_KEY_ID and APCA_API_SECRET_KEY must be set");
   }
   fill_listener_ = std::make_unique<AlpacaFillListener>(
-      position_manager_.get(), is_running_, api_key, api_secret);
+      position_manager_.get(), is_running_, api_key, api_secret,
+      pending_tracker_.get());
 
   ipc_address_ = getZmqMarketDataAddress();
 

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -92,6 +92,7 @@ inline void close_socket(SocketType sock) {
 }
 
 struct CapturedRequest {
+  std::string method;
   std::string path;
   std::string body;
 };
@@ -175,6 +176,8 @@ public:
 
     CapturedRequest req;
     auto first_space = raw.find(' ');
+    if (first_space != std::string::npos)
+      req.method = raw.substr(0, first_space);
     auto second_space = raw.find(' ', first_space + 1);
     if (first_space != std::string::npos && second_space != std::string::npos)
       req.path = raw.substr(first_space + 1, second_space - first_space - 1);
@@ -319,4 +322,50 @@ TEST_F(AlpacaRestClientPlaceOrderTest, SuccessResponseReturnsOrderAck) {
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->client_order_id, "ord-abc-123");
   EXPECT_EQ(result->status, "accepted");
+}
+
+class AlpacaRestClientCancelOrderTest : public AlpacaRestClientTestBase {};
+
+TEST_F(AlpacaRestClientCancelOrderTest, Cancel204ReturnsSuccess) {
+  StubHttpServer server(204, "");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  CapturedRequest req;
+  std::thread t([&]() { req = server.serve_one(); });
+  auto result = client.cancelOrder("order-uuid-123");
+  t.join();
+
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(req.method, "DELETE");
+  EXPECT_EQ(req.path, "/v2/orders/order-uuid-123");
+}
+
+TEST_F(AlpacaRestClientCancelOrderTest, Cancel404ReturnsSuccess) {
+  StubHttpServer server(404, R"({"message":"order not found"})");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  CapturedRequest req;
+  std::thread t([&]() { req = server.serve_one(); });
+  auto result = client.cancelOrder("gone-order-id");
+  t.join();
+
+  EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(AlpacaRestClientCancelOrderTest, Cancel422ReturnsError) {
+  StubHttpServer server(422, R"({"message":"order already filled"})");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  CapturedRequest req;
+  std::thread t([&]() { req = server.serve_one(); });
+  auto result = client.cancelOrder("filled-order-id");
+  t.join();
+
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().status_code, 422);
+  EXPECT_TRUE(result.error().message.find("order already filled") !=
+              std::string::npos);
 }

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -341,7 +341,7 @@ TEST_F(AlpacaRestClientCancelOrderTest, Cancel204ReturnsSuccess) {
   EXPECT_EQ(req.path, "/v2/orders/order-uuid-123");
 }
 
-TEST_F(AlpacaRestClientCancelOrderTest, Cancel404ReturnsSuccess) {
+TEST_F(AlpacaRestClientCancelOrderTest, Cancel404ReturnsError) {
   StubHttpServer server(404, R"({"message":"order not found"})");
   point_client_to(server.port());
   AlpacaRestClient client;
@@ -351,7 +351,8 @@ TEST_F(AlpacaRestClientCancelOrderTest, Cancel404ReturnsSuccess) {
   auto result = client.cancelOrder("gone-order-id");
   t.join();
 
-  EXPECT_TRUE(result.has_value());
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().status_code, 404);
 }
 
 TEST_F(AlpacaRestClientCancelOrderTest, Cancel422ReturnsError) {

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -60,6 +60,7 @@ struct FillParseParam {
   const char *side_str;
   const char *qty;
   const char *price;
+  const char *order_id;
   OrderSide expected_side;
   int64_t expected_qty;
   double expected_price;
@@ -69,13 +70,13 @@ class FillParseTest : public FillListenerTest,
                       public ::testing::WithParamInterface<FillParseParam> {};
 
 TEST_P(FillParseTest, ParsesFillFields) {
-  const auto &[event_type, symbol, side_str, qty, price, expected_side,
-               expected_qty, expected_price] = GetParam();
-  const std::string json = R"({"stream":"trade_updates","data":{"event":")" +
-                           std::string(event_type) + R"(","qty":")" + qty +
-                           R"(","price":")" + price +
-                           R"(","order":{"symbol":")" + symbol +
-                           R"(","side":")" + side_str + R"("}}})";
+  const auto &[event_type, symbol, side_str, qty, price, order_id,
+               expected_side, expected_qty, expected_price] = GetParam();
+  const std::string json =
+      R"({"stream":"trade_updates","data":{"event":")" +
+      std::string(event_type) + R"(","qty":")" + qty + R"(","price":")" +
+      price + R"(","order":{"symbol":")" + symbol + R"(","side":")" + side_str +
+      R"(","id":")" + order_id + R"("}}})";
   const auto update = parse(json);
 
   ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
@@ -87,24 +88,38 @@ TEST_P(FillParseTest, ParsesFillFields) {
   EXPECT_EQ(fill.side, expected_side);
   EXPECT_EQ(fill.quantity, expected_qty);
   EXPECT_DOUBLE_EQ(fill.price, expected_price);
+  EXPECT_EQ(std::string_view(
+                fill.alpaca_order_id,
+                strnlen(fill.alpaca_order_id, sizeof(fill.alpaca_order_id))),
+            order_id);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     FillTypes, FillParseTest,
     ::testing::Values(FillParseParam{"fill", "AAPL", "buy", "100", "150.25",
+                                     "b0929f79-27a5-480f-9b94-e2f123456789",
                                      OrderSide::Buy, 100, 150.25},
                       FillParseParam{"partial_fill", "GOOGL", "sell", "50",
-                                     "200.00", OrderSide::Sell, 50, 200.0}));
+                                     "200.00",
+                                     "c1234567-89ab-cdef-0123-456789abcdef",
+                                     OrderSide::Sell, 50, 200.0}));
 
-class CancelEventTypeTest : public FillListenerTest,
-                            public ::testing::WithParamInterface<const char *> {
+struct CancelParseParam {
+  const char *event_type;
+  const char *order_id;
 };
 
+class CancelEventTypeTest
+    : public FillListenerTest,
+      public ::testing::WithParamInterface<CancelParseParam> {};
+
 TEST_P(CancelEventTypeTest, ProducesCancelEvent) {
+  const auto &[event_type, order_id] = GetParam();
   const std::string json =
       R"({"stream":"trade_updates","data":{"event":")" +
-      std::string(GetParam()) +
-      R"(","order":{"symbol":"AAPL","side":"buy","qty":"100","filled_qty":"0"}}})";
+      std::string(event_type) +
+      R"(","order":{"symbol":"AAPL","side":"buy","qty":"100","filled_qty":"0","id":")" +
+      order_id + R"("}}})";
   const auto update = parse(json);
 
   ASSERT_TRUE(std::holds_alternative<CancelEvent>(update));
@@ -115,10 +130,37 @@ TEST_P(CancelEventTypeTest, ProducesCancelEvent) {
             "AAPL");
   EXPECT_EQ(cancel.side, OrderSide::Buy);
   EXPECT_EQ(cancel.quantity, 100);
+  EXPECT_EQ(std::string_view(cancel.alpaca_order_id,
+                             strnlen(cancel.alpaca_order_id,
+                                     sizeof(cancel.alpaca_order_id))),
+            order_id);
 }
 
-INSTANTIATE_TEST_SUITE_P(EventTypes, CancelEventTypeTest,
-                         ::testing::Values("canceled", "expired", "rejected"));
+INSTANTIATE_TEST_SUITE_P(
+    EventTypes, CancelEventTypeTest,
+    ::testing::Values(
+        CancelParseParam{"canceled", "aaa11111-2222-3333-4444-555566667777"},
+        CancelParseParam{"expired", "bbb11111-2222-3333-4444-555566667777"},
+        CancelParseParam{"rejected", "ccc11111-2222-3333-4444-555566667777"}));
+
+TEST_F(FillListenerTest, FillWithMissingOrderIdProducesEmptyId) {
+  const auto update = parse(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "50",
+      "price": "100.00",
+      "order": {"symbol": "AAPL", "side": "buy"}
+    }
+  })");
+
+  ASSERT_TRUE(std::holds_alternative<FillEvent>(update));
+  const auto &fill = std::get<FillEvent>(update);
+  EXPECT_EQ(std::string_view(
+                fill.alpaca_order_id,
+                strnlen(fill.alpaca_order_id, sizeof(fill.alpaca_order_id))),
+            "");
+}
 
 TEST_F(FillListenerTest, CancelAfterPartialFillUsesRemainingQty) {
   const auto update = parse(R"({
@@ -129,7 +171,8 @@ TEST_F(FillListenerTest, CancelAfterPartialFillUsesRemainingQty) {
         "symbol": "AAPL",
         "side": "buy",
         "qty": "100",
-        "filled_qty": "60"
+        "filled_qty": "60",
+        "id": "partial-cancel-id"
       }
     }
   })");

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -93,6 +93,7 @@ TEST_P(FillParseTest, ParsesFillFields) {
                 fill.alpaca_order_id,
                 strnlen(fill.alpaca_order_id, sizeof(fill.alpaca_order_id))),
             order_id);
+  EXPECT_EQ(fill.is_partial, std::string(event_type) == "partial_fill");
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -530,6 +531,28 @@ TEST_F(FillListenerTrackerTest, FillNotifiesTracker) {
   })");
 
   EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
+}
+
+TEST_F(FillListenerTrackerTest, PartialFillDoesNotClearTracker) {
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Buy, "partial-order-id");
+
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "partial_fill",
+      "qty": "50",
+      "price": "150.25",
+      "order": {"symbol": "AAPL", "side": "buy", "id": "partial-order-id"}
+    }
+  })");
+
+  EXPECT_TRUE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
 }
 
 TEST_F(FillListenerTrackerTest, CancelNotifiesTracker) {

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaFillListener.hpp"
+#include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
 #include "TestHelpers.hpp"
 #include <cstring>
@@ -486,4 +487,73 @@ TEST_F(FillListenerTest, StopDuringActiveProcessingCompletesCorrectly) {
   const int64_t pending = position_manager_->getPendingPosition("AAPL");
   EXPECT_EQ(filled + pending, num_fills);
   EXPECT_EQ(filled, processed.load(std::memory_order_relaxed));
+}
+
+class FillListenerTrackerTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    position_manager_ = std::make_unique<PositionManager>();
+    position_manager_->registerSymbol("AAPL");
+    tracker_ = std::make_unique<PendingOrderTracker>();
+    listener_ = std::make_unique<AlpacaFillListener>(
+        position_manager_.get(), is_running_, "test_key", "test_secret",
+        tracker_.get());
+  }
+
+  void callHandleTradeUpdate(const std::string &json) {
+    listener_->handleTradeUpdate(json);
+  }
+
+  std::unique_ptr<PositionManager> position_manager_;
+  std::unique_ptr<PendingOrderTracker> tracker_;
+  std::atomic<bool> is_running_{true};
+  std::unique_ptr<AlpacaFillListener> listener_;
+};
+
+TEST_F(FillListenerTrackerTest, FillNotifiesTracker) {
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Buy, "fill-order-id");
+
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {"symbol": "AAPL", "side": "buy", "id": "fill-order-id"}
+    }
+  })");
+
+  EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
+}
+
+TEST_F(FillListenerTrackerTest, CancelNotifiesTracker) {
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Buy, "cancel-order-id");
+
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "canceled",
+      "order": {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "100",
+        "filled_qty": "0",
+        "id": "cancel-order-id"
+      }
+    }
+  })");
+
+  EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
 }

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -2,7 +2,9 @@
 #include "LockFreeMPSCQueue.hpp"
 #include "Order.hpp"
 #include "OrderGateway.hpp"
+#include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
+#include "TestHelpers.hpp"
 #include "ThreadGuard.hpp"
 #include <expected>
 #include <future>
@@ -331,3 +333,196 @@ INSTANTIATE_TEST_SUITE_P(
         ShutdownExceptionParam{
             []() { return std::make_unique<WildThrowingRestClient>(); },
             "OrderGateway: Unknown error placing order"}));
+
+namespace {
+
+class TrackingRestClient final : public IRestClient {
+public:
+  struct Call {
+    enum Type { Place, Cancel } type;
+    std::string id;
+  };
+
+  explicit TrackingRestClient(
+      std::expected<void, OrderError> cancel_result = {})
+      : cancel_result_(std::move(cancel_result)) {}
+
+  std::expected<OrderAck, OrderError>
+  placeOrder(const Order & /*order*/) override {
+    std::string id = "alpaca-" + std::to_string(++place_counter_);
+    calls.push_back({Call::Place, id});
+    return OrderAck{id, "accepted"};
+  }
+
+  std::expected<void, OrderError>
+  cancelOrder(std::string_view alpaca_order_id) override {
+    calls.push_back({Call::Cancel, std::string(alpaca_order_id)});
+    return cancel_result_;
+  }
+
+  std::vector<Call> calls;
+
+private:
+  int place_counter_ = 0;
+  std::expected<void, OrderError> cancel_result_;
+};
+
+class ThrowingCancelClient final : public IRestClient {
+public:
+  std::expected<OrderAck, OrderError>
+  placeOrder(const Order & /*order*/) override {
+    std::string id = "alpaca-" + std::to_string(++place_counter_);
+    place_ids.push_back(id);
+    return OrderAck{id, "accepted"};
+  }
+
+  std::expected<void, OrderError>
+  cancelOrder(std::string_view /*alpaca_order_id*/) override {
+    throw std::runtime_error("cancel network error");
+  }
+
+  std::vector<std::string> place_ids;
+
+private:
+  int place_counter_ = 0;
+};
+
+} // namespace
+
+class CancelBeforeReplaceTest : public ::testing::Test {
+protected:
+  PositionManager position_manager_;
+  PendingOrderTracker tracker_;
+};
+
+TEST_F(CancelBeforeReplaceTest, CancelsPreviousBeforePlacingNew) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+
+  Order order1 = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  Order order2 = test_helpers::createOrder("AAPL", OrderSide::Buy, 200, 0);
+  order_queue.push(order1);
+  order_queue.push(order2);
+
+  auto *raw_client = new TrackingRestClient();
+  std::unique_ptr<IRestClient> client(raw_client);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_, &tracker_);
+  gateway.run();
+
+  ASSERT_GE(raw_client->calls.size(), 3u);
+  EXPECT_EQ(raw_client->calls[0].type, TrackingRestClient::Call::Place);
+  EXPECT_EQ(raw_client->calls[1].type, TrackingRestClient::Call::Cancel);
+  EXPECT_EQ(raw_client->calls[1].id, "alpaca-1");
+  EXPECT_EQ(raw_client->calls[2].type, TrackingRestClient::Call::Place);
+}
+
+TEST_F(CancelBeforeReplaceTest, NoCancelWhenNoPreviousOrder) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order_queue.push(order);
+
+  auto *raw_client = new TrackingRestClient();
+  std::unique_ptr<IRestClient> client(raw_client);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_, &tracker_);
+  gateway.run();
+
+  ASSERT_EQ(raw_client->calls.size(), 1u);
+  EXPECT_EQ(raw_client->calls[0].type, TrackingRestClient::Call::Place);
+}
+
+TEST_F(CancelBeforeReplaceTest, PlacesOrderEvenWhenCancelFails422) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+
+  Order order1 = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  Order order2 = test_helpers::createOrder("AAPL", OrderSide::Buy, 200, 0);
+  order_queue.push(order1);
+  order_queue.push(order2);
+
+  auto cancel_error = std::unexpected(OrderError{422, "order already filled"});
+  auto *raw_client = new TrackingRestClient(cancel_error);
+  std::unique_ptr<IRestClient> client(raw_client);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_, &tracker_);
+  gateway.run();
+
+  int place_count = 0;
+  for (const auto &call : raw_client->calls) {
+    if (call.type == TrackingRestClient::Call::Place)
+      ++place_count;
+  }
+  EXPECT_EQ(place_count, 2);
+}
+
+TEST_F(CancelBeforeReplaceTest, PlacesOrderEvenWhenCancelThrows) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+
+  Order order1 = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  Order order2 = test_helpers::createOrder("AAPL", OrderSide::Buy, 200, 0);
+  order_queue.push(order1);
+  order_queue.push(order2);
+
+  auto *raw_client = new ThrowingCancelClient();
+  std::unique_ptr<IRestClient> client(raw_client);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_, &tracker_);
+  gateway.run();
+
+  EXPECT_EQ(raw_client->place_ids.size(), 2u);
+}
+
+TEST_F(CancelBeforeReplaceTest, TracksDifferentSidesIndependently) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+
+  Order buy1 = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  Order sell1 = test_helpers::createOrder("AAPL", OrderSide::Sell, 50, 0);
+  order_queue.push(buy1);
+  order_queue.push(sell1);
+
+  auto *raw_client = new TrackingRestClient();
+  std::unique_ptr<IRestClient> client(raw_client);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_, &tracker_);
+  gateway.run();
+
+  ASSERT_EQ(raw_client->calls.size(), 2u);
+  EXPECT_EQ(raw_client->calls[0].type, TrackingRestClient::Call::Place);
+  EXPECT_EQ(raw_client->calls[1].type, TrackingRestClient::Call::Place);
+}
+
+TEST_F(CancelBeforeReplaceTest, DoesNotRecordFailedPlacement) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+
+  position_manager_.registerSymbol("AAPL");
+
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order_queue.push(order);
+
+  class FailingPlaceClient final : public IRestClient {
+  public:
+    std::expected<OrderAck, OrderError>
+    placeOrder(const Order & /*order*/) override {
+      return std::unexpected(OrderError{500, "internal error"});
+    }
+    std::expected<void, OrderError>
+    cancelOrder(std::string_view /*alpaca_order_id*/) override {
+      return {};
+    }
+  };
+
+  OrderGateway gateway(is_running, &order_queue,
+                       std::make_unique<FailingPlaceClient>(),
+                       &position_manager_, &tracker_);
+  gateway.run();
+
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  EXPECT_FALSE(tracker_.getExistingOrder(key, OrderSide::Buy).has_value());
+}

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -24,6 +24,11 @@ public:
     return OrderAck{"ord-123", "accepted"};
   }
 
+  std::expected<void, OrderError>
+  cancelOrder(std::string_view /*alpaca_order_id*/) override {
+    return {};
+  }
+
   std::promise<void> *promise_to_fulfill = nullptr;
 };
 
@@ -117,6 +122,10 @@ TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
       count_.fetch_add(1, std::memory_order_release);
       return OrderAck{"ord-" + std::to_string(order.id), "accepted"};
     }
+    std::expected<void, OrderError>
+    cancelOrder(std::string_view /*alpaca_order_id*/) override {
+      return {};
+    }
 
   private:
     std::vector<uint64_t> &ids_;
@@ -167,6 +176,10 @@ TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
     placeOrder(const Order & /*unused*/) override {
       return std::unexpected(OrderError{422, "insufficient qty"});
     }
+    std::expected<void, OrderError>
+    cancelOrder(std::string_view /*alpaca_order_id*/) override {
+      return {};
+    }
   };
 
   OrderGateway gateway(is_running, &order_queue,
@@ -189,6 +202,11 @@ public:
     throw std::runtime_error("simulated rest error");
   }
 
+  std::expected<void, OrderError>
+  cancelOrder(std::string_view /*alpaca_order_id*/) override {
+    return {};
+  }
+
 private:
   std::promise<void> *promise_;
 };
@@ -203,6 +221,11 @@ public:
     if (promise_)
       promise_->set_value();
     throw 42;
+  }
+
+  std::expected<void, OrderError>
+  cancelOrder(std::string_view /*alpaca_order_id*/) override {
+    return {};
   }
 
 private:

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -458,9 +458,11 @@ TEST_F(CancelBeforeReplaceTest, PlacesOrderEvenWhenCancelFails422) {
   EXPECT_EQ(place_count, 2);
 }
 
-TEST_F(CancelBeforeReplaceTest, PlacesOrderEvenWhenCancelThrows) {
+TEST_F(CancelBeforeReplaceTest, SkipsNewOrderWhenCancelThrows) {
   std::atomic is_running(false);
   LockFreeMPSCQueue<Order> order_queue;
+
+  position_manager_.registerSymbol("AAPL");
 
   Order order1 = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
   Order order2 = test_helpers::createOrder("AAPL", OrderSide::Buy, 200, 0);
@@ -473,7 +475,8 @@ TEST_F(CancelBeforeReplaceTest, PlacesOrderEvenWhenCancelThrows) {
                        &position_manager_, &tracker_);
   gateway.run();
 
-  EXPECT_EQ(raw_client->place_ids.size(), 2u);
+  // First order placed, second skipped because cancel threw
+  EXPECT_EQ(raw_client->place_ids.size(), 1u);
 }
 
 TEST_F(CancelBeforeReplaceTest, TracksDifferentSidesIndependently) {

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -458,6 +458,32 @@ TEST_F(CancelBeforeReplaceTest, PlacesOrderEvenWhenCancelFails422) {
   EXPECT_EQ(place_count, 2);
 }
 
+TEST_F(CancelBeforeReplaceTest, SkipsNewOrderWhenCancelReturns404) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+
+  position_manager_.registerSymbol("AAPL");
+
+  Order order1 = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  Order order2 = test_helpers::createOrder("AAPL", OrderSide::Buy, 200, 0);
+  order_queue.push(order1);
+  order_queue.push(order2);
+
+  auto cancel_error = std::unexpected(OrderError{404, "order not found"});
+  auto *raw_client = new TrackingRestClient(cancel_error);
+  std::unique_ptr<IRestClient> client(raw_client);
+  OrderGateway gateway(is_running, &order_queue, std::move(client),
+                       &position_manager_, &tracker_);
+  gateway.run();
+
+  int place_count = 0;
+  for (const auto &call : raw_client->calls) {
+    if (call.type == TrackingRestClient::Call::Place)
+      ++place_count;
+  }
+  EXPECT_EQ(place_count, 1);
+}
+
 TEST_F(CancelBeforeReplaceTest, SkipsNewOrderWhenCancelThrows) {
   std::atomic is_running(false);
   LockFreeMPSCQueue<Order> order_queue;

--- a/tests/test_pending_order_tracker.cpp
+++ b/tests/test_pending_order_tracker.cpp
@@ -30,7 +30,7 @@ TEST_F(PendingOrderTrackerTest, RecordAndRetrieve) {
   tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "order-abc");
   auto result = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(*result, "order-abc");
+  EXPECT_EQ(result->view(), "order-abc");
 }
 
 TEST_F(PendingOrderTrackerTest, RecordOverwritesPrevious) {
@@ -38,7 +38,7 @@ TEST_F(PendingOrderTrackerTest, RecordOverwritesPrevious) {
   tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "order-2");
   auto result = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(*result, "order-2");
+  EXPECT_EQ(result->view(), "order-2");
 }
 
 TEST_F(PendingOrderTrackerTest, OnCompletedRemovesMatchingId) {
@@ -53,7 +53,7 @@ TEST_F(PendingOrderTrackerTest, OnCompletedIgnoresMismatchedId) {
   tracker_.onOrderCompleted(makeSymbol("AAPL"), OrderSide::Buy, "order-old");
   auto result = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(*result, "order-new");
+  EXPECT_EQ(result->view(), "order-new");
 }
 
 struct SlotIndependenceParam {
@@ -83,8 +83,8 @@ TEST_P(SlotIndependenceTest, SlotsAreIndependent) {
   auto result_b = tracker_.getExistingOrder(makeSymbol(symbol_b), side_b);
   ASSERT_TRUE(result_a.has_value());
   ASSERT_TRUE(result_b.has_value());
-  EXPECT_EQ(*result_a, id_a);
-  EXPECT_EQ(*result_b, id_b);
+  EXPECT_EQ(result_a->view(), id_a);
+  EXPECT_EQ(result_b->view(), id_b);
 
   tracker_.onOrderCompleted(makeSymbol(symbol_a), side_a, id_a);
   EXPECT_FALSE(

--- a/tests/test_pending_order_tracker.cpp
+++ b/tests/test_pending_order_tracker.cpp
@@ -1,4 +1,6 @@
 #include "PendingOrderTracker.hpp"
+#include "ThreadGuard.hpp"
+#include <future>
 #include <gtest/gtest.h>
 #include <thread>
 
@@ -54,61 +56,85 @@ TEST_F(PendingOrderTrackerTest, OnCompletedIgnoresMismatchedId) {
   EXPECT_EQ(*result, "order-new");
 }
 
-TEST_F(PendingOrderTrackerTest, IndependentSlots) {
-  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "buy-order");
-  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Sell, "sell-order");
+struct SlotIndependenceParam {
+  const char *desc;
+  const char *symbol_a;
+  OrderSide side_a;
+  const char *id_a;
+  const char *symbol_b;
+  OrderSide side_b;
+  const char *id_b;
+};
 
-  auto buy = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
-  auto sell = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Sell);
-  ASSERT_TRUE(buy.has_value());
-  ASSERT_TRUE(sell.has_value());
-  EXPECT_EQ(*buy, "buy-order");
-  EXPECT_EQ(*sell, "sell-order");
+class SlotIndependenceTest
+    : public ::testing::TestWithParam<SlotIndependenceParam> {
+protected:
+  PendingOrderTracker tracker_;
+};
 
-  tracker_.onOrderCompleted(makeSymbol("AAPL"), OrderSide::Buy, "buy-order");
-  EXPECT_FALSE(tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy)
-                   .has_value());
-  EXPECT_TRUE(tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Sell)
-                  .has_value());
+TEST_P(SlotIndependenceTest, SlotsAreIndependent) {
+  const auto &[desc, symbol_a, side_a, id_a, symbol_b, side_b, id_b] =
+      GetParam();
+
+  tracker_.recordOrder(makeSymbol(symbol_a), side_a, id_a);
+  tracker_.recordOrder(makeSymbol(symbol_b), side_b, id_b);
+
+  auto result_a = tracker_.getExistingOrder(makeSymbol(symbol_a), side_a);
+  auto result_b = tracker_.getExistingOrder(makeSymbol(symbol_b), side_b);
+  ASSERT_TRUE(result_a.has_value());
+  ASSERT_TRUE(result_b.has_value());
+  EXPECT_EQ(*result_a, id_a);
+  EXPECT_EQ(*result_b, id_b);
+
+  tracker_.onOrderCompleted(makeSymbol(symbol_a), side_a, id_a);
+  EXPECT_FALSE(
+      tracker_.getExistingOrder(makeSymbol(symbol_a), side_a).has_value());
+  EXPECT_TRUE(
+      tracker_.getExistingOrder(makeSymbol(symbol_b), side_b).has_value());
 }
 
-TEST_F(PendingOrderTrackerTest, DifferentSymbolsAreIndependent) {
-  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "aapl-order");
-  tracker_.recordOrder(makeSymbol("TSLA"), OrderSide::Buy, "tsla-order");
-
-  auto aapl = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
-  auto tsla = tracker_.getExistingOrder(makeSymbol("TSLA"), OrderSide::Buy);
-  ASSERT_TRUE(aapl.has_value());
-  ASSERT_TRUE(tsla.has_value());
-  EXPECT_EQ(*aapl, "aapl-order");
-  EXPECT_EQ(*tsla, "tsla-order");
-}
+INSTANTIATE_TEST_SUITE_P(
+    SlotTypes, SlotIndependenceTest,
+    ::testing::Values(SlotIndependenceParam{"same symbol different sides",
+                                            "AAPL", OrderSide::Buy, "buy-order",
+                                            "AAPL", OrderSide::Sell,
+                                            "sell-order"},
+                      SlotIndependenceParam{
+                          "different symbols same side", "AAPL", OrderSide::Buy,
+                          "aapl-order", "TSLA", OrderSide::Buy, "tsla-order"}));
 
 TEST_F(PendingOrderTrackerTest, ConcurrentAccess) {
   constexpr int kIterations = 1000;
+  std::promise<void> done;
+  auto future = done.get_future();
 
-  std::thread writer1([&]() {
+  ThreadGuard writer1{std::thread([&]() {
     for (int i = 0; i < kIterations; ++i) {
       tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy,
                            "order-" + std::to_string(i));
     }
-  });
+  })};
 
-  std::thread writer2([&]() {
+  ThreadGuard writer2{std::thread([&]() {
     for (int i = 0; i < kIterations; ++i) {
       tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Sell,
                            "order-" + std::to_string(i));
     }
-  });
+  })};
 
-  std::thread reader([&]() {
+  ThreadGuard reader{std::thread([&]() {
     for (int i = 0; i < kIterations; ++i) {
       (void)tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
       (void)tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Sell);
     }
-  });
+    done.set_value();
+  })};
 
-  writer1.join();
-  writer2.join();
-  reader.join();
+  const auto status = future.wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready)
+      << "ConcurrentAccess test timed out — possible deadlock";
+
+  writer1.t.join();
+  writer2.t.join();
+  reader.t.join();
 }

--- a/tests/test_pending_order_tracker.cpp
+++ b/tests/test_pending_order_tracker.cpp
@@ -1,0 +1,114 @@
+#include "PendingOrderTracker.hpp"
+#include <gtest/gtest.h>
+#include <thread>
+
+namespace {
+
+SymbolKey makeSymbol(const char *s) {
+  SymbolKey key{};
+  std::memset(key.value, 0, sizeof(key.value));
+  auto len = (std::min)(std::strlen(s), sizeof(key.value));
+  std::memcpy(key.value, s, len);
+  return key;
+}
+
+} // namespace
+
+class PendingOrderTrackerTest : public ::testing::Test {
+protected:
+  PendingOrderTracker tracker_;
+};
+
+TEST_F(PendingOrderTrackerTest, GetReturnsNulloptWhenEmpty) {
+  EXPECT_FALSE(tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy)
+                   .has_value());
+}
+
+TEST_F(PendingOrderTrackerTest, RecordAndRetrieve) {
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "order-abc");
+  auto result = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "order-abc");
+}
+
+TEST_F(PendingOrderTrackerTest, RecordOverwritesPrevious) {
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "order-1");
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "order-2");
+  auto result = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "order-2");
+}
+
+TEST_F(PendingOrderTrackerTest, OnCompletedRemovesMatchingId) {
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "order-abc");
+  tracker_.onOrderCompleted(makeSymbol("AAPL"), OrderSide::Buy, "order-abc");
+  EXPECT_FALSE(tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy)
+                   .has_value());
+}
+
+TEST_F(PendingOrderTrackerTest, OnCompletedIgnoresMismatchedId) {
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "order-new");
+  tracker_.onOrderCompleted(makeSymbol("AAPL"), OrderSide::Buy, "order-old");
+  auto result = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "order-new");
+}
+
+TEST_F(PendingOrderTrackerTest, IndependentSlots) {
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "buy-order");
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Sell, "sell-order");
+
+  auto buy = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
+  auto sell = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Sell);
+  ASSERT_TRUE(buy.has_value());
+  ASSERT_TRUE(sell.has_value());
+  EXPECT_EQ(*buy, "buy-order");
+  EXPECT_EQ(*sell, "sell-order");
+
+  tracker_.onOrderCompleted(makeSymbol("AAPL"), OrderSide::Buy, "buy-order");
+  EXPECT_FALSE(tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy)
+                   .has_value());
+  EXPECT_TRUE(tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Sell)
+                  .has_value());
+}
+
+TEST_F(PendingOrderTrackerTest, DifferentSymbolsAreIndependent) {
+  tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy, "aapl-order");
+  tracker_.recordOrder(makeSymbol("TSLA"), OrderSide::Buy, "tsla-order");
+
+  auto aapl = tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
+  auto tsla = tracker_.getExistingOrder(makeSymbol("TSLA"), OrderSide::Buy);
+  ASSERT_TRUE(aapl.has_value());
+  ASSERT_TRUE(tsla.has_value());
+  EXPECT_EQ(*aapl, "aapl-order");
+  EXPECT_EQ(*tsla, "tsla-order");
+}
+
+TEST_F(PendingOrderTrackerTest, ConcurrentAccess) {
+  constexpr int kIterations = 1000;
+
+  std::thread writer1([&]() {
+    for (int i = 0; i < kIterations; ++i) {
+      tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Buy,
+                           "order-" + std::to_string(i));
+    }
+  });
+
+  std::thread writer2([&]() {
+    for (int i = 0; i < kIterations; ++i) {
+      tracker_.recordOrder(makeSymbol("AAPL"), OrderSide::Sell,
+                           "order-" + std::to_string(i));
+    }
+  });
+
+  std::thread reader([&]() {
+    for (int i = 0; i < kIterations; ++i) {
+      (void)tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Buy);
+      (void)tracker_.getExistingOrder(makeSymbol("AAPL"), OrderSide::Sell);
+    }
+  });
+
+  writer1.join();
+  writer2.join();
+  reader.join();
+}

--- a/tests/test_trading_engine.cpp
+++ b/tests/test_trading_engine.cpp
@@ -11,6 +11,11 @@ public:
   placeOrder(const Order & /*order*/) override {
     return OrderAck{"mock-id", "accepted"};
   }
+
+  std::expected<void, OrderError>
+  cancelOrder(std::string_view /*alpaca_order_id*/) override {
+    return {};
+  }
 };
 
 class TradingEngineTest : public ::testing::Test {


### PR DESCRIPTION
## Summary

- Add `cancelOrder` to `IRestClient` / `AlpacaRestClient` (DELETE /v2/orders/{id})
- Extract `alpaca_order_id` into FillEvent and CancelEvent for order lifecycle tracking
- New `PendingOrderTracker` maps (symbol, side) slots to outstanding Alpaca order IDs using TBB concurrent_hash_map
- OrderGateway now cancels the previous order on the same (symbol, side) before placing a new one
- FillListener notifies PendingOrderTracker on fill/cancel so slots stay in sync
- TradingEngine wires the tracker into both OrderGateway and FillListener
- Redefine hot path as network-to-network (WebSocket ingestion through REST submission) across rules and CLAUDE.md

Race handling: if the old order was already filled, Alpaca returns 422 -- the gateway logs and proceeds. The gateway does NOT call `onOrderCancelled()` for proactive cancels; only the fill listener handles position updates from WebSocket confirmations.

19 files changed, +998 -41. 190 tests passing.

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST order cancellation support.
  * Pending-order tracking to avoid duplicate placements and track lifecycle.
  * Fill/cancel events now include provider order IDs for reliable correlation.

* **Documentation**
  * New comprehensive low-latency engineering guidance and clarified hot‑path policies (zero‑allocation, non‑owning refs; no shared_ptr on hot path).

* **Tests**
  * Expanded tests covering cancellation, pending‑tracker behavior, and event parsing with order IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->