### PR TITLE
Replace TBB concurrent_hash_map with lock-free position table

### DIFF
--- a/include/PendingOrderTracker.hpp
+++ b/include/PendingOrderTracker.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Order.hpp"
-#include "PositionManager.hpp"
+#include "SymbolKey.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <cstring>

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -2,60 +2,75 @@
 
 #include "Fill.hpp"
 #include "Order.hpp"
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdint>
 #include <cstring>
-#include <functional>
 #include <string_view>
-#include <tbb/concurrent_hash_map.h>
-
-struct SymbolKey {
-  char value[8] = {};
-
-  [[nodiscard]] bool operator==(const SymbolKey &other) const {
-    return std::memcmp(value, other.value, sizeof(value)) == 0;
-  }
-};
-
-static_assert(sizeof(SymbolKey) == 8, "SymbolKey must be exactly 8 bytes");
-
-struct SymbolKeyHashCompare {
-  [[nodiscard]] static std::size_t hash(const SymbolKey &k) {
-    return std::hash<std::string_view>{}(
-        std::string_view(k.value, sizeof(k.value)));
-  }
-
-  [[nodiscard]] static bool equal(const SymbolKey &lhs, const SymbolKey &rhs) {
-    return std::memcmp(lhs.value, rhs.value, sizeof(lhs.value)) == 0;
-  }
-};
-
-struct PositionState {
-  int64_t filled = 0;
-  int64_t pending = 0;
-};
-
-static_assert(sizeof(PositionState) == 16, "PositionState must be 16 bytes");
-static_assert(alignof(PositionState) == 8,
-              "PositionState must be 8-byte aligned");
 
 class PositionManager {
 public:
+  static constexpr uint32_t kMaxSymbols = 256;
+
   PositionManager() = default;
 
   void registerSymbol(std::string_view symbol);
   void onFill(const Fill &fill);
-  void onOrderSent(const Order &order);
+  void onOrderSent(const Order &order) noexcept;
   void onOrderCancelled(const Order &order);
 
   [[nodiscard]] int64_t getFilledPosition(std::string_view symbol) const;
   [[nodiscard]] int64_t getPendingPosition(std::string_view symbol) const;
-  [[nodiscard]] int64_t getTotalExposure(std::string_view symbol) const;
+  [[nodiscard]] int64_t
+  getTotalExposure(std::string_view symbol) const noexcept;
 
 private:
-  using PositionMap =
-      tbb::concurrent_hash_map<SymbolKey, PositionState, SymbolKeyHashCompare>;
+  static constexpr uint64_t kEmptySlot = UINT64_MAX;
+  static constexpr uint32_t kMask = kMaxSymbols - 1;
 
-  [[nodiscard]] static SymbolKey makeKey(std::string_view symbol);
-  [[nodiscard]] static SymbolKey makeKeyFromBuffer(const char *symbol_buffer);
+  struct alignas(64) Entry {
+    std::atomic<uint64_t> key{kEmptySlot};
+    std::atomic<int64_t> filled{0};
+    std::atomic<int64_t> pending{0};
+  };
 
-  mutable PositionMap positions_;
+  static_assert(sizeof(Entry) == 64, "Entry must be one cache line");
+  static_assert(alignof(Entry) == 64, "Entry must be cache-line aligned");
+
+  std::array<Entry, kMaxSymbols> table_{};
+
+  [[nodiscard]] static uint64_t symbolToKey(const char *data,
+                                            std::size_t len) noexcept {
+    uint64_t k = 0;
+    const auto copy_len = (std::min)(len, std::size_t{8});
+    if (copy_len > 0) {
+      std::memcpy(&k, data, copy_len);
+    }
+    return k;
+  }
+
+  [[nodiscard]] static uint64_t symbolToKey(std::string_view symbol) noexcept {
+    return symbolToKey(symbol.data(), symbol.size());
+  }
+
+  [[nodiscard]] static uint64_t symbolBufferToKey(const char *buffer) noexcept {
+    uint64_t k = 0;
+    std::memcpy(&k, buffer, 8);
+    return k;
+  }
+
+  [[nodiscard]] static uint32_t hash(uint64_t key) noexcept {
+    // splitmix64 finalizer — excellent distribution
+    key ^= key >> 33;
+    key *= 0xff51afd7ed558ccdULL;
+    key ^= key >> 33;
+    key *= 0xc4ceb9fe1a85ec53ULL;
+    key ^= key >> 33;
+    return static_cast<uint32_t>(key);
+  }
+
+  [[nodiscard]] Entry *findOrInsert(uint64_t symbol_key) noexcept;
+  [[nodiscard]] Entry *findMutable(uint64_t symbol_key) noexcept;
+  [[nodiscard]] const Entry *find(uint64_t symbol_key) const noexcept;
 };

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -38,6 +38,11 @@ private:
   static_assert(sizeof(Entry) == 64, "Entry must be one cache line");
   static_assert(alignof(Entry) == 64, "Entry must be cache-line aligned");
 
+  static_assert(sizeof(Order::symbol) == 8,
+                "Order::symbol must be 8 bytes for unique key encoding");
+  static_assert(sizeof(Fill::symbol) == 8,
+                "Fill::symbol must be 8 bytes for unique key encoding");
+
   std::array<Entry, kMaxSymbols> table_{};
 
   [[nodiscard]] static uint64_t symbolToKey(const char *data,

--- a/include/SymbolKey.hpp
+++ b/include/SymbolKey.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstring>
+#include <functional>
+#include <string_view>
+
+struct SymbolKey {
+  char value[8] = {};
+
+  [[nodiscard]] bool operator==(const SymbolKey &other) const {
+    return std::memcmp(value, other.value, sizeof(value)) == 0;
+  }
+};
+
+static_assert(sizeof(SymbolKey) == 8, "SymbolKey must be exactly 8 bytes");
+
+struct SymbolKeyHashCompare {
+  [[nodiscard]] static std::size_t hash(const SymbolKey &k) {
+    return std::hash<std::string_view>{}(
+        std::string_view(k.value, sizeof(k.value)));
+  }
+
+  [[nodiscard]] static bool equal(const SymbolKey &lhs, const SymbolKey &rhs) {
+    return std::memcmp(lhs.value, rhs.value, sizeof(lhs.value)) == 0;
+  }
+};

--- a/include/SymbolKey.hpp
+++ b/include/SymbolKey.hpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <functional>
 #include <string_view>
+#include <type_traits>
 
 struct SymbolKey {
   char value[8] = {};
@@ -13,6 +14,8 @@ struct SymbolKey {
 };
 
 static_assert(sizeof(SymbolKey) == 8, "SymbolKey must be exactly 8 bytes");
+static_assert(std::is_trivially_copyable_v<SymbolKey>,
+              "SymbolKey must be trivially copyable for hash map use");
 
 struct SymbolKeyHashCompare {
   [[nodiscard]] static std::size_t hash(const SymbolKey &k) {

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -2,6 +2,7 @@
 #include "LatencyTracker.hpp"
 #include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
+#include "SymbolKey.hpp"
 #include "Utils.hpp"
 #include <cstring>
 #include <iostream>

--- a/src/PositionManager.cpp
+++ b/src/PositionManager.cpp
@@ -1,43 +1,74 @@
 #include "PositionManager.hpp"
-#include "Utils.hpp"
 
-#include <algorithm>
-#include <cstring>
+PositionManager::Entry *
+PositionManager::findOrInsert(uint64_t symbol_key) noexcept {
+  const uint32_t start = hash(symbol_key) & kMask;
+  for (uint32_t i = 0; i < kMaxSymbols; ++i) {
+    auto &entry = table_[(start + i) & kMask];
+    uint64_t expected = entry.key.load(std::memory_order_acquire);
 
-namespace {
+    if (expected == symbol_key) {
+      return &entry;
+    }
 
-constexpr std::size_t kSymbolCapacity = sizeof(SymbolKey{}.value);
-
-}
-
-SymbolKey PositionManager::makeKey(std::string_view symbol) {
-  SymbolKey key{};
-  const auto copy_len = (std::min)(symbol.size(), kSymbolCapacity);
-  if (copy_len > 0) {
-    std::memcpy(key.value, symbol.data(), copy_len);
+    if (expected == kEmptySlot) {
+      if (entry.key.compare_exchange_strong(expected, symbol_key,
+                                            std::memory_order_release,
+                                            std::memory_order_acquire)) {
+        return &entry;
+      }
+      // CAS failed — another thread claimed this slot
+      if (expected == symbol_key) {
+        return &entry;
+      }
+      // Different key was inserted — continue probing
+    }
   }
-  return key;
+  return nullptr; // table full
 }
 
-SymbolKey PositionManager::makeKeyFromBuffer(const char *symbol_buffer) {
-  return makeKey(std::string_view(symbol_buffer, kSymbolCapacity));
+PositionManager::Entry *
+PositionManager::findMutable(uint64_t symbol_key) noexcept {
+  const uint32_t start = hash(symbol_key) & kMask;
+  for (uint32_t i = 0; i < kMaxSymbols; ++i) {
+    auto &entry = table_[(start + i) & kMask];
+    const uint64_t k = entry.key.load(std::memory_order_acquire);
+
+    if (k == symbol_key) {
+      return &entry;
+    }
+    if (k == kEmptySlot) {
+      return nullptr;
+    }
+  }
+  return nullptr;
+}
+
+const PositionManager::Entry *
+PositionManager::find(uint64_t symbol_key) const noexcept {
+  const uint32_t start = hash(symbol_key) & kMask;
+  for (uint32_t i = 0; i < kMaxSymbols; ++i) {
+    const auto &entry = table_[(start + i) & kMask];
+    const uint64_t k = entry.key.load(std::memory_order_acquire);
+
+    if (k == symbol_key) {
+      return &entry;
+    }
+    if (k == kEmptySlot) {
+      return nullptr;
+    }
+  }
+  return nullptr;
 }
 
 void PositionManager::registerSymbol(std::string_view symbol) {
-  const SymbolKey key = makeKey(symbol);
-  PositionMap::accessor accessor;
-  const bool inserted = positions_.insert(accessor, key);
-  if (inserted) {
-    accessor->second = {0, 0};
-  }
+  (void)findOrInsert(symbolToKey(symbol));
 }
 
 void PositionManager::onFill(const Fill &fill) {
-  const SymbolKey key = makeKeyFromBuffer(fill.symbol);
-  PositionMap::accessor accessor;
-  const bool inserted = positions_.insert(accessor, key);
-  if (inserted) {
-    accessor->second = {0, 0};
+  Entry *entry = findOrInsert(symbolBufferToKey(fill.symbol));
+  if (!entry) [[unlikely]] {
+    return;
   }
 
   int64_t delta = fill.quantity;
@@ -45,16 +76,14 @@ void PositionManager::onFill(const Fill &fill) {
     delta = -delta;
   }
 
-  accessor->second.filled += delta;
-  accessor->second.pending -= delta;
+  entry->filled.fetch_add(delta, std::memory_order_relaxed);
+  entry->pending.fetch_sub(delta, std::memory_order_relaxed);
 }
 
-void PositionManager::onOrderSent(const Order &order) {
-  const SymbolKey key = makeKeyFromBuffer(order.symbol);
-  PositionMap::accessor accessor;
-  const bool inserted = positions_.insert(accessor, key);
-  if (inserted) {
-    accessor->second = {0, 0};
+void PositionManager::onOrderSent(const Order &order) noexcept {
+  Entry *entry = findOrInsert(symbolBufferToKey(order.symbol));
+  if (!entry) [[unlikely]] {
+    return;
   }
 
   int64_t delta = order.quantity;
@@ -62,44 +91,45 @@ void PositionManager::onOrderSent(const Order &order) {
     delta = -delta;
   }
 
-  accessor->second.pending += delta;
+  entry->pending.fetch_add(delta, std::memory_order_relaxed);
 }
 
 void PositionManager::onOrderCancelled(const Order &order) {
-  const SymbolKey key = makeKeyFromBuffer(order.symbol);
-  PositionMap::accessor accessor;
-  if (positions_.find(accessor, key)) {
-    int64_t delta = order.quantity;
-    if (order.side == OrderSide::Sell) {
-      delta = -delta;
-    }
-    accessor->second.pending -= delta;
+  Entry *entry = findMutable(symbolBufferToKey(order.symbol));
+  if (!entry) [[unlikely]] {
+    return;
   }
+
+  int64_t delta = order.quantity;
+  if (order.side == OrderSide::Sell) {
+    delta = -delta;
+  }
+
+  entry->pending.fetch_sub(delta, std::memory_order_relaxed);
 }
 
 int64_t PositionManager::getFilledPosition(std::string_view symbol) const {
-  const SymbolKey key = makeKey(symbol);
-  PositionMap::const_accessor accessor;
-  if (!positions_.find(accessor, key)) {
+  const Entry *entry = find(symbolToKey(symbol));
+  if (!entry) {
     return 0;
   }
-  return accessor->second.filled;
+  return entry->filled.load(std::memory_order_relaxed);
 }
 
 int64_t PositionManager::getPendingPosition(std::string_view symbol) const {
-  const SymbolKey key = makeKey(symbol);
-  PositionMap::const_accessor accessor;
-  if (!positions_.find(accessor, key)) {
+  const Entry *entry = find(symbolToKey(symbol));
+  if (!entry) {
     return 0;
   }
-  return accessor->second.pending;
+  return entry->pending.load(std::memory_order_relaxed);
 }
 
-int64_t PositionManager::getTotalExposure(std::string_view symbol) const {
-  const SymbolKey key = makeKey(symbol);
-  PositionMap::const_accessor accessor;
-  if (!positions_.find(accessor, key)) {
+int64_t
+PositionManager::getTotalExposure(std::string_view symbol) const noexcept {
+  const Entry *entry = find(symbolToKey(symbol));
+  if (!entry) {
     return 0;
   }
-  return accessor->second.filled + accessor->second.pending;
+  return entry->filled.load(std::memory_order_relaxed) +
+         entry->pending.load(std::memory_order_relaxed);
 }

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -9,6 +9,7 @@
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
+#include <thread>
 
 class FillListenerTest : public ::testing::Test {
 protected:

--- a/tests/test_risk_manager.cpp
+++ b/tests/test_risk_manager.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include <memory>
+#include <thread>
 
 using test_helpers::createFill;
 using test_helpers::createOrder;


### PR DESCRIPTION
## Summary

- Replace TBB `concurrent_hash_map` in `PositionManager` with a flat, open-addressing hash table using atomic operations
- All hot-path position lookups (`getTotalExposure`) and updates (`onOrderSent`) are now truly lock-free — no TBB accessor locks
- Each entry is cache-line aligned (`alignas(64)`) with `std::atomic<int64_t>` for filled/pending values
- Concurrent insert via `compare_exchange_strong` on key slots, splitmix64 hash for distribution
- Extract `SymbolKey` to its own header since `PendingOrderTracker` still needs it

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned position tracking to a fixed-size, cache-line aligned 256‑entry table using lock‑free atomic counters; added noexcept guarantees and a documented max symbol count.
* **New**
  * Added a compact 8‑byte symbol key type for consistent symbol encoding.
* **Tests**
  * Updated tests to support multithreaded scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->