### PR TITLE
Add latency benchmarking with HdrHistogram

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >
   -*,
   clang-diagnostic-*,
   clang-analyzer-*,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-narrowing-conversions,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,8 @@ repos:
       - id: mdformat
         args: ["--wrap", "120"]
         files: \.(md|markdown)$
+        additional_dependencies:
+          - mdformat-tables
 
 ci:
   autofix_commit_msg: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,9 @@ Uses **Taskwarrior** with `project:rop` for all tasks.
 
 ## Web Research
 
+When looking up library APIs, usage patterns, or implementation details, use **Context7 MCP** (`resolve-library-id` then
+`query-docs`) to fetch up-to-date documentation. This applies to agents, skills, and interactive sessions alike.
+
 When implementing low-latency patterns, performance optimizations, or financial protocol integrations, **always search
 the web** for current best practices. Key topics to research as needed:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ find_package(GTest REQUIRED)
 find_package(TBB CONFIG REQUIRED)
 find_package(ixwebsocket CONFIG REQUIRED)
 find_package(msgpack-cxx CONFIG REQUIRED)
+find_package(hdr_histogram CONFIG REQUIRED)
 
 file(GLOB_RECURSE SOURCES src/*.cpp)
 file(GLOB_RECURSE HEADERS include/*.hpp)
@@ -100,7 +101,8 @@ target_link_libraries(
             cpr::cpr
             TBB::tbb
             ixwebsocket::ixwebsocket
-            msgpack-cxx)
+            msgpack-cxx
+            hdr_histogram::hdr_histogram_static)
 
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
@@ -127,7 +129,8 @@ target_link_libraries(
            GTest::gtest_main
            TBB::tbb
            ixwebsocket::ixwebsocket
-           msgpack-cxx)
+           msgpack-cxx
+           hdr_histogram::hdr_histogram_static)
 
 if(SANITIZER_ACTIVE AND NOT MSVC)
     target_compile_options(rich_on_tests PRIVATE ${SANITIZER_FLAGS})

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,1 +1,38 @@
-# TBD
+# Performance
+
+## Latency Measurement
+
+The engine tracks five latency metrics via HdrHistogram, reporting p50, p90, p99, p99.9 on shutdown (SIGINT/SIGTERM).
+
+### Hot path metrics
+
+| Metric | Start | End | |--------|-------|-----| | End-to-end | WebSocket recv (`arrivedAt`) | Order dequeued in
+OrderGateway | | ZMQ transport | `arrivedAt` (pre-publish) | Post-ZMQ recv in consumer | | Strategy + Risk | Post-ZMQ
+recv | Pre-MPSC queue push | | MPSC queue | Queue push (`queuedAt`) | Queue pop in OrderGateway |
+
+### Cold path metrics
+
+| Metric | Start | End | |--------|-------|-----| | Fill round-trip | REST `placeOrder` returns | Fill received via
+WebSocket |
+
+### Implementation
+
+- **Library:** HdrHistogram_c (vcpkg `hdr-histogram`)
+- **Recording:** `hdr_record_value_atomic()` with CAS for thread-safe writes from multiple consumer threads
+- **Timestamp source:** `clock_gettime(CLOCK_MONOTONIC)` via vDSO (~20ns overhead on Linux), `steady_clock` on other
+  platforms
+- **Output:** Console summary + per-metric files (`latency_<metric>.txt`) with full percentile distribution
+
+### Overhead
+
+Each measurement point calls `nowNanos()` which costs ~20ns via vDSO on Linux. Five measurement points add ~100ns total
+to the hot path. This is acceptable given the REST submission at the end of the pipeline is ~20-50ms.
+
+### Timestamps in Order struct
+
+The `Order` struct carries two timestamps without growing beyond 64 bytes (one cache line):
+
+- `arrivedAt` — copied from the triggering `MarketEvent`
+- `queuedAt` — set at MPSC queue push time in the consumer
+
+These use padding bytes that were previously unused.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,14 +6,18 @@ The engine tracks five latency metrics via HdrHistogram, reporting p50, p90, p99
 
 ### Hot path metrics
 
-- **End-to-end:** WebSocket recv (`arrivedAt`) to order dequeued in OrderGateway
-- **ZMQ transport:** `arrivedAt` (pre-publish) to post-ZMQ recv in consumer
-- **Strategy + Risk:** post-ZMQ recv to pre-MPSC queue push
-- **MPSC queue:** queue push (`queuedAt`) to queue pop in OrderGateway
+| Metric          | Start                        | End                            |
+| --------------- | ---------------------------- | ------------------------------ |
+| End-to-end      | WebSocket recv (`arrivedAt`) | Order dequeued in OrderGateway |
+| ZMQ transport   | `arrivedAt` (pre-publish)    | Post-ZMQ recv in consumer      |
+| Strategy + Risk | Post-ZMQ recv                | Pre-MPSC queue push            |
+| MPSC queue      | Queue push (`queuedAt`)      | Queue pop in OrderGateway      |
 
 ### Cold path metrics
 
-- **Fill round-trip:** REST `placeOrder` returns to fill received via WebSocket
+| Metric          | Start                     | End                         |
+| --------------- | ------------------------- | --------------------------- |
+| Fill round-trip | REST `placeOrder` returns | Fill received via WebSocket |
 
 ### Implementation
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,14 +6,14 @@ The engine tracks five latency metrics via HdrHistogram, reporting p50, p90, p99
 
 ### Hot path metrics
 
-| Metric | Start | End | |--------|-------|-----| | End-to-end | WebSocket recv (`arrivedAt`) | Order dequeued in
-OrderGateway | | ZMQ transport | `arrivedAt` (pre-publish) | Post-ZMQ recv in consumer | | Strategy + Risk | Post-ZMQ
-recv | Pre-MPSC queue push | | MPSC queue | Queue push (`queuedAt`) | Queue pop in OrderGateway |
+- **End-to-end:** WebSocket recv (`arrivedAt`) to order dequeued in OrderGateway
+- **ZMQ transport:** `arrivedAt` (pre-publish) to post-ZMQ recv in consumer
+- **Strategy + Risk:** post-ZMQ recv to pre-MPSC queue push
+- **MPSC queue:** queue push (`queuedAt`) to queue pop in OrderGateway
 
 ### Cold path metrics
 
-| Metric | Start | End | |--------|-------|-----| | Fill round-trip | REST `placeOrder` returns | Fill received via
-WebSocket |
+- **Fill round-trip:** REST `placeOrder` returns to fill received via WebSocket
 
 ### Implementation
 

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -41,6 +41,7 @@ using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 
 [[nodiscard]] TradeUpdate parseTradingUpdate(const nlohmann::json &parsed);
 
+class LatencyTracker;
 class PendingOrderTracker;
 
 class AlpacaFillListener : public IFillListener {
@@ -51,7 +52,8 @@ public:
   AlpacaFillListener(PositionManager *position_manager,
                      std::atomic<bool> &is_running, const std::string &api_key,
                      const std::string &api_secret,
-                     PendingOrderTracker *pending_tracker = nullptr);
+                     PendingOrderTracker *pending_tracker = nullptr,
+                     LatencyTracker *latency_tracker = nullptr);
 
   ~AlpacaFillListener() override;
 
@@ -66,6 +68,7 @@ private:
 
   PositionManager *position_manager_;
   PendingOrderTracker *pending_tracker_;
+  LatencyTracker *latency_tracker_;
   std::atomic<bool> &is_running_;
   std::string api_key_;
   std::string api_secret_;

--- a/include/LatencyTracker.hpp
+++ b/include/LatencyTracker.hpp
@@ -47,12 +47,12 @@ private:
       "end_to_end", "zmq_transport", "strategy_risk", "mpsc_queue",
       "fill_round_trip"};
 
-  static constexpr std::array<const char *, kMetricCount> kMetricDescriptions = {
-      "End-to-end hot path (WebSocket recv -> pre-REST call)",
-      "ZMQ transport (pre-publish -> post-receive)",
-      "Strategy + Risk check (post-ZMQ recv -> pre-queue push)",
-      "MPSC queue (push -> pop)",
-      "Fill round-trip [cold] (post-REST return -> fill received)"};
+  static constexpr std::array<const char *, kMetricCount> kMetricDescriptions =
+      {"End-to-end hot path (WebSocket recv -> pre-REST call)",
+       "ZMQ transport (pre-publish -> post-receive)",
+       "Strategy + Risk check (post-ZMQ recv -> pre-queue push)",
+       "MPSC queue (push -> pop)",
+       "Fill round-trip [cold] (post-REST return -> fill received)"};
 
   void dumpOne(LatencyMetric metric, const std::string &output_dir) const;
 

--- a/include/LatencyTracker.hpp
+++ b/include/LatencyTracker.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+struct hdr_histogram;
+
+enum class LatencyMetric : uint8_t {
+  EndToEnd,
+  ZmqTransport,
+  StrategyRisk,
+  MpscQueue,
+  FillRoundTrip,
+  Count
+};
+
+class LatencyTracker {
+public:
+  LatencyTracker();
+  ~LatencyTracker();
+
+  LatencyTracker(const LatencyTracker &) = delete;
+  LatencyTracker &operator=(const LatencyTracker &) = delete;
+  LatencyTracker(LatencyTracker &&) = delete;
+  LatencyTracker &operator=(LatencyTracker &&) = delete;
+
+  void record(LatencyMetric metric, uint64_t nanos) noexcept;
+  void recordOrderSubmit(std::string_view client_order_id);
+  void recordFillReceived(std::string_view client_order_id);
+  void dump(const std::string &output_dir = ".") const;
+
+  [[nodiscard]] int64_t percentile(LatencyMetric metric, double pct) const;
+  [[nodiscard]] int64_t count(LatencyMetric metric) const;
+
+private:
+  static constexpr size_t kMetricCount =
+      static_cast<size_t>(LatencyMetric::Count);
+  static constexpr int64_t kLowestTrackable = 1;
+  static constexpr int64_t kHighestTrackable = 60'000'000'000LL;
+  static constexpr int kSignificantDigits = 3;
+
+  static constexpr std::array<const char *, kMetricCount> kMetricNames = {
+      "end_to_end", "zmq_transport", "strategy_risk", "mpsc_queue",
+      "fill_round_trip"};
+
+  static constexpr std::array<const char *, kMetricCount> kMetricDescriptions = {
+      "End-to-end hot path (WebSocket recv -> pre-REST call)",
+      "ZMQ transport (pre-publish -> post-receive)",
+      "Strategy + Risk check (post-ZMQ recv -> pre-queue push)",
+      "MPSC queue (push -> pop)",
+      "Fill round-trip [cold] (post-REST return -> fill received)"};
+
+  void dumpOne(LatencyMetric metric, const std::string &output_dir) const;
+
+  std::array<hdr_histogram *, kMetricCount> histograms_{};
+
+  mutable std::mutex submit_mutex_;
+  std::unordered_map<std::string, uint64_t> submit_timestamps_;
+};

--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -20,10 +20,10 @@ public:
                       OrderCallbackType order_callback,
                       RiskManager *risk_manager,
                       LatencyTracker *latency_tracker = nullptr)
-      : subscriber_(context, zmq::socket_type::sub), symbol_{},
-        is_running_(is_running), order_callback_(order_callback),
-        strategy_(std::make_unique<StrategyType>()),
-        risk_manager_(risk_manager), latency_tracker_(latency_tracker) {
+      : is_running_(is_running), strategy_(std::make_unique<StrategyType>()),
+        risk_manager_(risk_manager), latency_tracker_(latency_tracker),
+        subscriber_(context, zmq::socket_type::sub),
+        order_callback_(order_callback), symbol_{} {
     if (symbol.size() > 8) {
       throw std::invalid_argument(
           "MarketEventConsumer symbol must be <= 8 bytes");
@@ -89,11 +89,11 @@ public:
   }
 
 private:
-  zmq::socket_t subscriber_;
-  char symbol_[9];
   std::atomic<bool> &is_running_;
-  OrderCallbackType order_callback_;
   std::unique_ptr<StrategyType> strategy_;
   RiskManager *risk_manager_;
   LatencyTracker *latency_tracker_;
+  zmq::socket_t subscriber_;
+  OrderCallbackType order_callback_;
+  char symbol_[9];
 };

--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -65,9 +65,9 @@ public:
       MarketEvent event{};
       std::memcpy(&event, payload.data(), sizeof(MarketEvent));
 
-      const uint64_t zmq_received_at = nowNanos();
-
+      uint64_t zmq_received_at = 0;
       if (latency_tracker_) [[likely]] {
+        zmq_received_at = nowNanos();
         latency_tracker_->record(LatencyMetric::ZmqTransport,
                                  zmq_received_at - event.arrivedAt);
       }

--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "LatencyTracker.hpp"
 #include "MarketEvent.hpp"
 #include "RiskManager.hpp"
 #include "Strategy.hpp"
+#include "Utils.hpp"
 #include <atomic>
 #include <cstring>
 #include <iostream>
@@ -16,11 +18,12 @@ public:
   MarketEventConsumer(zmq::context_t &context, const std::string &address,
                       const std::string &symbol, std::atomic<bool> &is_running,
                       OrderCallbackType order_callback,
-                      RiskManager *risk_manager)
+                      RiskManager *risk_manager,
+                      LatencyTracker *latency_tracker = nullptr)
       : subscriber_(context, zmq::socket_type::sub), symbol_{},
         is_running_(is_running), order_callback_(order_callback),
         strategy_(std::make_unique<StrategyType>()),
-        risk_manager_(risk_manager) {
+        risk_manager_(risk_manager), latency_tracker_(latency_tracker) {
     if (symbol.size() > 8) {
       throw std::invalid_argument(
           "MarketEventConsumer symbol must be <= 8 bytes");
@@ -61,8 +64,25 @@ public:
 
       MarketEvent event{};
       std::memcpy(&event, payload.data(), sizeof(MarketEvent));
+
+      const uint64_t zmq_received_at = nowNanos();
+
+      if (latency_tracker_) [[likely]] {
+        latency_tracker_->record(LatencyMetric::ZmqTransport,
+                                 zmq_received_at - event.arrivedAt);
+      }
+
       auto order = strategy_->onMarketEvent(event);
       if (order && risk_manager_->onNewOrder(*order)) {
+        const uint64_t pre_queue_at = nowNanos();
+
+        if (latency_tracker_) [[likely]] {
+          latency_tracker_->record(LatencyMetric::StrategyRisk,
+                                   pre_queue_at - zmq_received_at);
+        }
+
+        order->arrivedAt = event.arrivedAt;
+        order->queuedAt = pre_queue_at;
         order_callback_(*order);
       }
     }
@@ -75,4 +95,5 @@ private:
   OrderCallbackType order_callback_;
   std::unique_ptr<StrategyType> strategy_;
   RiskManager *risk_manager_;
+  LatencyTracker *latency_tracker_;
 };

--- a/include/Order.hpp
+++ b/include/Order.hpp
@@ -16,6 +16,8 @@ struct alignas(64) Order {
   uint64_t price;
   OrderSide side;
   OrderType type;
+  uint64_t arrivedAt;
+  uint64_t queuedAt;
 };
 
 static_assert(sizeof(Order) == 64, "Order must be exactly one cache line");

--- a/include/OrderGateway.hpp
+++ b/include/OrderGateway.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <memory>
 
+class LatencyTracker;
 class PendingOrderTracker;
 class PositionManager;
 
@@ -15,7 +16,8 @@ public:
                LockFreeMPSCQueue<Order> *order_queue,
                std::unique_ptr<IRestClient> rest_client,
                PositionManager *position_manager,
-               PendingOrderTracker *pending_tracker = nullptr);
+               PendingOrderTracker *pending_tracker = nullptr,
+               LatencyTracker *latency_tracker = nullptr);
 
   void run();
 
@@ -27,5 +29,6 @@ private:
   std::unique_ptr<IRestClient> rest_client_;
   PositionManager *position_manager_;
   PendingOrderTracker *pending_tracker_;
+  LatencyTracker *latency_tracker_;
   uint64_t order_id_counter_ = 0;
 };

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -64,6 +64,7 @@ private:
   std::atomic<bool> shutdown_done_{false};
   std::string ipc_address_;
   std::vector<std::string> symbols_;
+  std::unique_ptr<LatencyTracker> latency_tracker_;
   std::unique_ptr<PositionManager> position_manager_;
   std::unique_ptr<OrderCooldown> order_cooldown_;
   std::unique_ptr<RiskManager> risk_manager_;
@@ -75,5 +76,4 @@ private:
   std::vector<ConsumerThread> consumer_threads_;
   std::unique_ptr<IFillListener> fill_listener_;
   std::unique_ptr<AlpacaPipeline> market_publisher_;
-  std::unique_ptr<LatencyTracker> latency_tracker_;
 };

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -61,6 +61,7 @@ private:
   void shutdown();
 
   std::atomic<bool> is_running_;
+  std::atomic<bool> shutdown_done_{false};
   std::string ipc_address_;
   std::vector<std::string> symbols_;
   std::unique_ptr<PositionManager> position_manager_;

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -2,6 +2,7 @@
 
 #include "AlpacaPipeline.hpp"
 #include "IRestClient.hpp"
+#include "LatencyTracker.hpp"
 #include "LockFreeMPSCQueue.hpp"
 #include "MarketEventConsumer.hpp"
 #include "Order.hpp"
@@ -73,4 +74,5 @@ private:
   std::vector<ConsumerThread> consumer_threads_;
   std::unique_ptr<IFillListener> fill_listener_;
   std::unique_ptr<AlpacaPipeline> market_publisher_;
+  std::unique_ptr<LatencyTracker> latency_tracker_;
 };

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaFillListener.hpp"
+#include "LatencyTracker.hpp"
 #include "PendingOrderTracker.hpp"
 #include "ThreadPinning.hpp"
 #include <algorithm>
@@ -164,9 +165,11 @@ AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
                                        std::atomic<bool> &is_running,
                                        const std::string &api_key,
                                        const std::string &api_secret,
-                                       PendingOrderTracker *pending_tracker)
+                                       PendingOrderTracker *pending_tracker,
+                                       LatencyTracker *latency_tracker)
     : position_manager_(position_manager), pending_tracker_(pending_tracker),
-      is_running_(is_running), api_key_(api_key), api_secret_(api_secret) {
+      latency_tracker_(latency_tracker), is_running_(is_running),
+      api_key_(api_key), api_secret_(api_secret) {
   if (position_manager_ == nullptr) {
     throw std::invalid_argument(
         "AlpacaFillListener: position_manager must not be null");
@@ -291,12 +294,15 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     fill.quantity = fill_event.quantity;
     fill.price = fill_event.price;
     position_manager_->onFill(fill);
+    std::string_view order_id(
+        fill_event.alpaca_order_id,
+        strnlen(fill_event.alpaca_order_id, kOrderIdCapacity));
+    if (latency_tracker_ && !order_id.empty()) {
+      latency_tracker_->recordFillReceived(order_id);
+    }
     if (pending_tracker_ && !fill_event.is_partial) {
       SymbolKey key{};
       std::memcpy(key.value, fill_event.symbol, kSymbolCapacity);
-      std::string_view order_id(
-          fill_event.alpaca_order_id,
-          strnlen(fill_event.alpaca_order_id, kOrderIdCapacity));
       pending_tracker_->onOrderCompleted(key, fill_event.side, order_id);
     }
     std::cout << "FillListener: "

--- a/src/LatencyTracker.cpp
+++ b/src/LatencyTracker.cpp
@@ -1,0 +1,145 @@
+#include "LatencyTracker.hpp"
+#include "Utils.hpp"
+#include <cstdio>
+#include <fstream>
+#include <hdr/hdr_histogram.h>
+#include <iostream>
+#include <stdexcept>
+
+LatencyTracker::LatencyTracker() {
+  for (size_t i = 0; i < kMetricCount; ++i) {
+    if (hdr_init(kLowestTrackable, kHighestTrackable, kSignificantDigits,
+                 &histograms_[i]) != 0) {
+      for (size_t j = 0; j < i; ++j) {
+        hdr_close(histograms_[j]);
+      }
+      throw std::runtime_error("Failed to initialize HdrHistogram");
+    }
+  }
+}
+
+LatencyTracker::~LatencyTracker() {
+  for (auto *h : histograms_) {
+    if (h) {
+      hdr_close(h);
+    }
+  }
+}
+
+void LatencyTracker::record(LatencyMetric metric, uint64_t nanos) noexcept {
+  const auto idx = static_cast<size_t>(metric);
+  if (idx >= kMetricCount) [[unlikely]] {
+    return;
+  }
+  hdr_record_value_atomic(histograms_[idx], static_cast<int64_t>(nanos));
+}
+
+void LatencyTracker::recordOrderSubmit(
+    std::string_view client_order_id) {
+  const uint64_t now = nowNanos();
+  std::lock_guard lock(submit_mutex_);
+  submit_timestamps_[std::string(client_order_id)] = now;
+}
+
+void LatencyTracker::recordFillReceived(
+    std::string_view client_order_id) {
+  const uint64_t now = nowNanos();
+  std::lock_guard lock(submit_mutex_);
+  if (auto it = submit_timestamps_.find(std::string(client_order_id));
+      it != submit_timestamps_.end()) {
+    const uint64_t latency = now - it->second;
+    hdr_record_value_atomic(
+        histograms_[static_cast<size_t>(LatencyMetric::FillRoundTrip)],
+        static_cast<int64_t>(latency));
+    submit_timestamps_.erase(it);
+  }
+}
+
+int64_t LatencyTracker::percentile(LatencyMetric metric, double pct) const {
+  const auto idx = static_cast<size_t>(metric);
+  if (idx >= kMetricCount) {
+    return 0;
+  }
+  return hdr_value_at_percentile(histograms_[idx], pct);
+}
+
+int64_t LatencyTracker::count(LatencyMetric metric) const {
+  const auto idx = static_cast<size_t>(metric);
+  if (idx >= kMetricCount) {
+    return 0;
+  }
+  return histograms_[idx]->total_count;
+}
+
+void LatencyTracker::dumpOne(LatencyMetric metric,
+                             const std::string &output_dir) const {
+  const auto idx = static_cast<size_t>(metric);
+  auto *h = histograms_[idx];
+  const char *name = kMetricNames[idx];
+  const char *desc = kMetricDescriptions[idx];
+
+  if (h->total_count == 0) {
+    std::cout << "\n=== " << desc << " ===\n";
+    std::cout << "  (no samples recorded)\n";
+    return;
+  }
+
+  const auto p50 = hdr_value_at_percentile(h, 50.0);
+  const auto p90 = hdr_value_at_percentile(h, 90.0);
+  const auto p99 = hdr_value_at_percentile(h, 99.0);
+  const auto p999 = hdr_value_at_percentile(h, 99.9);
+  const auto min_val = hdr_min(h);
+  const auto max_val = hdr_max(h);
+  const auto mean_val = hdr_mean(h);
+
+  std::cout << "\n=== " << desc << " ===\n";
+  std::cout << "  Samples: " << h->total_count << '\n';
+
+  auto fmt = [](int64_t nanos) -> std::string {
+    char buf[64];
+    if (nanos < 1000) {
+      std::snprintf(buf, sizeof(buf), "%ldns", static_cast<long>(nanos));
+    } else if (nanos < 1'000'000) {
+      std::snprintf(buf, sizeof(buf), "%.2fus",
+                    static_cast<double>(nanos) / 1000.0);
+    } else if (nanos < 1'000'000'000) {
+      std::snprintf(buf, sizeof(buf), "%.2fms",
+                    static_cast<double>(nanos) / 1'000'000.0);
+    } else {
+      std::snprintf(buf, sizeof(buf), "%.3fs",
+                    static_cast<double>(nanos) / 1'000'000'000.0);
+    }
+    return buf;
+  };
+
+  std::cout << "  Min:     " << fmt(min_val) << '\n';
+  std::cout << "  Mean:    " << fmt(static_cast<int64_t>(mean_val)) << '\n';
+  std::cout << "  p50:     " << fmt(p50) << '\n';
+  std::cout << "  p90:     " << fmt(p90) << '\n';
+  std::cout << "  p99:     " << fmt(p99) << '\n';
+  std::cout << "  p99.9:   " << fmt(p999) << '\n';
+  std::cout << "  Max:     " << fmt(max_val) << '\n';
+
+  const std::string filepath = output_dir + "/latency_" + name + ".txt";
+  FILE *fp = std::fopen(filepath.c_str(), "w");
+  if (fp) {
+    std::fprintf(fp, "%s\n", desc);
+    std::fprintf(fp, "Samples: %ld\n\n", static_cast<long>(h->total_count));
+    hdr_percentiles_print(h, fp, 5, 1.0, CLASSIC);
+    std::fclose(fp);
+    std::cout << "  Written: " << filepath << '\n';
+  }
+}
+
+void LatencyTracker::dump(const std::string &output_dir) const {
+  std::cout << "\n"
+            << "========================================\n"
+            << "  LATENCY REPORT\n"
+            << "========================================\n";
+
+  for (size_t i = 0; i < kMetricCount; ++i) {
+    dumpOne(static_cast<LatencyMetric>(i), output_dir);
+  }
+
+  std::cout << "========================================\n";
+}

--- a/src/LatencyTracker.cpp
+++ b/src/LatencyTracker.cpp
@@ -1,5 +1,6 @@
 #include "LatencyTracker.hpp"
 #include "Utils.hpp"
+#include <cinttypes>
 #include <cstdio>
 #include <fstream>
 #include <hdr/hdr_histogram.h>
@@ -96,7 +97,7 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   auto fmt = [](int64_t nanos) -> std::string {
     char buf[64];
     if (nanos < 1000) {
-      std::snprintf(buf, sizeof(buf), "%ldns", static_cast<long>(nanos));
+      std::snprintf(buf, sizeof(buf), "%" PRId64 "ns", nanos);
     } else if (nanos < 1'000'000) {
       std::snprintf(buf, sizeof(buf), "%.2fus",
                     static_cast<double>(nanos) / 1000.0);
@@ -122,7 +123,8 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   FILE *fp = std::fopen(filepath.c_str(), "w");
   if (fp) {
     std::fprintf(fp, "%s\n", desc);
-    std::fprintf(fp, "Samples: %ld\n\n", static_cast<long>(h->total_count));
+    std::fprintf(fp, "Samples: %" PRId64 "\n\n",
+                 static_cast<int64_t>(h->total_count));
     hdr_percentiles_print(h, fp, 5, 1.0, CLASSIC);
     std::fclose(fp);
     std::cout << "  Written: " << filepath << '\n';

--- a/src/LatencyTracker.cpp
+++ b/src/LatencyTracker.cpp
@@ -1,10 +1,11 @@
 #include "LatencyTracker.hpp"
 #include "Utils.hpp"
-#include <cinttypes>
 #include <cstdio>
 #include <fstream>
 #include <hdr/hdr_histogram.h>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 LatencyTracker::LatencyTracker() {
@@ -95,20 +96,20 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   std::cout << "  Samples: " << h->total_count << '\n';
 
   auto fmt = [](int64_t nanos) -> std::string {
-    char buf[64];
+    std::ostringstream oss;
     if (nanos < 1000) {
-      std::snprintf(buf, sizeof(buf), "%" PRId64 "ns", nanos);
+      oss << nanos << "ns";
     } else if (nanos < 1'000'000) {
-      std::snprintf(buf, sizeof(buf), "%.2fus",
-                    static_cast<double>(nanos) / 1000.0);
+      oss << std::fixed << std::setprecision(2)
+          << (static_cast<double>(nanos) / 1000.0) << "us";
     } else if (nanos < 1'000'000'000) {
-      std::snprintf(buf, sizeof(buf), "%.2fms",
-                    static_cast<double>(nanos) / 1'000'000.0);
+      oss << std::fixed << std::setprecision(2)
+          << (static_cast<double>(nanos) / 1'000'000.0) << "ms";
     } else {
-      std::snprintf(buf, sizeof(buf), "%.3fs",
-                    static_cast<double>(nanos) / 1'000'000'000.0);
+      oss << std::fixed << std::setprecision(3)
+          << (static_cast<double>(nanos) / 1'000'000'000.0) << "s";
     }
-    return buf;
+    return oss.str();
   };
 
   std::cout << "  Min:     " << fmt(min_val) << '\n';
@@ -120,11 +121,15 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   std::cout << "  Max:     " << fmt(max_val) << '\n';
 
   const std::string filepath = output_dir + "/latency_" + name + ".txt";
-  FILE *fp = std::fopen(filepath.c_str(), "w");
+  {
+    std::ofstream file(filepath);
+    if (!file.is_open()) {
+      return;
+    }
+    file << desc << "\nSamples: " << h->total_count << "\n\n";
+  }
+  FILE *fp = std::fopen(filepath.c_str(), "a");
   if (fp) {
-    std::fprintf(fp, "%s\n", desc);
-    std::fprintf(fp, "Samples: %" PRId64 "\n\n",
-                 static_cast<int64_t>(h->total_count));
     hdr_percentiles_print(h, fp, 5, 1.0, CLASSIC);
     std::fclose(fp);
     std::cout << "  Written: " << filepath << '\n';

--- a/src/LatencyTracker.cpp
+++ b/src/LatencyTracker.cpp
@@ -1,6 +1,5 @@
 #include "LatencyTracker.hpp"
 #include "Utils.hpp"
-#include <cstdio>
 #include <fstream>
 #include <hdr/hdr_histogram.h>
 #include <iomanip>
@@ -126,17 +125,13 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
     return;
   }
   file << desc << "\nSamples: " << h->total_count << "\n\n";
-
-  FILE *tmp = std::tmpfile();
-  if (tmp) {
-    hdr_percentiles_print(h, tmp, 5, 1.0, CLASSIC);
-    std::fseek(tmp, 0, SEEK_SET);
-    char buf[4096];
-    while (std::size_t n = std::fread(buf, 1, sizeof(buf), tmp)) {
-      file.write(buf, static_cast<std::streamsize>(n));
-    }
-    std::fclose(tmp);
-  }
+  file << "Min:     " << fmt(min_val) << '\n';
+  file << "Mean:    " << fmt(static_cast<int64_t>(mean_val)) << '\n';
+  file << "p50:     " << fmt(p50) << '\n';
+  file << "p90:     " << fmt(p90) << '\n';
+  file << "p99:     " << fmt(p99) << '\n';
+  file << "p99.9:   " << fmt(p999) << '\n';
+  file << "Max:     " << fmt(max_val) << '\n';
   std::cout << "  Written: " << filepath << '\n';
 }
 

--- a/src/LatencyTracker.cpp
+++ b/src/LatencyTracker.cpp
@@ -121,19 +121,23 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   std::cout << "  Max:     " << fmt(max_val) << '\n';
 
   const std::string filepath = output_dir + "/latency_" + name + ".txt";
-  {
-    std::ofstream file(filepath);
-    if (!file.is_open()) {
-      return;
+  std::ofstream file(filepath);
+  if (!file.is_open()) {
+    return;
+  }
+  file << desc << "\nSamples: " << h->total_count << "\n\n";
+
+  FILE *tmp = std::tmpfile();
+  if (tmp) {
+    hdr_percentiles_print(h, tmp, 5, 1.0, CLASSIC);
+    std::fseek(tmp, 0, SEEK_SET);
+    char buf[4096];
+    while (std::size_t n = std::fread(buf, 1, sizeof(buf), tmp)) {
+      file.write(buf, static_cast<std::streamsize>(n));
     }
-    file << desc << "\nSamples: " << h->total_count << "\n\n";
+    std::fclose(tmp);
   }
-  FILE *fp = std::fopen(filepath.c_str(), "a");
-  if (fp) {
-    hdr_percentiles_print(h, fp, 5, 1.0, CLASSIC);
-    std::fclose(fp);
-    std::cout << "  Written: " << filepath << '\n';
-  }
+  std::cout << "  Written: " << filepath << '\n';
 }
 
 void LatencyTracker::dump(const std::string &output_dir) const {

--- a/src/LatencyTracker.cpp
+++ b/src/LatencyTracker.cpp
@@ -34,15 +34,13 @@ void LatencyTracker::record(LatencyMetric metric, uint64_t nanos) noexcept {
   hdr_record_value_atomic(histograms_[idx], static_cast<int64_t>(nanos));
 }
 
-void LatencyTracker::recordOrderSubmit(
-    std::string_view client_order_id) {
+void LatencyTracker::recordOrderSubmit(std::string_view client_order_id) {
   const uint64_t now = nowNanos();
   std::lock_guard lock(submit_mutex_);
   submit_timestamps_[std::string(client_order_id)] = now;
 }
 
-void LatencyTracker::recordFillReceived(
-    std::string_view client_order_id) {
+void LatencyTracker::recordFillReceived(std::string_view client_order_id) {
   const uint64_t now = nowNanos();
   std::lock_guard lock(submit_mutex_);
   if (auto it = submit_timestamps_.find(std::string(client_order_id));

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -1,6 +1,8 @@
 #include "OrderGateway.hpp"
+#include "LatencyTracker.hpp"
 #include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
+#include "Utils.hpp"
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -9,10 +11,11 @@ OrderGateway::OrderGateway(std::atomic<bool> &is_running,
                            LockFreeMPSCQueue<Order> *order_queue,
                            std::unique_ptr<IRestClient> rest_client,
                            PositionManager *position_manager,
-                           PendingOrderTracker *pending_tracker)
+                           PendingOrderTracker *pending_tracker,
+                           LatencyTracker *latency_tracker)
     : is_running_(is_running), order_queue_(order_queue),
       rest_client_(std::move(rest_client)), position_manager_(position_manager),
-      pending_tracker_(pending_tracker) {
+      pending_tracker_(pending_tracker), latency_tracker_(latency_tracker) {
   if (order_queue_ == nullptr) {
     throw std::invalid_argument("OrderGateway: order_queue must not be null");
   }
@@ -72,6 +75,9 @@ void OrderGateway::executeOrder(const Order &order) {
       if (pending_tracker_) {
         pending_tracker_->recordOrder(key, order.side, result->client_order_id);
       }
+      if (latency_tracker_) {
+        latency_tracker_->recordOrderSubmit(result->client_order_id);
+      }
     } else {
       std::cerr << "OrderGateway: Rejected (HTTP " << result.error().status_code
                 << "): " << result.error().message << '\n';
@@ -89,13 +95,31 @@ void OrderGateway::executeOrder(const Order &order) {
 void OrderGateway::run() {
   Order order_to_execute{};
   while (order_queue_->wait_and_pop(order_to_execute, is_running_)) {
+    const uint64_t dequeued_at = nowNanos();
     order_to_execute.id = ++order_id_counter_;
+
+    if (latency_tracker_) {
+      latency_tracker_->record(LatencyMetric::MpscQueue,
+                               dequeued_at - order_to_execute.queuedAt);
+      latency_tracker_->record(LatencyMetric::EndToEnd,
+                               dequeued_at - order_to_execute.arrivedAt);
+    }
+
     executeOrder(order_to_execute);
   }
 
   Order remaining_order{};
   while (order_queue_->try_pop(remaining_order)) {
+    const uint64_t dequeued_at = nowNanos();
     remaining_order.id = ++order_id_counter_;
+
+    if (latency_tracker_) {
+      latency_tracker_->record(LatencyMetric::MpscQueue,
+                               dequeued_at - remaining_order.queuedAt);
+      latency_tracker_->record(LatencyMetric::EndToEnd,
+                               dequeued_at - remaining_order.arrivedAt);
+    }
+
     executeOrder(remaining_order);
   }
 }

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -19,7 +19,6 @@ void signalHandler(const int signum) {
 TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
                              std::unique_ptr<IRestClient> rest_client)
     : is_running_(true), symbols_(symbols) {
-  setup_signal_handler();
   latency_tracker_ = std::make_unique<LatencyTracker>();
   position_manager_ = std::make_unique<PositionManager>();
   for (const auto &symbol : symbols_) {
@@ -55,6 +54,8 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
   auto sink = ZmqMarketEventSink(context_, ipc_address_);
   market_publisher_ = std::make_unique<AlpacaPipeline>(
       std::move(source), std::move(decoder), std::move(sink));
+
+  setup_signal_handler();
 }
 
 TradingEngine::~TradingEngine() {

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -112,6 +112,10 @@ void TradingEngine::main_loop() const {
 }
 
 void TradingEngine::shutdown() {
+  if (shutdown_done_.exchange(true)) {
+    return;
+  }
+
   market_publisher_->stop();
 
   for (auto &[thread, consumer] : consumer_threads_) {

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -4,7 +4,6 @@
 #include "Utils.hpp"
 #include <csignal>
 #include <cstdlib>
-#include <filesystem>
 #include <iostream>
 
 namespace {
@@ -21,6 +20,7 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
                              std::unique_ptr<IRestClient> rest_client)
     : is_running_(true), symbols_(symbols) {
   setup_signal_handler();
+  latency_tracker_ = std::make_unique<LatencyTracker>();
   position_manager_ = std::make_unique<PositionManager>();
   for (const auto &symbol : symbols_) {
     position_manager_->registerSymbol(symbol);
@@ -35,7 +35,7 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
   order_queue_ = std::make_unique<LockFreeMPSCQueue<Order>>();
   order_gateway_ = std::make_unique<OrderGateway>(
       is_running_, order_queue_.get(), std::move(rest_client),
-      position_manager_.get(), pending_tracker_.get());
+      position_manager_.get(), pending_tracker_.get(), latency_tracker_.get());
 
   const char *api_key = std::getenv("APCA_API_KEY_ID");
   const char *api_secret = std::getenv("APCA_API_SECRET_KEY");
@@ -45,7 +45,7 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
   }
   fill_listener_ = std::make_unique<AlpacaFillListener>(
       position_manager_.get(), is_running_, api_key, api_secret,
-      pending_tracker_.get());
+      pending_tracker_.get(), latency_tracker_.get());
 
   ipc_address_ = getZmqMarketDataAddress();
 
@@ -93,7 +93,7 @@ void TradingEngine::launch_consumers() {
 
     auto consumer = std::make_unique<ConsumerType>(
         context_, ipc_address_, symbol, is_running_, callback,
-        risk_manager_.get());
+        risk_manager_.get(), latency_tracker_.get());
 
     consumer_threads_.push_back(
         {std::thread(&ConsumerType::run, consumer.get()), std::move(consumer)});
@@ -127,6 +127,10 @@ void TradingEngine::shutdown() {
     order_gateway_thread_.join();
   }
   order_gateway_.reset();
+
+  if (latency_tracker_) {
+    latency_tracker_->dump(".");
+  }
 }
 
 void TradingEngine::run() {

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -133,7 +133,13 @@ void TradingEngine::shutdown() {
   order_gateway_.reset();
 
   if (latency_tracker_) {
-    latency_tracker_->dump(".");
+    try {
+      latency_tracker_->dump(".");
+    } catch (const std::exception &e) {
+      std::cerr << "Latency tracker dump failed: " << e.what() << '\n';
+    } catch (...) {
+      std::cerr << "Latency tracker dump failed with unknown error" << '\n';
+    }
   }
 }
 

--- a/src/ZmqMarketEventSink.cpp
+++ b/src/ZmqMarketEventSink.cpp
@@ -30,9 +30,11 @@ void ZmqMarketEventSink::stop() {}
 void ZmqMarketEventSink::publish(const MarketEvent &event,
                                  std::string_view symbol) {
   const auto topic_len = (std::min)(symbol.size(), kSymbolCapacity);
-  auto res =
-      zmq_pub_.send(zmq::buffer(symbol.data(), topic_len),
-                    zmq::send_flags::sndmore | zmq::send_flags::dontwait);
+  auto res = zmq_pub_.send(
+      zmq::buffer(symbol.data(), topic_len),
+      zmq::send_flags::sndmore |
+          zmq::send_flags::
+              dontwait); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
   if (!res.has_value()) {
     return;
   }

--- a/src/ZmqMarketEventSink.cpp
+++ b/src/ZmqMarketEventSink.cpp
@@ -30,11 +30,9 @@ void ZmqMarketEventSink::stop() {}
 void ZmqMarketEventSink::publish(const MarketEvent &event,
                                  std::string_view symbol) {
   const auto topic_len = (std::min)(symbol.size(), kSymbolCapacity);
-  auto res = zmq_pub_.send(
-      zmq::buffer(symbol.data(), topic_len),
-      zmq::send_flags::sndmore |
-          zmq::send_flags::
-              dontwait); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+  auto res =
+      zmq_pub_.send(zmq::buffer(symbol.data(), topic_len),
+                    zmq::send_flags::sndmore | zmq::send_flags::dontwait);
   if (!res.has_value()) {
     return;
   }

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaFillListener.hpp"
+#include "LatencyTracker.hpp"
 #include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
 #include "TestHelpers.hpp"
@@ -553,6 +554,36 @@ TEST_F(FillListenerTrackerTest, PartialFillDoesNotClearTracker) {
   })");
 
   EXPECT_TRUE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
+}
+
+TEST_F(FillListenerTrackerTest, FillRecordsLatencyWhenTrackerProvided) {
+  auto latency_tracker = std::make_unique<LatencyTracker>();
+  latency_tracker->recordOrderSubmit("latency-order-id");
+
+  listener_ = std::make_unique<AlpacaFillListener>(
+      position_manager_.get(), is_running_, "test_key", "test_secret",
+      tracker_.get(), latency_tracker.get());
+
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Buy, "latency-order-id");
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {"symbol": "AAPL", "side": "buy", "id": "latency-order-id"}
+    }
+  })");
+
+  EXPECT_EQ(latency_tracker->count(LatencyMetric::FillRoundTrip), 1);
+  EXPECT_GT(latency_tracker->percentile(LatencyMetric::FillRoundTrip, 50.0), 0);
 }
 
 TEST_F(FillListenerTrackerTest, CancelNotifiesTracker) {

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -1,0 +1,171 @@
+#include "LatencyTracker.hpp"
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+#include <thread>
+#include <vector>
+
+class LatencyTrackerTest : public ::testing::Test {
+protected:
+  LatencyTracker tracker_;
+};
+
+TEST_F(LatencyTrackerTest, RecordAndRetrievePercentile) {
+  for (int i = 1; i <= 1000; ++i) {
+    tracker_.record(LatencyMetric::EndToEnd, static_cast<uint64_t>(i) * 1000);
+  }
+
+  EXPECT_EQ(tracker_.count(LatencyMetric::EndToEnd), 1000);
+
+  const auto p50 = tracker_.percentile(LatencyMetric::EndToEnd, 50.0);
+  EXPECT_GE(p50, 400'000);
+  EXPECT_LE(p50, 600'000);
+
+  const auto p99 = tracker_.percentile(LatencyMetric::EndToEnd, 99.0);
+  EXPECT_GE(p99, 900'000);
+}
+
+TEST_F(LatencyTrackerTest, EmptyHistogramReturnsZero) {
+  EXPECT_EQ(tracker_.count(LatencyMetric::MpscQueue), 0);
+  EXPECT_EQ(tracker_.percentile(LatencyMetric::MpscQueue, 50.0), 0);
+}
+
+TEST_F(LatencyTrackerTest, MultipleMetricsAreIndependent) {
+  tracker_.record(LatencyMetric::ZmqTransport, 5000);
+  tracker_.record(LatencyMetric::StrategyRisk, 3000);
+
+  EXPECT_EQ(tracker_.count(LatencyMetric::ZmqTransport), 1);
+  EXPECT_EQ(tracker_.count(LatencyMetric::StrategyRisk), 1);
+  EXPECT_EQ(tracker_.count(LatencyMetric::EndToEnd), 0);
+}
+
+TEST_F(LatencyTrackerTest, InvalidMetricDoesNotCrash) {
+  tracker_.record(static_cast<LatencyMetric>(255), 1000);
+  EXPECT_EQ(tracker_.percentile(static_cast<LatencyMetric>(255), 50.0), 0);
+  EXPECT_EQ(tracker_.count(static_cast<LatencyMetric>(255)), 0);
+}
+
+TEST_F(LatencyTrackerTest, ConcurrentRecordFromMultipleThreads) {
+  constexpr int num_threads = 8;
+  constexpr int samples_per_thread = 10000;
+
+  std::atomic<bool> start{false};
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+
+  for (int t = 0; t < num_threads; ++t) {
+    threads.emplace_back([&, t]() {
+      while (!start.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < samples_per_thread; ++i) {
+        tracker_.record(
+            LatencyMetric::ZmqTransport,
+            static_cast<uint64_t>(t + 1) * 1000 + static_cast<uint64_t>(i));
+      }
+    });
+  }
+
+  start.store(true, std::memory_order_release);
+  for (auto &t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(tracker_.count(LatencyMetric::ZmqTransport),
+            num_threads * samples_per_thread);
+}
+
+TEST_F(LatencyTrackerTest, FillRoundTripTracking) {
+  tracker_.recordOrderSubmit("order-abc");
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  tracker_.recordFillReceived("order-abc");
+
+  EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 1);
+  EXPECT_GE(tracker_.percentile(LatencyMetric::FillRoundTrip, 50.0), 50'000);
+}
+
+TEST_F(LatencyTrackerTest, FillWithUnknownOrderIdIsIgnored) {
+  tracker_.recordFillReceived("unknown-order");
+  EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 0);
+}
+
+TEST_F(LatencyTrackerTest, DumpProducesFiles) {
+  const auto tmp = std::filesystem::temp_directory_path() / "latency_test";
+  std::filesystem::create_directories(tmp);
+
+  tracker_.record(LatencyMetric::EndToEnd, 50'000);
+  tracker_.record(LatencyMetric::EndToEnd, 100'000);
+  tracker_.dump(tmp.string());
+
+  EXPECT_TRUE(
+      std::filesystem::exists(tmp / "latency_end_to_end.txt"));
+
+  std::filesystem::remove_all(tmp);
+}
+
+TEST_F(LatencyTrackerTest, DumpEmptyMetricsDoesNotCrash) {
+  const auto tmp =
+      std::filesystem::temp_directory_path() / "latency_empty_test";
+  std::filesystem::create_directories(tmp);
+
+  tracker_.dump(tmp.string());
+
+  EXPECT_FALSE(
+      std::filesystem::exists(tmp / "latency_end_to_end.txt"));
+
+  std::filesystem::remove_all(tmp);
+}
+
+TEST_F(LatencyTrackerTest, DuplicateSubmitOverwritesTimestamp) {
+  tracker_.recordOrderSubmit("order-dup");
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  tracker_.recordOrderSubmit("order-dup");
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  tracker_.recordFillReceived("order-dup");
+
+  EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 1);
+  const auto latency =
+      tracker_.percentile(LatencyMetric::FillRoundTrip, 50.0);
+  EXPECT_LT(latency, 500'000);
+}
+
+TEST_F(LatencyTrackerTest, FillBeforeSubmitIsIgnored) {
+  tracker_.recordFillReceived("order-never-submitted");
+  EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 0);
+}
+
+TEST_F(LatencyTrackerTest, LargeLatencyValuesRecorded) {
+  const uint64_t large_value = 59'000'000'000ULL;
+  tracker_.record(LatencyMetric::EndToEnd, large_value);
+
+  EXPECT_EQ(tracker_.count(LatencyMetric::EndToEnd), 1);
+  const auto p50 = tracker_.percentile(LatencyMetric::EndToEnd, 50.0);
+  EXPECT_GE(p50, 58'000'000'000LL);
+}
+
+TEST_F(LatencyTrackerTest, DumpWritesAllMetricFiles) {
+  const auto tmp =
+      std::filesystem::temp_directory_path() / "latency_all_metrics";
+  std::filesystem::create_directories(tmp);
+
+  tracker_.record(LatencyMetric::EndToEnd, 1000);
+  tracker_.record(LatencyMetric::ZmqTransport, 2000);
+  tracker_.record(LatencyMetric::StrategyRisk, 3000);
+  tracker_.record(LatencyMetric::MpscQueue, 4000);
+  tracker_.record(LatencyMetric::FillRoundTrip, 5000);
+  tracker_.dump(tmp.string());
+
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_end_to_end.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_zmq_transport.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_strategy_risk.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_mpsc_queue.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_fill_round_trip.txt"));
+
+  std::ifstream file(tmp / "latency_end_to_end.txt");
+  std::string first_line;
+  std::getline(file, first_line);
+  EXPECT_FALSE(first_line.empty());
+
+  std::filesystem::remove_all(tmp);
+}

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -42,9 +42,9 @@ TEST_F(LatencyTrackerTest, MultipleMetricsAreIndependent) {
 }
 
 TEST_F(LatencyTrackerTest, InvalidMetricDoesNotCrash) {
-  tracker_.record(static_cast<LatencyMetric>(255), 1000);
-  EXPECT_EQ(tracker_.percentile(static_cast<LatencyMetric>(255), 50.0), 0);
-  EXPECT_EQ(tracker_.count(static_cast<LatencyMetric>(255)), 0);
+  tracker_.record(LatencyMetric::Count, 1000);
+  EXPECT_EQ(tracker_.percentile(LatencyMetric::Count, 50.0), 0);
+  EXPECT_EQ(tracker_.count(LatencyMetric::Count), 0);
 }
 
 TEST_F(LatencyTrackerTest, ConcurrentRecordFromMultipleThreads) {

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -127,9 +127,14 @@ TEST_F(LatencyTrackerTest, DuplicateSubmitOverwritesTimestamp) {
   EXPECT_LT(latency, 40'000'000);
 }
 
-TEST_F(LatencyTrackerTest, FillBeforeSubmitIsIgnored) {
-  tracker_.recordFillReceived("order-never-submitted");
-  EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 0);
+TEST_F(LatencyTrackerTest, SecondFillForSameOrderIsIgnored) {
+  tracker_.recordOrderSubmit("order-once");
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  tracker_.recordFillReceived("order-once");
+  EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 1);
+
+  tracker_.recordFillReceived("order-once");
+  EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 1);
 }
 
 TEST_F(LatencyTrackerTest, LargeLatencyValuesRecorded) {

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -146,6 +146,25 @@ TEST_F(LatencyTrackerTest, LargeLatencyValuesRecorded) {
   EXPECT_GE(p50, 58'000'000'000LL);
 }
 
+TEST_F(LatencyTrackerTest, DumpFormatsAllLatencyRanges) {
+  const auto tmp =
+      std::filesystem::temp_directory_path() / "latency_fmt_ranges";
+  std::filesystem::create_directories(tmp);
+
+  tracker_.record(LatencyMetric::EndToEnd, 500);
+  tracker_.record(LatencyMetric::ZmqTransport, 50'000);
+  tracker_.record(LatencyMetric::StrategyRisk, 5'000'000);
+  tracker_.record(LatencyMetric::MpscQueue, 2'000'000'000);
+  tracker_.dump(tmp.string());
+
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_end_to_end.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_zmq_transport.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_strategy_risk.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_mpsc_queue.txt"));
+
+  std::filesystem::remove_all(tmp);
+}
+
 TEST_F(LatencyTrackerTest, DumpWritesAllMetricFiles) {
   const auto tmp =
       std::filesystem::temp_directory_path() / "latency_all_metrics";

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -117,14 +117,14 @@ TEST_F(LatencyTrackerTest, DumpEmptyMetricsDoesNotCrash) {
 
 TEST_F(LatencyTrackerTest, DuplicateSubmitOverwritesTimestamp) {
   tracker_.recordOrderSubmit("order-dup");
-  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
   tracker_.recordOrderSubmit("order-dup");
-  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
   tracker_.recordFillReceived("order-dup");
 
   EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 1);
   const auto latency = tracker_.percentile(LatencyMetric::FillRoundTrip, 50.0);
-  EXPECT_LT(latency, 500'000);
+  EXPECT_LT(latency, 40'000'000);
 }
 
 TEST_F(LatencyTrackerTest, FillBeforeSubmitIsIgnored) {

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -146,34 +146,15 @@ TEST_F(LatencyTrackerTest, LargeLatencyValuesRecorded) {
   EXPECT_GE(p50, 58'000'000'000LL);
 }
 
-TEST_F(LatencyTrackerTest, DumpFormatsAllLatencyRanges) {
+TEST_F(LatencyTrackerTest, DumpWritesAllMetricFilesAndFormatsAllRanges) {
   const auto tmp =
-      std::filesystem::temp_directory_path() / "latency_fmt_ranges";
+      std::filesystem::temp_directory_path() / "latency_all_metrics";
   std::filesystem::create_directories(tmp);
 
   tracker_.record(LatencyMetric::EndToEnd, 500);
   tracker_.record(LatencyMetric::ZmqTransport, 50'000);
   tracker_.record(LatencyMetric::StrategyRisk, 5'000'000);
   tracker_.record(LatencyMetric::MpscQueue, 2'000'000'000);
-  tracker_.dump(tmp.string());
-
-  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_end_to_end.txt"));
-  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_zmq_transport.txt"));
-  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_strategy_risk.txt"));
-  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_mpsc_queue.txt"));
-
-  std::filesystem::remove_all(tmp);
-}
-
-TEST_F(LatencyTrackerTest, DumpWritesAllMetricFiles) {
-  const auto tmp =
-      std::filesystem::temp_directory_path() / "latency_all_metrics";
-  std::filesystem::create_directories(tmp);
-
-  tracker_.record(LatencyMetric::EndToEnd, 1000);
-  tracker_.record(LatencyMetric::ZmqTransport, 2000);
-  tracker_.record(LatencyMetric::StrategyRisk, 3000);
-  tracker_.record(LatencyMetric::MpscQueue, 4000);
   tracker_.record(LatencyMetric::FillRoundTrip, 5000);
   tracker_.dump(tmp.string());
 

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -60,9 +60,9 @@ TEST_F(LatencyTrackerTest, ConcurrentRecordFromMultipleThreads) {
       while (!start.load(std::memory_order_acquire)) {
       }
       for (int i = 0; i < samples_per_thread; ++i) {
-        tracker_.record(
-            LatencyMetric::ZmqTransport,
-            static_cast<uint64_t>(t + 1) * 1000 + static_cast<uint64_t>(i));
+        tracker_.record(LatencyMetric::ZmqTransport,
+                        static_cast<uint64_t>(t + 1) * 1000 +
+                            static_cast<uint64_t>(i));
       }
     });
   }
@@ -98,8 +98,7 @@ TEST_F(LatencyTrackerTest, DumpProducesFiles) {
   tracker_.record(LatencyMetric::EndToEnd, 100'000);
   tracker_.dump(tmp.string());
 
-  EXPECT_TRUE(
-      std::filesystem::exists(tmp / "latency_end_to_end.txt"));
+  EXPECT_TRUE(std::filesystem::exists(tmp / "latency_end_to_end.txt"));
 
   std::filesystem::remove_all(tmp);
 }
@@ -111,8 +110,7 @@ TEST_F(LatencyTrackerTest, DumpEmptyMetricsDoesNotCrash) {
 
   tracker_.dump(tmp.string());
 
-  EXPECT_FALSE(
-      std::filesystem::exists(tmp / "latency_end_to_end.txt"));
+  EXPECT_FALSE(std::filesystem::exists(tmp / "latency_end_to_end.txt"));
 
   std::filesystem::remove_all(tmp);
 }
@@ -125,8 +123,7 @@ TEST_F(LatencyTrackerTest, DuplicateSubmitOverwritesTimestamp) {
   tracker_.recordFillReceived("order-dup");
 
   EXPECT_EQ(tracker_.count(LatencyMetric::FillRoundTrip), 1);
-  const auto latency =
-      tracker_.percentile(LatencyMetric::FillRoundTrip, 50.0);
+  const auto latency = tracker_.percentile(LatencyMetric::FillRoundTrip, 50.0);
   EXPECT_LT(latency, 500'000);
 }
 

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -164,10 +164,12 @@ TEST_F(LatencyTrackerTest, DumpWritesAllMetricFilesAndFormatsAllRanges) {
   EXPECT_TRUE(std::filesystem::exists(tmp / "latency_mpsc_queue.txt"));
   EXPECT_TRUE(std::filesystem::exists(tmp / "latency_fill_round_trip.txt"));
 
-  std::ifstream file(tmp / "latency_end_to_end.txt");
-  std::string first_line;
-  std::getline(file, first_line);
-  EXPECT_FALSE(first_line.empty());
+  {
+    std::ifstream file(tmp / "latency_end_to_end.txt");
+    std::string first_line;
+    std::getline(file, first_line);
+    EXPECT_FALSE(first_line.empty());
+  }
 
   std::filesystem::remove_all(tmp);
 }

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -3,6 +3,7 @@
 #include "Order.hpp"
 #include "PositionManager.hpp"
 #include "ThreadGuard.hpp"
+#include "Utils.hpp"
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -237,4 +238,53 @@ TEST_F(MarketEventConsumerTest, SkipsMismatchedPayloadSize) {
 
   EXPECT_EQ(CountingStrategy::invocation_count.load(std::memory_order_relaxed),
             0);
+}
+
+TEST_F(MarketEventConsumerTest, PropagatesTimestampsToOrder) {
+  zmq::context_t context(1);
+  zmq::socket_t publisher(context, zmq::socket_type::pub);
+  publisher.bind(ipc_address);
+
+  std::atomic is_test_running(true);
+  std::promise<Order> promise;
+  auto future = promise.get_future();
+  PromiseOrderCallback test_callback{&promise};
+
+  MarketEventConsumer<MockStrategy, PromiseOrderCallback> consumer(
+      context, ipc_address, "TEST", is_test_running, test_callback,
+      risk_manager_.get());
+
+  ThreadGuard consumer_thread_guard{
+      std::thread(&MarketEventConsumer<MockStrategy, PromiseOrderCallback>::run,
+                  &consumer)};
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  MarketEvent sent_event{};
+  sent_event.eventType = 2;
+  const uint64_t known_arrived_at = nowNanos();
+  sent_event.arrivedAt = known_arrived_at;
+
+  auto start_time = std::chrono::steady_clock::now();
+  while (future.wait_for(std::chrono::milliseconds(10)) !=
+         std::future_status::ready) {
+    zmq::message_t topic("TEST", 4);
+    zmq::message_t payload(&sent_event, sizeof(MarketEvent));
+    publisher.send(topic, zmq::send_flags::sndmore);
+    publisher.send(payload, zmq::send_flags::none);
+    if (std::chrono::steady_clock::now() - start_time >
+        std::chrono::seconds(2)) {
+      break;
+    }
+  }
+
+  is_test_running.store(false);
+
+  ASSERT_TRUE(future.valid());
+  auto status = future.wait_for(std::chrono::seconds(0));
+  ASSERT_EQ(status, std::future_status::ready);
+  Order received_order = future.get();
+  EXPECT_EQ(received_order.arrivedAt, known_arrived_at);
+  EXPECT_GT(received_order.queuedAt, 0U);
+  EXPECT_GE(received_order.queuedAt, known_arrived_at);
 }

--- a/tests/test_market_event_consumer.cpp
+++ b/tests/test_market_event_consumer.cpp
@@ -1,3 +1,4 @@
+#include "LatencyTracker.hpp"
 #include "MarketEvent.hpp"
 #include "MarketEventConsumer.hpp"
 #include "Order.hpp"
@@ -287,4 +288,54 @@ TEST_F(MarketEventConsumerTest, PropagatesTimestampsToOrder) {
   EXPECT_EQ(received_order.arrivedAt, known_arrived_at);
   EXPECT_GT(received_order.queuedAt, 0U);
   EXPECT_GE(received_order.queuedAt, known_arrived_at);
+}
+
+TEST_F(MarketEventConsumerTest, RecordsLatencyMetricsWhenTrackerProvided) {
+  zmq::context_t context(1);
+  zmq::socket_t publisher(context, zmq::socket_type::pub);
+  publisher.bind(ipc_address);
+
+  std::atomic is_test_running(true);
+  std::promise<Order> promise;
+  auto future = promise.get_future();
+  PromiseOrderCallback test_callback{&promise};
+  LatencyTracker tracker;
+
+  MarketEventConsumer<MockStrategy, PromiseOrderCallback> consumer(
+      context, ipc_address, "TEST", is_test_running, test_callback,
+      risk_manager_.get(), &tracker);
+
+  ThreadGuard consumer_thread_guard{
+      std::thread(&MarketEventConsumer<MockStrategy, PromiseOrderCallback>::run,
+                  &consumer)};
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  MarketEvent sent_event{};
+  sent_event.eventType = 2;
+  sent_event.arrivedAt = nowNanos();
+
+  auto start_time = std::chrono::steady_clock::now();
+  while (future.wait_for(std::chrono::milliseconds(10)) !=
+         std::future_status::ready) {
+    zmq::message_t topic("TEST", 4);
+    zmq::message_t payload(&sent_event, sizeof(MarketEvent));
+    publisher.send(topic, zmq::send_flags::sndmore);
+    publisher.send(payload, zmq::send_flags::none);
+    if (std::chrono::steady_clock::now() - start_time >
+        std::chrono::seconds(2)) {
+      break;
+    }
+  }
+
+  is_test_running.store(false);
+
+  ASSERT_TRUE(future.valid());
+  auto status = future.wait_for(std::chrono::seconds(0));
+  ASSERT_EQ(status, std::future_status::ready);
+
+  EXPECT_GE(tracker.count(LatencyMetric::ZmqTransport), 1);
+  EXPECT_GE(tracker.count(LatencyMetric::StrategyRisk), 1);
+  EXPECT_GT(tracker.percentile(LatencyMetric::ZmqTransport, 50.0), 0);
+  EXPECT_GT(tracker.percentile(LatencyMetric::StrategyRisk, 50.0), 0);
 }

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -1,4 +1,5 @@
 #include "IRestClient.hpp"
+#include "LatencyTracker.hpp"
 #include "LockFreeMPSCQueue.hpp"
 #include "Order.hpp"
 #include "OrderGateway.hpp"
@@ -6,6 +7,7 @@
 #include "PositionManager.hpp"
 #include "TestHelpers.hpp"
 #include "ThreadGuard.hpp"
+#include "Utils.hpp"
 #include <cstdint>
 #include <expected>
 #include <future>
@@ -555,4 +557,73 @@ TEST_F(CancelBeforeReplaceTest, DoesNotRecordFailedPlacement) {
   SymbolKey key{};
   std::memcpy(key.value, "AAPL", 4);
   EXPECT_FALSE(tracker_.getExistingOrder(key, OrderSide::Buy).has_value());
+}
+
+TEST_F(OrderGatewayTest, RecordsLatencyMetricsWhileRunning) {
+  std::atomic is_running(true);
+  LockFreeMPSCQueue<Order> order_queue;
+  std::promise<void> promise;
+  auto future = promise.get_future();
+  LatencyTracker tracker;
+
+  auto mock_client = std::make_unique<MockRestClient>(&promise);
+  OrderGateway gateway(is_running, &order_queue, std::move(mock_client),
+                       &position_manager_, nullptr, &tracker);
+
+  ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
+
+  Order order{};
+  order.arrivedAt = nowNanos();
+  order.queuedAt = nowNanos();
+  order_queue.push(order);
+
+  auto status = future.wait_for(std::chrono::seconds(2));
+  ASSERT_EQ(status, std::future_status::ready);
+  is_running.store(false);
+  guard.t.join();
+
+  EXPECT_EQ(tracker.count(LatencyMetric::MpscQueue), 1);
+  EXPECT_EQ(tracker.count(LatencyMetric::EndToEnd), 1);
+  EXPECT_GT(tracker.percentile(LatencyMetric::MpscQueue, 50.0), 0);
+  EXPECT_GT(tracker.percentile(LatencyMetric::EndToEnd, 50.0), 0);
+}
+
+TEST_F(OrderGatewayTest, RecordsLatencyMetricsDuringDrain) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+  LatencyTracker tracker;
+
+  Order order{};
+  order.arrivedAt = nowNanos();
+  order.queuedAt = nowNanos();
+  order_queue.push(order);
+
+  OrderGateway gateway(is_running, &order_queue,
+                       std::make_unique<MockRestClient>(), &position_manager_,
+                       nullptr, &tracker);
+  gateway.run();
+
+  EXPECT_EQ(tracker.count(LatencyMetric::MpscQueue), 1);
+  EXPECT_EQ(tracker.count(LatencyMetric::EndToEnd), 1);
+}
+
+TEST_F(OrderGatewayTest, RecordsOrderSubmitTimestamp) {
+  std::atomic is_running(false);
+  LockFreeMPSCQueue<Order> order_queue;
+  LatencyTracker tracker;
+
+  Order order{};
+  order.arrivedAt = nowNanos();
+  order.queuedAt = nowNanos();
+  order_queue.push(order);
+
+  OrderGateway gateway(is_running, &order_queue,
+                       std::make_unique<MockRestClient>(), &position_manager_,
+                       nullptr, &tracker);
+  gateway.run();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  tracker.recordFillReceived("ord-123");
+
+  EXPECT_EQ(tracker.count(LatencyMetric::FillRoundTrip), 1);
 }

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -588,7 +588,7 @@ TEST_F(OrderGatewayTest, RecordsLatencyMetricsWhileRunning) {
   EXPECT_GT(tracker.percentile(LatencyMetric::EndToEnd, 50.0), 0);
 }
 
-TEST_F(OrderGatewayTest, RecordsLatencyMetricsDuringDrain) {
+TEST_F(OrderGatewayTest, RecordsAllLatencyMetricsDuringDrain) {
   std::atomic is_running(false);
   LockFreeMPSCQueue<Order> order_queue;
   LatencyTracker tracker;
@@ -605,22 +605,6 @@ TEST_F(OrderGatewayTest, RecordsLatencyMetricsDuringDrain) {
 
   EXPECT_EQ(tracker.count(LatencyMetric::MpscQueue), 1);
   EXPECT_EQ(tracker.count(LatencyMetric::EndToEnd), 1);
-}
-
-TEST_F(OrderGatewayTest, RecordsOrderSubmitTimestamp) {
-  std::atomic is_running(false);
-  LockFreeMPSCQueue<Order> order_queue;
-  LatencyTracker tracker;
-
-  Order order{};
-  order.arrivedAt = nowNanos();
-  order.queuedAt = nowNanos();
-  order_queue.push(order);
-
-  OrderGateway gateway(is_running, &order_queue,
-                       std::make_unique<MockRestClient>(), &position_manager_,
-                       nullptr, &tracker);
-  gateway.run();
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
   tracker.recordFillReceived("ord-123");

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,8 @@
     "gtest",
     "tbb",
     "ixwebsocket",
-    "msgpack"
+    "msgpack",
+    "hdr-histogram"
   ],
   "builtin-baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1"
 }


### PR DESCRIPTION
## Summary

- Add LatencyTracker using HdrHistogram for lock-free nanosecond-precision
  recording across five metrics: end-to-end, ZMQ transport, strategy+risk,
  MPSC queue, and fill round-trip
- Instrument MarketEventConsumer, OrderGateway, and AlpacaFillListener with
  timestamp capture at each pipeline stage
- Add arrivedAt/queuedAt fields to Order struct (maintains 64-byte cache-line
  layout)
- TradingEngine owns the tracker and dumps a percentile report on shutdown
- 12 new tests covering recording, concurrency, fill tracking, timestamp
  propagation, dump output, and edge cases

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added latency measurement and tracking with percentiles, round-trip metrics, automatic metric dump on shutdown, and per-order arrivedAt/queuedAt timestamp propagation.

* **Documentation**
  * Added comprehensive PERFORMANCE.md describing metrics, formats, and overhead.

* **Tests**
  * Added tests for latency recording, percentiles, round-trip timing, timestamp propagation, concurrency, and dump output.

* **Chores**
  * Updated formatting tooling for table support and added histogram dependency for latency metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->