### PR TITLE
Rewrite AlpacaRestClient with persistent session and pre-built payloads

### DIFF
--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -4,6 +4,7 @@
 #include "Order.hpp"
 #include <cpr/cpr.h>
 #include <expected>
+#include <memory>
 #include <string>
 
 class AlpacaRestClient final : public IRestClient {
@@ -16,7 +17,7 @@ public:
   cancelOrder(std::string_view alpaca_order_id) override;
 
 private:
-  std::string api_key_;
-  std::string api_secret_;
-  cpr::Url base_url_;
+  std::unique_ptr<cpr::Session> session_;
+  std::string order_url_;
+  std::string cancel_url_prefix_;
 };

--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -17,7 +17,10 @@ public:
   cancelOrder(std::string_view alpaca_order_id) override;
 
 private:
+  void buildOrderPayload(const Order &order);
+
   std::unique_ptr<cpr::Session> session_;
   std::string order_url_;
   std::string cancel_url_prefix_;
+  std::string payload_buf_;
 };

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -2,7 +2,37 @@
 #include <cstring>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
-#include <string_view>
+#include <string>
+
+namespace {
+
+std::string buildOrderPayload(const Order &order) {
+  std::string payload;
+  payload.reserve(256);
+  payload += R"({"symbol":")";
+  payload.append(order.symbol, strnlen(order.symbol, sizeof(order.symbol)));
+  payload += R"(","qty":")";
+  payload += std::to_string(order.quantity);
+  payload += R"(","side":")";
+  payload += (order.side == OrderSide::Buy) ? "buy" : "sell";
+
+  if (order.type == OrderType::Market) {
+    payload += R"(","type":"market","time_in_force":"day"})";
+  } else {
+    payload += R"(","type":"limit","time_in_force":"day","limit_price":")";
+    const auto whole = order.price / SCALING_FACTOR;
+    const auto frac = order.price % SCALING_FACTOR;
+    payload += std::to_string(whole);
+    payload += '.';
+    auto frac_str = std::to_string(frac);
+    payload.append(4 - frac_str.size(), '0');
+    payload += frac_str;
+    payload += R"("})";
+  }
+  return payload;
+}
+
+} // namespace
 
 AlpacaRestClient::AlpacaRestClient() {
   const char *api_key_cstr = std::getenv("APCA_API_KEY_ID");
@@ -14,37 +44,25 @@ AlpacaRestClient::AlpacaRestClient() {
                              "APCA_API_SECRET_KEY not set in environment.");
   }
 
-  api_key_ = api_key_cstr;
-  api_secret_ = api_secret_cstr;
+  const std::string base_url =
+      base_url_cstr ? base_url_cstr : "https://paper-api.alpaca.markets";
 
-  if (base_url_cstr) {
-    base_url_ = cpr::Url{base_url_cstr};
-  } else {
-    base_url_ = cpr::Url{"https://paper-api.alpaca.markets"};
-  }
+  order_url_ = base_url + "/v2/orders";
+  cancel_url_prefix_ = base_url + "/v2/orders/";
+
+  session_ = std::make_unique<cpr::Session>();
+  session_->SetHeader(cpr::Header{{"APCA-API-KEY-ID", api_key_cstr},
+                                  {"APCA-API-SECRET-KEY", api_secret_cstr},
+                                  {"Content-Type", "application/json"}});
 }
 
 std::expected<OrderAck, OrderError>
 AlpacaRestClient::placeOrder(const Order &order) {
-  nlohmann::json payload;
-  payload["symbol"] = std::string_view(
-      order.symbol, strnlen(order.symbol, sizeof(order.symbol)));
-  payload["qty"] = std::to_string(order.quantity);
-  payload["side"] = (order.side == OrderSide::Buy) ? "buy" : "sell";
-  payload["type"] = (order.type == OrderType::Market) ? "market" : "limit";
-  payload["time_in_force"] = "day";
+  auto payload = buildOrderPayload(order);
 
-  if (order.type == OrderType::Limit) {
-    payload["limit_price"] =
-        std::to_string(static_cast<double>(order.price) / SCALING_FACTOR);
-  }
-
-  const cpr::Response r =
-      cpr::Post(cpr::Url{base_url_ + "/v2/orders"},
-                cpr::Header{{"APCA-API-KEY-ID", api_key_},
-                            {"APCA-API-SECRET-KEY", api_secret_},
-                            {"Content-Type", "application/json"}},
-                cpr::Body{payload.dump()});
+  session_->SetUrl(cpr::Url{order_url_});
+  session_->SetBody(cpr::Body{std::move(payload)});
+  const cpr::Response r = session_->Post();
 
   if (r.status_code >= 400) {
     return std::unexpected(
@@ -63,10 +81,9 @@ AlpacaRestClient::placeOrder(const Order &order) {
 
 std::expected<void, OrderError>
 AlpacaRestClient::cancelOrder(std::string_view alpaca_order_id) {
-  const cpr::Response r = cpr::Delete(
-      cpr::Url{base_url_ + "/v2/orders/" + std::string(alpaca_order_id)},
-      cpr::Header{{"APCA-API-KEY-ID", api_key_},
-                  {"APCA-API-SECRET-KEY", api_secret_}});
+  session_->SetUrl(cpr::Url{cancel_url_prefix_ + std::string(alpaca_order_id)});
+  session_->RemoveContent();
+  const cpr::Response r = session_->Delete();
 
   if (r.status_code == 204) {
     return {};

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -6,31 +6,28 @@
 
 namespace {
 
-std::string buildOrderPayload(const Order &order) {
-  std::string payload;
-  payload.reserve(256);
-  payload += R"({"symbol":")";
-  payload.append(order.symbol, strnlen(order.symbol, sizeof(order.symbol)));
-  payload += R"(","qty":")";
-  payload += std::to_string(order.quantity);
-  payload += R"(","side":")";
-  payload += (order.side == OrderSide::Buy) ? "buy" : "sell";
-
-  if (order.type == OrderType::Market) {
-    payload += R"(","type":"market","time_in_force":"day"})";
-  } else {
-    payload += R"(","type":"limit","time_in_force":"day","limit_price":")";
-    const auto whole = order.price / SCALING_FACTOR;
-    const auto frac = order.price % SCALING_FACTOR;
-    payload += std::to_string(whole);
-    payload += '.';
-    auto frac_str = std::to_string(frac);
-    payload.append(4 - frac_str.size(), '0');
-    payload += frac_str;
-    payload += R"("})";
+constexpr std::size_t kPriceDecimals = [] {
+  std::size_t digits = 0;
+  int64_t f = SCALING_FACTOR;
+  while (f > 1) {
+    f /= 10;
+    ++digits;
   }
-  return payload;
-}
+  return digits;
+}();
+
+static_assert(kPriceDecimals > 0);
+static_assert(
+    [] {
+      int64_t f = SCALING_FACTOR;
+      while (f > 1) {
+        if (f % 10 != 0)
+          return false;
+        f /= 10;
+      }
+      return f == 1;
+    }(),
+    "SCALING_FACTOR must be a power of 10");
 
 } // namespace
 
@@ -50,18 +47,47 @@ AlpacaRestClient::AlpacaRestClient() {
   order_url_ = base_url + "/v2/orders";
   cancel_url_prefix_ = base_url + "/v2/orders/";
 
+  payload_buf_.reserve(256);
+
   session_ = std::make_unique<cpr::Session>();
   session_->SetHeader(cpr::Header{{"APCA-API-KEY-ID", api_key_cstr},
                                   {"APCA-API-SECRET-KEY", api_secret_cstr},
                                   {"Content-Type", "application/json"}});
 }
 
+void AlpacaRestClient::buildOrderPayload(const Order &order) {
+  payload_buf_.clear();
+  payload_buf_ += R"({"symbol":")";
+  payload_buf_.append(order.symbol,
+                      strnlen(order.symbol, sizeof(order.symbol)));
+  payload_buf_ += R"(","qty":")";
+  payload_buf_ += std::to_string(order.quantity);
+  payload_buf_ += R"(","side":")";
+  payload_buf_ += (order.side == OrderSide::Buy) ? "buy" : "sell";
+
+  if (order.type == OrderType::Market) {
+    payload_buf_ += R"(","type":"market","time_in_force":"day"})";
+  } else {
+    payload_buf_ += R"(","type":"limit","time_in_force":"day","limit_price":")";
+    const auto whole = order.price / SCALING_FACTOR;
+    const auto frac = order.price % SCALING_FACTOR;
+    payload_buf_ += std::to_string(whole);
+    payload_buf_ += '.';
+    auto frac_str = std::to_string(frac);
+    if (frac_str.size() < kPriceDecimals) {
+      payload_buf_.append(kPriceDecimals - frac_str.size(), '0');
+    }
+    payload_buf_ += frac_str;
+    payload_buf_ += R"("})";
+  }
+}
+
 std::expected<OrderAck, OrderError>
 AlpacaRestClient::placeOrder(const Order &order) {
-  auto payload = buildOrderPayload(order);
+  buildOrderPayload(order);
 
   session_->SetUrl(cpr::Url{order_url_});
-  session_->SetBody(cpr::Body{std::move(payload)});
+  session_->SetBody(cpr::Body{payload_buf_});
   const cpr::Response r = session_->Post();
 
   if (r.status_code >= 400) {


### PR DESCRIPTION
## Summary

- Replace per-request `cpr::Post()`/`cpr::Delete()` with a persistent
  `cpr::Session` that reuses TCP+TLS connections via HTTP keep-alive,
  eliminating 20-50ms connection setup overhead per order
- Pre-build order URL, cancel URL prefix, and auth headers once at
  construction instead of per-request
- Replace `nlohmann::json` payload construction with a string builder
  (`reserve(256)`, zero reallocation) — removes nlohmann from the
  outer hot path
- Format `limit_price` with integer arithmetic (whole/frac) instead of
  floating-point division to avoid precision loss
- Call `RemoveContent()` before DELETE requests to clear stale POST body

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal REST client reworked for more efficient request handling: persistent session usage, centralized request construction, and streamlined URL/payload management. No changes to public APIs or method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->