### PR TITLE
Add Alpaca rate limit tracking

### DIFF
--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -12,7 +12,7 @@ class AlpacaRestClient final : public IRestClient {
 public:
   explicit AlpacaRestClient(
       int64_t rate_limit_threshold = RateLimiter::kDefaultThreshold,
-      ThrottlePolicy throttle_policy = ThrottlePolicy::Wait);
+      ThrottlePolicy throttle_policy = ThrottlePolicy::Drop);
   [[nodiscard]] std::expected<OrderAck, OrderError>
   placeOrder(const Order &order) override;
 

--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -2,6 +2,7 @@
 
 #include "IRestClient.hpp"
 #include "Order.hpp"
+#include "RateLimiter.hpp"
 #include <cpr/cpr.h>
 #include <expected>
 #include <memory>
@@ -16,11 +17,15 @@ public:
   [[nodiscard]] std::expected<void, OrderError>
   cancelOrder(std::string_view alpaca_order_id) override;
 
+  [[nodiscard]] const RateLimiter &rateLimiter() const;
+
 private:
   void buildOrderPayload(const Order &order);
+  void updateRateLimit(const cpr::Response &r);
 
   std::unique_ptr<cpr::Session> session_;
   std::string order_url_;
   std::string cancel_url_prefix_;
   std::string payload_buf_;
+  RateLimiter rate_limiter_;
 };

--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -10,7 +10,9 @@
 
 class AlpacaRestClient final : public IRestClient {
 public:
-  AlpacaRestClient();
+  explicit AlpacaRestClient(
+      int64_t rate_limit_threshold = RateLimiter::kDefaultThreshold,
+      ThrottlePolicy throttle_policy = ThrottlePolicy::Wait);
   [[nodiscard]] std::expected<OrderAck, OrderError>
   placeOrder(const Order &order) override;
 

--- a/include/RateLimiter.hpp
+++ b/include/RateLimiter.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+enum class ThrottlePolicy : uint8_t {
+  Wait,
+  Drop,
+};
+
+class RateLimiter {
+public:
+  static constexpr int64_t kMaxRequestsPerWindow = 200;
+  static constexpr int64_t kDefaultThreshold = 10;
+  static constexpr int64_t kWindowDurationNs = 60'000'000'000LL;
+
+  explicit RateLimiter(int64_t threshold = kDefaultThreshold,
+                       ThrottlePolicy policy = ThrottlePolicy::Wait) noexcept;
+
+  void update(int64_t remaining) noexcept;
+  void onRateLimited() noexcept;
+
+  [[nodiscard]] bool canSend() const noexcept;
+
+  [[nodiscard]] bool waitOrDrop() const;
+
+  [[nodiscard]] int64_t remaining() const noexcept;
+  [[nodiscard]] int64_t threshold() const noexcept;
+  [[nodiscard]] ThrottlePolicy policy() const noexcept;
+
+private:
+  std::atomic<int64_t> remaining_{kMaxRequestsPerWindow};
+  mutable std::atomic<int64_t> throttle_start_ns_{0};
+  int64_t threshold_;
+  ThrottlePolicy policy_;
+};

--- a/include/RateLimiter.hpp
+++ b/include/RateLimiter.hpp
@@ -15,7 +15,7 @@ public:
   static constexpr int64_t kWindowDurationNs = 60'000'000'000LL;
 
   explicit RateLimiter(int64_t threshold = kDefaultThreshold,
-                       ThrottlePolicy policy = ThrottlePolicy::Wait) noexcept;
+                       ThrottlePolicy policy = ThrottlePolicy::Drop) noexcept;
 
   void update(int64_t remaining) noexcept;
   void onRateLimited() noexcept;

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaRestClient.hpp"
+#include <charconv>
 #include <cstring>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
@@ -31,7 +32,9 @@ static_assert(
 
 } // namespace
 
-AlpacaRestClient::AlpacaRestClient() {
+AlpacaRestClient::AlpacaRestClient(int64_t rate_limit_threshold,
+                                   ThrottlePolicy throttle_policy)
+    : rate_limiter_(rate_limit_threshold, throttle_policy) {
   const char *api_key_cstr = std::getenv("APCA_API_KEY_ID");
   const char *api_secret_cstr = std::getenv("APCA_API_SECRET_KEY");
   const char *base_url_cstr = std::getenv("APCA_API_BASE_URL");
@@ -89,7 +92,13 @@ void AlpacaRestClient::updateRateLimit(const cpr::Response &r) {
   }
   auto it = r.header.find("X-Ratelimit-Remaining");
   if (it != r.header.end()) {
-    rate_limiter_.update(std::stoll(it->second));
+    int64_t remaining = 0;
+    const auto &val = it->second;
+    auto [ptr, ec] =
+        std::from_chars(val.data(), val.data() + val.size(), remaining);
+    if (ec == std::errc{}) {
+      rate_limiter_.update((std::max)(remaining, int64_t{0}));
+    }
   }
 }
 

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -96,7 +96,7 @@ void AlpacaRestClient::updateRateLimit(const cpr::Response &r) {
     const auto &val = it->second;
     auto [ptr, ec] =
         std::from_chars(val.data(), val.data() + val.size(), remaining);
-    if (ec == std::errc{}) {
+    if (ec == std::errc{} && ptr == val.data() + val.size()) {
       rate_limiter_.update((std::max)(remaining, int64_t{0}));
     }
   }

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -82,13 +82,28 @@ void AlpacaRestClient::buildOrderPayload(const Order &order) {
   }
 }
 
+void AlpacaRestClient::updateRateLimit(const cpr::Response &r) {
+  if (r.status_code == 429) {
+    rate_limiter_.onRateLimited();
+    return;
+  }
+  auto it = r.header.find("X-Ratelimit-Remaining");
+  if (it != r.header.end()) {
+    rate_limiter_.update(std::stoll(it->second));
+  }
+}
+
 std::expected<OrderAck, OrderError>
 AlpacaRestClient::placeOrder(const Order &order) {
+  if (!rate_limiter_.waitOrDrop()) {
+    return std::unexpected(OrderError{429, "Rate limited (dropped by policy)"});
+  }
   buildOrderPayload(order);
 
   session_->SetUrl(cpr::Url{order_url_});
   session_->SetBody(cpr::Body{payload_buf_});
   const cpr::Response r = session_->Post();
+  updateRateLimit(r);
 
   if (r.status_code >= 400) {
     return std::unexpected(
@@ -107,9 +122,13 @@ AlpacaRestClient::placeOrder(const Order &order) {
 
 std::expected<void, OrderError>
 AlpacaRestClient::cancelOrder(std::string_view alpaca_order_id) {
+  if (!rate_limiter_.waitOrDrop()) {
+    return std::unexpected(OrderError{429, "Rate limited (dropped by policy)"});
+  }
   session_->SetUrl(cpr::Url{cancel_url_prefix_ + std::string(alpaca_order_id)});
   session_->RemoveContent();
   const cpr::Response r = session_->Delete();
+  updateRateLimit(r);
 
   if (r.status_code == 204) {
     return {};
@@ -117,4 +136,8 @@ AlpacaRestClient::cancelOrder(std::string_view alpaca_order_id) {
 
   return std::unexpected(
       OrderError{r.status_code, "Error canceling order: " + r.text});
+}
+
+const RateLimiter &AlpacaRestClient::rateLimiter() const {
+  return rate_limiter_;
 }

--- a/src/RateLimiter.cpp
+++ b/src/RateLimiter.cpp
@@ -1,9 +1,11 @@
 #include "RateLimiter.hpp"
 #include "Utils.hpp"
+#include <algorithm>
 #include <thread>
 
 RateLimiter::RateLimiter(int64_t threshold, ThrottlePolicy policy) noexcept
-    : threshold_(threshold), policy_(policy) {}
+    : threshold_(std::clamp(threshold, int64_t{1}, kMaxRequestsPerWindow)),
+      policy_(policy) {}
 
 void RateLimiter::update(int64_t remaining) noexcept {
   remaining_.store(remaining, std::memory_order_relaxed);

--- a/src/RateLimiter.cpp
+++ b/src/RateLimiter.cpp
@@ -1,0 +1,60 @@
+#include "RateLimiter.hpp"
+#include "Utils.hpp"
+#include <thread>
+
+RateLimiter::RateLimiter(int64_t threshold, ThrottlePolicy policy) noexcept
+    : threshold_(threshold), policy_(policy) {}
+
+void RateLimiter::update(int64_t remaining) noexcept {
+  remaining_.store(remaining, std::memory_order_relaxed);
+  if (remaining < threshold_) {
+    int64_t expected = 0;
+    throttle_start_ns_.compare_exchange_strong(expected, nowNanos(),
+                                               std::memory_order_relaxed);
+  } else {
+    throttle_start_ns_.store(0, std::memory_order_relaxed);
+  }
+}
+
+void RateLimiter::onRateLimited() noexcept {
+  remaining_.store(0, std::memory_order_relaxed);
+  int64_t expected = 0;
+  throttle_start_ns_.compare_exchange_strong(expected, nowNanos(),
+                                             std::memory_order_relaxed);
+}
+
+bool RateLimiter::canSend() const noexcept {
+  if (remaining_.load(std::memory_order_relaxed) >= threshold_) {
+    return true;
+  }
+  const int64_t start = throttle_start_ns_.load(std::memory_order_relaxed);
+  if (start == 0) {
+    return true;
+  }
+  if (static_cast<int64_t>(nowNanos()) - start >= kWindowDurationNs) {
+    throttle_start_ns_.store(0, std::memory_order_relaxed);
+    return true;
+  }
+  return false;
+}
+
+bool RateLimiter::waitOrDrop() const {
+  if (canSend()) {
+    return true;
+  }
+  if (policy_ == ThrottlePolicy::Drop) {
+    return false;
+  }
+  while (!canSend()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  return true;
+}
+
+int64_t RateLimiter::remaining() const noexcept {
+  return remaining_.load(std::memory_order_relaxed);
+}
+
+int64_t RateLimiter::threshold() const noexcept { return threshold_; }
+
+ThrottlePolicy RateLimiter::policy() const noexcept { return policy_; }

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -407,11 +407,13 @@ TEST_P(AlpacaRateLimitHeaderTest, UpdatesRateLimiterFromHeader) {
   EXPECT_EQ(client.rateLimiter().canSend(), expected_can_send);
 }
 
-INSTANTIATE_TEST_SUITE_P(RemainingValues, AlpacaRateLimitHeaderTest,
-                         ::testing::Values(RateLimitHeaderParam{42, true},
-                                           RateLimitHeaderParam{10, true},
-                                           RateLimitHeaderParam{3, false},
-                                           RateLimitHeaderParam{0, false}));
+INSTANTIATE_TEST_SUITE_P(
+    RemainingValues, AlpacaRateLimitHeaderTest,
+    ::testing::Values(
+        RateLimitHeaderParam{42, true},
+        RateLimitHeaderParam{RateLimiter::kDefaultThreshold, true},
+        RateLimitHeaderParam{RateLimiter::kDefaultThreshold - 1, false},
+        RateLimitHeaderParam{0, false}));
 
 class AlpacaRestClientRateLimitTest : public AlpacaRestClientTestBase {};
 
@@ -481,4 +483,23 @@ TEST_F(AlpacaRestClientRateLimitTest, ConstructorForwardsThrottleConfig) {
   AlpacaRestClient client(20, ThrottlePolicy::Drop);
   EXPECT_EQ(client.rateLimiter().threshold(), 20);
   EXPECT_EQ(client.rateLimiter().policy(), ThrottlePolicy::Drop);
+}
+
+TEST_F(AlpacaRestClientRateLimitTest, DropPolicyRejectsOrderWhenThrottled) {
+  std::string header = "X-Ratelimit-Remaining: 0\r\n";
+  StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
+  point_client_to(server.port());
+  AlpacaRestClient client(10, ThrottlePolicy::Drop);
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  auto first = client.placeOrder(order);
+  t.join();
+
+  ASSERT_TRUE(first.has_value());
+  EXPECT_FALSE(client.rateLimiter().canSend());
+
+  auto second = client.placeOrder(order);
+  ASSERT_FALSE(second.has_value());
+  EXPECT_EQ(second.error().status_code, 429);
 }

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -15,11 +15,11 @@ using SocketType = int;
 #endif
 
 #include "AlpacaRestClient.hpp"
+#include "RateLimiter.hpp"
 #include <Utils.hpp>
 #include <cstring>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
-#include <sstream>
 #include <thread>
 
 class AlpacaRestClientTestBase : public ::testing::Test {
@@ -100,9 +100,11 @@ struct CapturedRequest {
 class StubHttpServer {
 public:
   explicit StubHttpServer(int status_code,
-                          std::string response_body = R"({"id":"ord-123"})")
+                          std::string response_body = R"({"id":"ord-123"})",
+                          std::string extra_headers = "")
       : status_code_(status_code), response_body_(std::move(response_body)),
-        server_fd_(initSocket()), port_(0) {
+        extra_headers_(std::move(extra_headers)), server_fd_(initSocket()),
+        port_(0) {
     int opt = 1;
     setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR,
                reinterpret_cast<const char *>(&opt), sizeof(opt));
@@ -168,7 +170,7 @@ public:
     std::string response =
         "HTTP/1.1 " + std::to_string(status_code_) +
         " \r\nContent-Length: " + std::to_string(response_body_.size()) +
-        "\r\n\r\n" + response_body_;
+        "\r\n" + extra_headers_ + "\r\n" + response_body_;
     send(client, response.c_str(), static_cast<int>(response.size()), 0);
     close_socket(client);
 
@@ -196,6 +198,7 @@ private:
 
   int status_code_;
   std::string response_body_;
+  std::string extra_headers_;
   SocketType server_fd_;
   int port_;
 };
@@ -375,4 +378,84 @@ TEST_F(AlpacaRestClientCancelOrderTest, Cancel422ReturnsError) {
   EXPECT_EQ(result.error().status_code, 422);
   EXPECT_TRUE(result.error().message.find("order already filled") !=
               std::string::npos);
+}
+
+struct RateLimitHeaderParam {
+  int64_t header_remaining;
+  bool expected_can_send;
+};
+
+class AlpacaRateLimitHeaderTest
+    : public AlpacaRestClientTestBase,
+      public ::testing::WithParamInterface<RateLimitHeaderParam> {};
+
+TEST_P(AlpacaRateLimitHeaderTest, UpdatesRateLimiterFromHeader) {
+  const auto &[remaining, expected_can_send] = GetParam();
+  std::string header =
+      "X-Ratelimit-Remaining: " + std::to_string(remaining) + "\r\n";
+  StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
+  point_client_to(server.port());
+  AlpacaRestClient client;
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.placeOrder(order);
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(client.rateLimiter().remaining(), remaining);
+  EXPECT_EQ(client.rateLimiter().canSend(), expected_can_send);
+}
+
+INSTANTIATE_TEST_SUITE_P(RemainingValues, AlpacaRateLimitHeaderTest,
+                         ::testing::Values(RateLimitHeaderParam{42, true},
+                                           RateLimitHeaderParam{10, true},
+                                           RateLimitHeaderParam{3, false},
+                                           RateLimitHeaderParam{0, false}));
+
+class AlpacaRestClientRateLimitTest : public AlpacaRestClientTestBase {};
+
+TEST_F(AlpacaRestClientRateLimitTest, ThrottlesOn429) {
+  StubHttpServer server(429,
+                        R"({"code":42910000,"message":"rate limit exceeded"})");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.placeOrder(order);
+  t.join();
+
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().status_code, 429);
+  EXPECT_EQ(client.rateLimiter().remaining(), 0);
+  EXPECT_FALSE(client.rateLimiter().canSend());
+}
+
+TEST_F(AlpacaRestClientRateLimitTest, NoHeaderLeavesDefaultRemaining) {
+  StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.placeOrder(order);
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(client.rateLimiter().remaining(),
+            RateLimiter::kMaxRequestsPerWindow);
+  EXPECT_TRUE(client.rateLimiter().canSend());
+}
+
+TEST_F(AlpacaRestClientRateLimitTest, CancelAlsoUpdatesRateLimit) {
+  StubHttpServer server(204, "", "X-Ratelimit-Remaining: 15\r\n");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.cancelOrder("some-order-id");
+  t.join();
+
+  EXPECT_EQ(client.rateLimiter().remaining(), 15);
 }

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -459,3 +459,26 @@ TEST_F(AlpacaRestClientRateLimitTest, CancelAlsoUpdatesRateLimit) {
 
   EXPECT_EQ(client.rateLimiter().remaining(), 15);
 }
+
+TEST_F(AlpacaRestClientRateLimitTest, MalformedHeaderDoesNotCrash) {
+  StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})",
+                        "X-Ratelimit-Remaining: not-a-number\r\n");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.placeOrder(order);
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(client.rateLimiter().remaining(),
+            RateLimiter::kMaxRequestsPerWindow);
+}
+
+TEST_F(AlpacaRestClientRateLimitTest, ConstructorForwardsThrottleConfig) {
+  point_client_to(12345);
+  AlpacaRestClient client(20, ThrottlePolicy::Drop);
+  EXPECT_EQ(client.rateLimiter().threshold(), 20);
+  EXPECT_EQ(client.rateLimiter().policy(), ThrottlePolicy::Drop);
+}

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -462,9 +462,25 @@ TEST_F(AlpacaRestClientRateLimitTest, CancelAlsoUpdatesRateLimit) {
   EXPECT_EQ(client.rateLimiter().remaining(), 15);
 }
 
-TEST_F(AlpacaRestClientRateLimitTest, MalformedHeaderDoesNotCrash) {
+TEST_F(AlpacaRestClientRateLimitTest, NonNumericHeaderDoesNotCrash) {
   StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})",
                         "X-Ratelimit-Remaining: not-a-number\r\n");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.placeOrder(order);
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(client.rateLimiter().remaining(),
+            RateLimiter::kMaxRequestsPerWindow);
+}
+
+TEST_F(AlpacaRestClientRateLimitTest, NumericPrefixHeaderIsRejected) {
+  StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})",
+                        "X-Ratelimit-Remaining: 10foo\r\n");
   point_client_to(server.port());
   AlpacaRestClient client;
   Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
@@ -485,7 +501,8 @@ TEST_F(AlpacaRestClientRateLimitTest, ConstructorForwardsThrottleConfig) {
   EXPECT_EQ(client.rateLimiter().policy(), ThrottlePolicy::Drop);
 }
 
-TEST_F(AlpacaRestClientRateLimitTest, DropPolicyRejectsOrderWhenThrottled) {
+TEST_F(AlpacaRestClientRateLimitTest,
+       DropPolicyRejectsPlaceOrderWhenThrottled) {
   std::string header = "X-Ratelimit-Remaining: 0\r\n";
   StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
   point_client_to(server.port());
@@ -502,4 +519,24 @@ TEST_F(AlpacaRestClientRateLimitTest, DropPolicyRejectsOrderWhenThrottled) {
   auto second = client.placeOrder(order);
   ASSERT_FALSE(second.has_value());
   EXPECT_EQ(second.error().status_code, 429);
+}
+
+TEST_F(AlpacaRestClientRateLimitTest,
+       DropPolicyRejectsCancelOrderWhenThrottled) {
+  std::string header = "X-Ratelimit-Remaining: 0\r\n";
+  StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
+  point_client_to(server.port());
+  AlpacaRestClient client(10, ThrottlePolicy::Drop);
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  auto first = client.placeOrder(order);
+  t.join();
+
+  ASSERT_TRUE(first.has_value());
+  EXPECT_FALSE(client.rateLimiter().canSend());
+
+  auto cancel = client.cancelOrder("some-order-id");
+  ASSERT_FALSE(cancel.has_value());
+  EXPECT_EQ(cancel.error().status_code, 429);
 }

--- a/tests/test_rate_limiter.cpp
+++ b/tests/test_rate_limiter.cpp
@@ -117,3 +117,14 @@ TEST_F(RateLimiterTest, MultipleOnRateLimitedCallsAreIdempotent) {
   limiter_.update(100);
   EXPECT_TRUE(limiter_.canSend());
 }
+
+TEST_F(RateLimiterTest, ThresholdClampedToValidRange) {
+  RateLimiter zero_threshold(0);
+  EXPECT_EQ(zero_threshold.threshold(), 1);
+
+  RateLimiter negative_threshold(-5);
+  EXPECT_EQ(negative_threshold.threshold(), 1);
+
+  RateLimiter over_max(999);
+  EXPECT_EQ(over_max.threshold(), RateLimiter::kMaxRequestsPerWindow);
+}

--- a/tests/test_rate_limiter.cpp
+++ b/tests/test_rate_limiter.cpp
@@ -1,0 +1,119 @@
+#include "RateLimiter.hpp"
+#include <gtest/gtest.h>
+#include <thread>
+
+class RateLimiterTest : public ::testing::Test {
+protected:
+  RateLimiter limiter_{5};
+};
+
+TEST_F(RateLimiterTest, StartsWithFullCapacity) {
+  EXPECT_EQ(limiter_.remaining(), RateLimiter::kMaxRequestsPerWindow);
+  EXPECT_TRUE(limiter_.canSend());
+}
+
+struct UpdateParam {
+  int64_t remaining;
+  bool expected_can_send;
+};
+
+class RateLimiterUpdateTest : public ::testing::TestWithParam<UpdateParam> {};
+
+TEST_P(RateLimiterUpdateTest, CanSendMatchesThreshold) {
+  RateLimiter limiter{5};
+  const auto &[remaining, expected] = GetParam();
+  limiter.update(remaining);
+  EXPECT_EQ(limiter.remaining(), remaining);
+  EXPECT_EQ(limiter.canSend(), expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BelowAndAboveThreshold, RateLimiterUpdateTest,
+    ::testing::Values(UpdateParam{0, false}, UpdateParam{1, false},
+                      UpdateParam{4, false}, UpdateParam{5, true},
+                      UpdateParam{50, true}, UpdateParam{200, true}));
+
+TEST_F(RateLimiterTest, UpdateAboveThresholdClearsThrottle) {
+  limiter_.update(2);
+  EXPECT_FALSE(limiter_.canSend());
+
+  limiter_.update(100);
+  EXPECT_TRUE(limiter_.canSend());
+}
+
+TEST_F(RateLimiterTest, OnRateLimitedBlocksSending) {
+  limiter_.onRateLimited();
+  EXPECT_EQ(limiter_.remaining(), 0);
+  EXPECT_FALSE(limiter_.canSend());
+}
+
+TEST_F(RateLimiterTest, OnRateLimitedThenUpdateAboveThresholdResumes) {
+  limiter_.onRateLimited();
+  EXPECT_FALSE(limiter_.canSend());
+
+  limiter_.update(150);
+  EXPECT_TRUE(limiter_.canSend());
+}
+
+TEST_F(RateLimiterTest, DefaultThresholdIsTen) {
+  RateLimiter default_limiter;
+  EXPECT_EQ(default_limiter.threshold(), RateLimiter::kDefaultThreshold);
+
+  default_limiter.update(10);
+  EXPECT_TRUE(default_limiter.canSend());
+
+  default_limiter.update(9);
+  EXPECT_FALSE(default_limiter.canSend());
+}
+
+TEST_F(RateLimiterTest, WaitPolicyBlocksUntilReady) {
+  RateLimiter wait_limiter{5, ThrottlePolicy::Wait};
+  wait_limiter.onRateLimited();
+
+  std::thread waiter([&]() { EXPECT_TRUE(wait_limiter.waitOrDrop()); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  wait_limiter.update(100);
+  waiter.join();
+  EXPECT_TRUE(wait_limiter.canSend());
+}
+
+TEST_F(RateLimiterTest, DropPolicyReturnsFalseWhenThrottled) {
+  RateLimiter drop_limiter{5, ThrottlePolicy::Drop};
+  drop_limiter.onRateLimited();
+  EXPECT_FALSE(drop_limiter.waitOrDrop());
+}
+
+TEST_F(RateLimiterTest, WaitOrDropReturnsTrueWhenNotThrottled) {
+  EXPECT_TRUE(limiter_.waitOrDrop());
+  RateLimiter drop_limiter{5, ThrottlePolicy::Drop};
+  EXPECT_TRUE(drop_limiter.waitOrDrop());
+}
+
+TEST_F(RateLimiterTest, PolicyAccessor) {
+  EXPECT_EQ(limiter_.policy(), ThrottlePolicy::Wait);
+  RateLimiter drop_limiter{5, ThrottlePolicy::Drop};
+  EXPECT_EQ(drop_limiter.policy(), ThrottlePolicy::Drop);
+}
+
+TEST_F(RateLimiterTest, RepeatedUpdatesTrackLatestValue) {
+  limiter_.update(100);
+  EXPECT_EQ(limiter_.remaining(), 100);
+
+  limiter_.update(50);
+  EXPECT_EQ(limiter_.remaining(), 50);
+
+  limiter_.update(3);
+  EXPECT_EQ(limiter_.remaining(), 3);
+  EXPECT_FALSE(limiter_.canSend());
+}
+
+TEST_F(RateLimiterTest, MultipleOnRateLimitedCallsAreIdempotent) {
+  limiter_.onRateLimited();
+  limiter_.onRateLimited();
+  limiter_.onRateLimited();
+  EXPECT_FALSE(limiter_.canSend());
+
+  limiter_.update(100);
+  EXPECT_TRUE(limiter_.canSend());
+}

--- a/tests/test_rate_limiter.cpp
+++ b/tests/test_rate_limiter.cpp
@@ -1,4 +1,5 @@
 #include "RateLimiter.hpp"
+#include <future>
 #include <gtest/gtest.h>
 #include <thread>
 
@@ -31,7 +32,8 @@ INSTANTIATE_TEST_SUITE_P(
     BelowAndAboveThreshold, RateLimiterUpdateTest,
     ::testing::Values(UpdateParam{0, false}, UpdateParam{1, false},
                       UpdateParam{4, false}, UpdateParam{5, true},
-                      UpdateParam{50, true}, UpdateParam{200, true}));
+                      UpdateParam{50, true},
+                      UpdateParam{RateLimiter::kMaxRequestsPerWindow, true}));
 
 TEST_F(RateLimiterTest, UpdateAboveThresholdClearsThrottle) {
   limiter_.update(2);
@@ -70,10 +72,17 @@ TEST_F(RateLimiterTest, WaitPolicyBlocksUntilReady) {
   RateLimiter wait_limiter{5, ThrottlePolicy::Wait};
   wait_limiter.onRateLimited();
 
-  std::thread waiter([&]() { EXPECT_TRUE(wait_limiter.waitOrDrop()); });
+  std::promise<bool> result_promise;
+  auto result_future = result_promise.get_future();
+  std::thread waiter(
+      [&]() { result_promise.set_value(wait_limiter.waitOrDrop()); });
 
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   wait_limiter.update(100);
+
+  ASSERT_EQ(result_future.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+  EXPECT_TRUE(result_future.get());
   waiter.join();
   EXPECT_TRUE(wait_limiter.canSend());
 }

--- a/tests/test_rate_limiter.cpp
+++ b/tests/test_rate_limiter.cpp
@@ -91,9 +91,9 @@ TEST_F(RateLimiterTest, WaitOrDropReturnsTrueWhenNotThrottled) {
 }
 
 TEST_F(RateLimiterTest, PolicyAccessor) {
-  EXPECT_EQ(limiter_.policy(), ThrottlePolicy::Wait);
-  RateLimiter drop_limiter{5, ThrottlePolicy::Drop};
-  EXPECT_EQ(drop_limiter.policy(), ThrottlePolicy::Drop);
+  EXPECT_EQ(limiter_.policy(), ThrottlePolicy::Drop);
+  RateLimiter wait_limiter{5, ThrottlePolicy::Wait};
+  EXPECT_EQ(wait_limiter.policy(), ThrottlePolicy::Wait);
 }
 
 TEST_F(RateLimiterTest, RepeatedUpdatesTrackLatestValue) {


### PR DESCRIPTION
## Summary

- RateLimiter class with atomic state tracking: parses X-Ratelimit-Remaining headers, detects 429 responses, enforces 60-second window cooldown
- ThrottlePolicy enum (Wait/Drop) for configurable behavior — Wait blocks until window resets, Drop returns immediately so the order is skipped
- AlpacaRestClient owns the RateLimiter and gates every placeOrder/cancelOrder call through waitOrDrop()
- StubHttpServer extended with extra response headers for integration testing
- Parameterized tests (TEST_P) for threshold boundary values and header parsing

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic client-side rate limiting with configurable throttle behavior (wait or drop) to reduce API limit errors.
  * Client now observes server rate-limit headers and adapts request flow; exposes a read-only rate limiter status.

* **Tests**
  * Added comprehensive unit and integration tests validating rate-limit handling and throttle policies.
  * Test harness updated to emit custom rate-limit headers for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->