### PR TITLE
Add REST reconciliation after WebSocket reconnect

### DIFF
--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -8,8 +8,6 @@
 #include <string>
 #include <thread>
 #include <type_traits>
-#include <unordered_map>
-#include <unordered_set>
 #include <variant>
 
 struct FillEvent {
@@ -42,6 +40,7 @@ using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 
 [[nodiscard]] TradeUpdate parseTradingUpdate(const nlohmann::json &parsed);
 
+struct AlpacaOrderStatus;
 class IRestClient;
 class LatencyTracker;
 class PendingOrderTracker;
@@ -70,6 +69,10 @@ private:
   void sendSubscribe();
   void handleTradeUpdate(const std::string &json);
   void reconcileAfterReconnect();
+  [[nodiscard]] int64_t reconcileFill(const AlpacaOrderStatus &alpaca_order,
+                                      OrderSide side);
+  [[nodiscard]] int64_t reconcileCancel(const AlpacaOrderStatus &alpaca_order,
+                                        OrderSide side);
 
   PositionManager *position_manager_;
   PendingOrderTracker *pending_tracker_;
@@ -81,6 +84,24 @@ private:
   ix::WebSocket ws_;
   std::thread thread_;
   bool has_connected_{false};
-  std::unordered_map<std::string, int64_t> filled_qty_by_order_;
-  std::unordered_set<std::string> completed_order_ids_;
+  std::string session_start_iso_;
+
+  static constexpr std::size_t kMaxTrackedOrders = 4096;
+
+  struct FilledEntry {
+    char order_id[48]{};
+    int64_t filled_qty{0};
+  };
+
+  struct CompletedEntry {
+    char order_id[48]{};
+  };
+
+  std::vector<FilledEntry> filled_entries_;
+  std::vector<CompletedEntry> completed_entries_;
+
+  [[nodiscard]] int64_t findFilledQty(std::string_view order_id) const noexcept;
+  void upsertFilledQty(std::string_view order_id, int64_t qty);
+  [[nodiscard]] bool isCompleted(std::string_view order_id) const noexcept;
+  void markCompleted(std::string_view order_id);
 };

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -6,9 +6,11 @@
 #include <ixwebsocket/IXWebSocket.h>
 #include <nlohmann/json_fwd.hpp>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <type_traits>
 #include <variant>
+#include <vector>
 
 struct FillEvent {
   char symbol[8];
@@ -96,6 +98,14 @@ private:
   struct CompletedEntry {
     char order_id[48]{};
   };
+
+  static_assert(sizeof(FilledEntry) == 56, "FilledEntry must be 56 bytes");
+  static_assert(std::is_trivially_copyable_v<FilledEntry>,
+                "FilledEntry must be trivially copyable");
+  static_assert(sizeof(CompletedEntry) == 48,
+                "CompletedEntry must be 48 bytes");
+  static_assert(std::is_trivially_copyable_v<CompletedEntry>,
+                "CompletedEntry must be trivially copyable");
 
   std::vector<FilledEntry> filled_entries_;
   std::vector<CompletedEntry> completed_entries_;

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -4,11 +4,12 @@
 #include "PositionManager.hpp"
 #include <atomic>
 #include <ixwebsocket/IXWebSocket.h>
-#include <memory>
 #include <nlohmann/json_fwd.hpp>
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <variant>
 
 struct FillEvent {
@@ -41,19 +42,22 @@ using TradeUpdate = std::variant<std::monostate, FillEvent, CancelEvent>;
 
 [[nodiscard]] TradeUpdate parseTradingUpdate(const nlohmann::json &parsed);
 
+class IRestClient;
 class LatencyTracker;
 class PendingOrderTracker;
 
 class AlpacaFillListener : public IFillListener {
   friend class FillListenerTest;
   friend class FillListenerTrackerTest;
+  friend class FillListenerReconcileTest;
 
 public:
   AlpacaFillListener(PositionManager *position_manager,
                      std::atomic<bool> &is_running, const std::string &api_key,
                      const std::string &api_secret,
                      PendingOrderTracker *pending_tracker = nullptr,
-                     LatencyTracker *latency_tracker = nullptr);
+                     LatencyTracker *latency_tracker = nullptr,
+                     IRestClient *reconciliation_client = nullptr);
 
   ~AlpacaFillListener() override;
 
@@ -65,13 +69,18 @@ private:
   void sendAuth();
   void sendSubscribe();
   void handleTradeUpdate(const std::string &json);
+  void reconcileAfterReconnect();
 
   PositionManager *position_manager_;
   PendingOrderTracker *pending_tracker_;
   LatencyTracker *latency_tracker_;
+  IRestClient *reconciliation_client_;
   std::atomic<bool> &is_running_;
   std::string api_key_;
   std::string api_secret_;
   ix::WebSocket ws_;
   std::thread thread_;
+  bool has_connected_{false};
+  std::unordered_map<std::string, int64_t> filled_qty_by_order_;
+  std::unordered_set<std::string> completed_order_ids_;
 };

--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -19,6 +19,9 @@ public:
   [[nodiscard]] std::expected<void, OrderError>
   cancelOrder(std::string_view alpaca_order_id) override;
 
+  [[nodiscard]] std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view status_filter) override;
+
   [[nodiscard]] const RateLimiter &rateLimiter() const;
 
 private:

--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -20,7 +20,7 @@ public:
   cancelOrder(std::string_view alpaca_order_id) override;
 
   [[nodiscard]] std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view status_filter) override;
+  queryOrders(std::string_view status_filter, std::string_view after) override;
 
   [[nodiscard]] const RateLimiter &rateLimiter() const;
 

--- a/include/IRestClient.hpp
+++ b/include/IRestClient.hpp
@@ -38,5 +38,5 @@ public:
 
   [[nodiscard]] virtual std::expected<std::vector<AlpacaOrderStatus>,
                                       OrderError>
-  queryOrders(std::string_view status_filter) = 0;
+  queryOrders(std::string_view status_filter, std::string_view after) = 0;
 };

--- a/include/IRestClient.hpp
+++ b/include/IRestClient.hpp
@@ -21,6 +21,7 @@ struct AlpacaOrderStatus {
   std::string symbol;
   std::string side;
   std::string status;
+  std::string created_at;
   int64_t qty{0};
   int64_t filled_qty{0};
   double filled_avg_price{0.0};

--- a/include/IRestClient.hpp
+++ b/include/IRestClient.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <expected>
 #include <string>
+#include <vector>
 
 struct OrderAck {
   std::string client_order_id;
@@ -15,6 +16,16 @@ struct OrderError {
   std::string message;
 };
 
+struct AlpacaOrderStatus {
+  std::string id;
+  std::string symbol;
+  std::string side;
+  std::string status;
+  int64_t qty{0};
+  int64_t filled_qty{0};
+  double filled_avg_price{0.0};
+};
+
 class IRestClient {
 public:
   virtual ~IRestClient() = default;
@@ -24,4 +35,8 @@ public:
 
   [[nodiscard]] virtual std::expected<void, OrderError>
   cancelOrder(std::string_view alpaca_order_id) = 0;
+
+  [[nodiscard]] virtual std::expected<std::vector<AlpacaOrderStatus>,
+                                      OrderError>
+  queryOrders(std::string_view status_filter) = 0;
 };

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -40,8 +40,10 @@ static_assert(sizeof(ConsumerType) % 64 == 0,
 
 class TradingEngine {
 public:
-  explicit TradingEngine(const std::vector<std::string> &symbols,
-                         std::unique_ptr<IRestClient> rest_client);
+  explicit TradingEngine(
+      const std::vector<std::string> &symbols,
+      std::unique_ptr<IRestClient> rest_client,
+      std::unique_ptr<IRestClient> reconciliation_client = nullptr);
 
   ~TradingEngine();
 
@@ -74,6 +76,7 @@ private:
   std::unique_ptr<OrderGateway> order_gateway_;
   std::thread order_gateway_thread_;
   std::vector<ConsumerThread> consumer_threads_;
+  std::unique_ptr<IRestClient> reconciliation_client_;
   std::unique_ptr<IFillListener> fill_listener_;
   std::unique_ptr<AlpacaPipeline> market_publisher_;
 };

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -386,35 +386,47 @@ void AlpacaFillListener::reconcileAfterReconnect() {
 
   std::cout << "FillListener: Starting post-reconnect reconciliation" << '\n';
 
-  auto result = reconciliation_client_->queryOrders("all", session_start_iso_);
-  if (!result) {
-    std::cerr << "FillListener: Reconciliation query failed (HTTP "
-              << result.error().status_code << "): " << result.error().message
-              << '\n';
-    return;
-  }
-
-  const auto &orders = *result;
+  constexpr int64_t kPageSize = 500;
   int64_t reconciled_fills = 0;
   int64_t reconciled_cancels = 0;
+  std::string cursor = session_start_iso_;
 
-  for (const auto &alpaca_order : orders) {
-    if (alpaca_order.id.empty() || isCompleted(alpaca_order.id)) {
-      continue;
+  for (;;) {
+    auto result = reconciliation_client_->queryOrders("all", cursor);
+    if (!result) {
+      std::cerr << "FillListener: Reconciliation query failed (HTTP "
+                << result.error().status_code << "): " << result.error().message
+                << '\n';
+      break;
     }
 
-    const auto side_opt = parseSide(alpaca_order.side);
-    if (!side_opt.has_value()) {
-      continue;
+    const auto &page = *result;
+    for (const auto &alpaca_order : page) {
+      if (alpaca_order.id.empty() || isCompleted(alpaca_order.id)) {
+        continue;
+      }
+
+      const auto side_opt = parseSide(alpaca_order.side);
+      if (!side_opt.has_value()) {
+        continue;
+      }
+
+      if (alpaca_order.status == "filled" ||
+          alpaca_order.status == "partially_filled") {
+        reconciled_fills += reconcileFill(alpaca_order, *side_opt);
+      } else if (alpaca_order.status == "canceled" ||
+                 alpaca_order.status == "expired" ||
+                 alpaca_order.status == "rejected") {
+        reconciled_cancels += reconcileCancel(alpaca_order, *side_opt);
+      }
     }
 
-    if (alpaca_order.status == "filled" ||
-        alpaca_order.status == "partially_filled") {
-      reconciled_fills += reconcileFill(alpaca_order, *side_opt);
-    } else if (alpaca_order.status == "canceled" ||
-               alpaca_order.status == "expired" ||
-               alpaca_order.status == "rejected") {
-      reconciled_cancels += reconcileCancel(alpaca_order, *side_opt);
+    if (static_cast<int64_t>(page.size()) < kPageSize || page.empty()) {
+      break;
+    }
+    cursor = page.back().created_at;
+    if (cursor.empty()) {
+      break;
     }
   }
 

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -4,7 +4,9 @@
 #include "PendingOrderTracker.hpp"
 #include "ThreadPinning.hpp"
 #include <algorithm>
+#include <chrono>
 #include <cstring>
+#include <ctime>
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -71,6 +73,20 @@ void copyOrderId(char (&dest)[48], const std::string &src) {
     std::cerr << "FillListener: parsePrice failed: " << e.what() << '\n';
   }
   return std::nullopt;
+}
+
+[[nodiscard]] std::string nowIso8601() {
+  const auto now = std::chrono::system_clock::now();
+  const auto t = std::chrono::system_clock::to_time_t(now);
+  std::tm tm{};
+#if defined(_WIN32)
+  gmtime_s(&tm, &t);
+#else
+  gmtime_r(&t, &tm);
+#endif
+  char buf[32]{};
+  std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+  return buf;
 }
 
 } // namespace
@@ -262,11 +278,13 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     if (parsed.contains("data") && parsed["data"].contains("status") &&
         parsed["data"]["status"] == "authorized") {
       std::cout << "FillListener: Authorized" << '\n';
+      sendSubscribe();
       if (has_connected_) {
         reconcileAfterReconnect();
+      } else {
+        session_start_iso_ = nowIso8601();
       }
       has_connected_ = true;
-      sendSubscribe();
     } else {
       std::cerr << "FillListener: Authorization failed" << '\n';
     }
@@ -311,9 +329,9 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
         fill_event.alpaca_order_id,
         strnlen(fill_event.alpaca_order_id, kOrderIdCapacity));
     if (!order_id.empty()) {
-      filled_qty_by_order_[std::string(order_id)] += fill_event.quantity;
+      upsertFilledQty(order_id, findFilledQty(order_id) + fill_event.quantity);
       if (!fill_event.is_partial) {
-        completed_order_ids_.insert(std::string(order_id));
+        markCompleted(order_id);
       }
     }
     if (latency_tracker_ && !order_id.empty()) {
@@ -344,7 +362,7 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
         cancel_event.alpaca_order_id,
         strnlen(cancel_event.alpaca_order_id, kOrderIdCapacity));
     if (!order_id.empty()) {
-      completed_order_ids_.insert(std::string(order_id));
+      markCompleted(order_id);
     }
     if (pending_tracker_) {
       SymbolKey key{};
@@ -368,7 +386,7 @@ void AlpacaFillListener::reconcileAfterReconnect() {
 
   std::cout << "FillListener: Starting post-reconnect reconciliation" << '\n';
 
-  auto result = reconciliation_client_->queryOrders("all");
+  auto result = reconciliation_client_->queryOrders("all", session_start_iso_);
   if (!result) {
     std::cerr << "FillListener: Reconciliation query failed (HTTP "
               << result.error().status_code << "): " << result.error().message
@@ -381,11 +399,7 @@ void AlpacaFillListener::reconcileAfterReconnect() {
   int64_t reconciled_cancels = 0;
 
   for (const auto &alpaca_order : orders) {
-    if (alpaca_order.id.empty()) {
-      continue;
-    }
-
-    if (completed_order_ids_.contains(alpaca_order.id)) {
+    if (alpaca_order.id.empty() || isCompleted(alpaca_order.id)) {
       continue;
     }
 
@@ -396,88 +410,144 @@ void AlpacaFillListener::reconcileAfterReconnect() {
 
     if (alpaca_order.status == "filled" ||
         alpaca_order.status == "partially_filled") {
-      const int64_t already_filled =
-          filled_qty_by_order_.contains(alpaca_order.id)
-              ? filled_qty_by_order_[alpaca_order.id]
-              : 0;
-      const int64_t remaining = alpaca_order.filled_qty - already_filled;
-
-      if (remaining <= 0) {
-        continue;
-      }
-
-      Fill fill{};
-      copySymbol(fill.symbol, alpaca_order.symbol);
-      fill.executionId = 0;
-      fill.orderId = 0;
-      fill.side = *side_opt;
-      fill.quantity = remaining;
-      fill.price = alpaca_order.filled_avg_price;
-      position_manager_->onFill(fill);
-
-      filled_qty_by_order_[alpaca_order.id] = alpaca_order.filled_qty;
-      if (alpaca_order.status == "filled") {
-        completed_order_ids_.insert(alpaca_order.id);
-        if (pending_tracker_) {
-          SymbolKey key{};
-          copySymbol(key.value, alpaca_order.symbol);
-          pending_tracker_->onOrderCompleted(key, *side_opt, alpaca_order.id);
-        }
-      }
-
-      ++reconciled_fills;
-      std::cout << "FillListener: Reconciled fill (" << alpaca_order.symbol
-                << " qty=" << remaining
-                << " avg_price=" << alpaca_order.filled_avg_price << ")"
-                << '\n';
+      reconciled_fills += reconcileFill(alpaca_order, *side_opt);
     } else if (alpaca_order.status == "canceled" ||
-               alpaca_order.status == "expired") {
-      const int64_t already_filled =
-          filled_qty_by_order_.contains(alpaca_order.id)
-              ? filled_qty_by_order_[alpaca_order.id]
-              : 0;
-      const int64_t missed_fills = alpaca_order.filled_qty - already_filled;
-
-      if (missed_fills > 0) {
-        Fill fill{};
-        copySymbol(fill.symbol, alpaca_order.symbol);
-        fill.executionId = 0;
-        fill.orderId = 0;
-        fill.side = *side_opt;
-        fill.quantity = missed_fills;
-        fill.price = alpaca_order.filled_avg_price;
-        position_manager_->onFill(fill);
-        filled_qty_by_order_[alpaca_order.id] = alpaca_order.filled_qty;
-      }
-
-      const int64_t unfilled =
-          (std::max)(int64_t{0}, alpaca_order.qty - alpaca_order.filled_qty);
-      if (unfilled > 0) {
-        Order order{};
-        order.id = 0;
-        copySymbol(order.symbol, alpaca_order.symbol);
-        order.quantity = unfilled;
-        order.price = 0;
-        order.side = *side_opt;
-        order.type = OrderType::Market;
-        position_manager_->onOrderCancelled(order);
-      }
-
-      completed_order_ids_.insert(alpaca_order.id);
-      if (pending_tracker_) {
-        SymbolKey key{};
-        copySymbol(key.value, alpaca_order.symbol);
-        pending_tracker_->onOrderCompleted(key, *side_opt, alpaca_order.id);
-      }
-
-      ++reconciled_cancels;
-      std::cout << "FillListener: Reconciled cancel (" << alpaca_order.symbol
-                << " filled=" << missed_fills << " unfilled=" << unfilled << ")"
-                << '\n';
+               alpaca_order.status == "expired" ||
+               alpaca_order.status == "rejected") {
+      reconciled_cancels += reconcileCancel(alpaca_order, *side_opt);
     }
   }
 
   std::cout << "FillListener: Reconciliation complete (fills="
             << reconciled_fills << " cancels=" << reconciled_cancels << ")"
             << '\n';
+}
+
+int64_t AlpacaFillListener::reconcileFill(const AlpacaOrderStatus &alpaca_order,
+                                          OrderSide side) {
+  const int64_t already_filled = findFilledQty(alpaca_order.id);
+  const int64_t remaining = alpaca_order.filled_qty - already_filled;
+
+  if (remaining <= 0) {
+    return 0;
+  }
+
+  Fill fill{};
+  copySymbol(fill.symbol, alpaca_order.symbol);
+  fill.executionId = 0;
+  fill.orderId = 0;
+  fill.side = side;
+  fill.quantity = remaining;
+  fill.price = alpaca_order.filled_avg_price;
+  position_manager_->onFill(fill);
+
+  upsertFilledQty(alpaca_order.id, alpaca_order.filled_qty);
+  if (alpaca_order.status == "filled") {
+    markCompleted(alpaca_order.id);
+    if (pending_tracker_) {
+      SymbolKey key{};
+      copySymbol(key.value, alpaca_order.symbol);
+      pending_tracker_->onOrderCompleted(key, side, alpaca_order.id);
+    }
+  }
+
+  std::cout << "FillListener: Reconciled fill (" << alpaca_order.symbol
+            << " qty=" << remaining
+            << " avg_price=" << alpaca_order.filled_avg_price << ")" << '\n';
+  return 1;
+}
+
+int64_t
+AlpacaFillListener::reconcileCancel(const AlpacaOrderStatus &alpaca_order,
+                                    OrderSide side) {
+  const int64_t already_filled = findFilledQty(alpaca_order.id);
+  const int64_t missed_fills = alpaca_order.filled_qty - already_filled;
+
+  if (missed_fills > 0) {
+    Fill fill{};
+    copySymbol(fill.symbol, alpaca_order.symbol);
+    fill.executionId = 0;
+    fill.orderId = 0;
+    fill.side = side;
+    fill.quantity = missed_fills;
+    fill.price = alpaca_order.filled_avg_price;
+    position_manager_->onFill(fill);
+    upsertFilledQty(alpaca_order.id, alpaca_order.filled_qty);
+  }
+
+  const int64_t unfilled =
+      (std::max)(int64_t{0}, alpaca_order.qty - alpaca_order.filled_qty);
+  if (unfilled > 0) {
+    Order order{};
+    order.id = 0;
+    copySymbol(order.symbol, alpaca_order.symbol);
+    order.quantity = unfilled;
+    order.price = 0;
+    order.side = side;
+    order.type = OrderType::Market;
+    position_manager_->onOrderCancelled(order);
+  }
+
+  markCompleted(alpaca_order.id);
+  if (pending_tracker_) {
+    SymbolKey key{};
+    copySymbol(key.value, alpaca_order.symbol);
+    pending_tracker_->onOrderCompleted(key, side, alpaca_order.id);
+  }
+
+  std::cout << "FillListener: Reconciled cancel (" << alpaca_order.symbol
+            << " filled=" << missed_fills << " unfilled=" << unfilled << ")"
+            << '\n';
+  return 1;
+}
+
+int64_t
+AlpacaFillListener::findFilledQty(std::string_view order_id) const noexcept {
+  for (const auto &e : filled_entries_) {
+    if (std::string_view(e.order_id, strnlen(e.order_id, kOrderIdCapacity)) ==
+        order_id) {
+      return e.filled_qty;
+    }
+  }
+  return 0;
+}
+
+void AlpacaFillListener::upsertFilledQty(std::string_view order_id,
+                                         int64_t qty) {
+  for (auto &e : filled_entries_) {
+    if (std::string_view(e.order_id, strnlen(e.order_id, kOrderIdCapacity)) ==
+        order_id) {
+      e.filled_qty = qty;
+      return;
+    }
+  }
+  if (filled_entries_.size() >= kMaxTrackedOrders) {
+    filled_entries_.erase(filled_entries_.begin());
+  }
+  FilledEntry entry{};
+  copyOrderId(entry.order_id, std::string(order_id));
+  entry.filled_qty = qty;
+  filled_entries_.push_back(entry);
+}
+
+bool AlpacaFillListener::isCompleted(std::string_view order_id) const noexcept {
+  for (const auto &e : completed_entries_) {
+    if (std::string_view(e.order_id, strnlen(e.order_id, kOrderIdCapacity)) ==
+        order_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void AlpacaFillListener::markCompleted(std::string_view order_id) {
+  if (isCompleted(order_id)) {
+    return;
+  }
+  if (completed_entries_.size() >= kMaxTrackedOrders) {
+    completed_entries_.erase(completed_entries_.begin());
+  }
+  CompletedEntry entry{};
+  copyOrderId(entry.order_id, std::string(order_id));
+  completed_entries_.push_back(entry);
 }

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaFillListener.hpp"
+#include "IRestClient.hpp"
 #include "LatencyTracker.hpp"
 #include "PendingOrderTracker.hpp"
 #include "ThreadPinning.hpp"
@@ -166,9 +167,11 @@ AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
                                        const std::string &api_key,
                                        const std::string &api_secret,
                                        PendingOrderTracker *pending_tracker,
-                                       LatencyTracker *latency_tracker)
+                                       LatencyTracker *latency_tracker,
+                                       IRestClient *reconciliation_client)
     : position_manager_(position_manager), pending_tracker_(pending_tracker),
-      latency_tracker_(latency_tracker), is_running_(is_running),
+      latency_tracker_(latency_tracker),
+      reconciliation_client_(reconciliation_client), is_running_(is_running),
       api_key_(api_key), api_secret_(api_secret) {
   if (position_manager_ == nullptr) {
     throw std::invalid_argument(
@@ -205,7 +208,13 @@ void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
 
   switch (msg->type) {
   case ix::WebSocketMessageType::Open:
-    std::cout << "FillListener: WebSocket connected" << '\n';
+    if (has_connected_) {
+      std::cout << "FillListener: WebSocket reconnected — will reconcile after "
+                   "auth"
+                << '\n';
+    } else {
+      std::cout << "FillListener: WebSocket connected" << '\n';
+    }
     sendAuth();
     break;
 
@@ -253,6 +262,10 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     if (parsed.contains("data") && parsed["data"].contains("status") &&
         parsed["data"]["status"] == "authorized") {
       std::cout << "FillListener: Authorized" << '\n';
+      if (has_connected_) {
+        reconcileAfterReconnect();
+      }
+      has_connected_ = true;
       sendSubscribe();
     } else {
       std::cerr << "FillListener: Authorization failed" << '\n';
@@ -297,6 +310,12 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     std::string_view order_id(
         fill_event.alpaca_order_id,
         strnlen(fill_event.alpaca_order_id, kOrderIdCapacity));
+    if (!order_id.empty()) {
+      filled_qty_by_order_[std::string(order_id)] += fill_event.quantity;
+      if (!fill_event.is_partial) {
+        completed_order_ids_.insert(std::string(order_id));
+      }
+    }
     if (latency_tracker_ && !order_id.empty()) {
       latency_tracker_->recordFillReceived(order_id);
     }
@@ -321,12 +340,15 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
     order.side = cancel_event.side;
     order.type = OrderType::Market;
     position_manager_->onOrderCancelled(order);
+    std::string_view order_id(
+        cancel_event.alpaca_order_id,
+        strnlen(cancel_event.alpaca_order_id, kOrderIdCapacity));
+    if (!order_id.empty()) {
+      completed_order_ids_.insert(std::string(order_id));
+    }
     if (pending_tracker_) {
       SymbolKey key{};
       std::memcpy(key.value, cancel_event.symbol, kSymbolCapacity);
-      std::string_view order_id(
-          cancel_event.alpaca_order_id,
-          strnlen(cancel_event.alpaca_order_id, kOrderIdCapacity));
       pending_tracker_->onOrderCompleted(key, cancel_event.side, order_id);
     }
     std::cout << "FillListener: Cancel processed ("
@@ -334,4 +356,128 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
                                   strnlen(cancel_event.symbol, kSymbolCapacity))
               << " qty=" << cancel_event.quantity << ")" << '\n';
   }
+}
+
+void AlpacaFillListener::reconcileAfterReconnect() {
+  if (reconciliation_client_ == nullptr) {
+    std::cerr << "FillListener: No reconciliation client — skipping "
+                 "post-reconnect reconciliation"
+              << '\n';
+    return;
+  }
+
+  std::cout << "FillListener: Starting post-reconnect reconciliation" << '\n';
+
+  auto result = reconciliation_client_->queryOrders("all");
+  if (!result) {
+    std::cerr << "FillListener: Reconciliation query failed (HTTP "
+              << result.error().status_code << "): " << result.error().message
+              << '\n';
+    return;
+  }
+
+  const auto &orders = *result;
+  int64_t reconciled_fills = 0;
+  int64_t reconciled_cancels = 0;
+
+  for (const auto &alpaca_order : orders) {
+    if (alpaca_order.id.empty()) {
+      continue;
+    }
+
+    if (completed_order_ids_.contains(alpaca_order.id)) {
+      continue;
+    }
+
+    const auto side_opt = parseSide(alpaca_order.side);
+    if (!side_opt.has_value()) {
+      continue;
+    }
+
+    if (alpaca_order.status == "filled" ||
+        alpaca_order.status == "partially_filled") {
+      const int64_t already_filled =
+          filled_qty_by_order_.contains(alpaca_order.id)
+              ? filled_qty_by_order_[alpaca_order.id]
+              : 0;
+      const int64_t remaining = alpaca_order.filled_qty - already_filled;
+
+      if (remaining <= 0) {
+        continue;
+      }
+
+      Fill fill{};
+      copySymbol(fill.symbol, alpaca_order.symbol);
+      fill.executionId = 0;
+      fill.orderId = 0;
+      fill.side = *side_opt;
+      fill.quantity = remaining;
+      fill.price = alpaca_order.filled_avg_price;
+      position_manager_->onFill(fill);
+
+      filled_qty_by_order_[alpaca_order.id] = alpaca_order.filled_qty;
+      if (alpaca_order.status == "filled") {
+        completed_order_ids_.insert(alpaca_order.id);
+        if (pending_tracker_) {
+          SymbolKey key{};
+          copySymbol(key.value, alpaca_order.symbol);
+          pending_tracker_->onOrderCompleted(key, *side_opt, alpaca_order.id);
+        }
+      }
+
+      ++reconciled_fills;
+      std::cout << "FillListener: Reconciled fill (" << alpaca_order.symbol
+                << " qty=" << remaining
+                << " avg_price=" << alpaca_order.filled_avg_price << ")"
+                << '\n';
+    } else if (alpaca_order.status == "canceled" ||
+               alpaca_order.status == "expired") {
+      const int64_t already_filled =
+          filled_qty_by_order_.contains(alpaca_order.id)
+              ? filled_qty_by_order_[alpaca_order.id]
+              : 0;
+      const int64_t missed_fills = alpaca_order.filled_qty - already_filled;
+
+      if (missed_fills > 0) {
+        Fill fill{};
+        copySymbol(fill.symbol, alpaca_order.symbol);
+        fill.executionId = 0;
+        fill.orderId = 0;
+        fill.side = *side_opt;
+        fill.quantity = missed_fills;
+        fill.price = alpaca_order.filled_avg_price;
+        position_manager_->onFill(fill);
+        filled_qty_by_order_[alpaca_order.id] = alpaca_order.filled_qty;
+      }
+
+      const int64_t unfilled =
+          (std::max)(int64_t{0}, alpaca_order.qty - alpaca_order.filled_qty);
+      if (unfilled > 0) {
+        Order order{};
+        order.id = 0;
+        copySymbol(order.symbol, alpaca_order.symbol);
+        order.quantity = unfilled;
+        order.price = 0;
+        order.side = *side_opt;
+        order.type = OrderType::Market;
+        position_manager_->onOrderCancelled(order);
+      }
+
+      completed_order_ids_.insert(alpaca_order.id);
+      if (pending_tracker_) {
+        SymbolKey key{};
+        copySymbol(key.value, alpaca_order.symbol);
+        pending_tracker_->onOrderCompleted(key, *side_opt, alpaca_order.id);
+      }
+
+      ++reconciled_cancels;
+      std::cout << "FillListener: Reconciled cancel (" << alpaca_order.symbol
+                << " filled=" << missed_fills << " unfilled=" << unfilled << ")"
+                << '\n';
+    }
+  }
+
+  std::cout << "FillListener: Reconciliation complete (fills="
+            << reconciled_fills << " cancels=" << reconciled_cancels << ")"
+            << '\n';
 }

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -194,10 +194,12 @@ AlpacaRestClient::queryOrders(std::string_view status_filter,
     return std::unexpected(OrderError{429, "Rate limited (dropped by policy)"});
   }
 
-  std::string url = order_url_ + "?status=" + std::string(status_filter) +
-                    "&limit=500&direction=desc";
+  std::string url =
+      order_url_ + "?status=" + std::string(status_filter) + "&limit=500";
   if (!after.empty()) {
-    url += "&after=" + std::string(after);
+    url += "&after=" + std::string(after) + "&direction=asc";
+  } else {
+    url += "&direction=desc";
   }
   session_->SetUrl(cpr::Url{url});
   session_->RemoveContent();
@@ -247,17 +249,31 @@ AlpacaRestClient::queryOrders(std::string_view status_filter,
       }
     }
 
-    const auto avg_price_str = item.value("filled_avg_price", "");
-    if (!avg_price_str.empty() && avg_price_str != "null") {
-      try {
-        order.filled_avg_price = std::stod(avg_price_str);
-      } catch (const std::exception &e) {
-        std::cerr << "AlpacaRestClient: Failed to parse filled_avg_price '"
-                  << avg_price_str << "': " << e.what() << '\n';
-        order.filled_avg_price = 0.0;
+    if (item.contains("filled_avg_price")) {
+      const auto &price_val = item["filled_avg_price"];
+      if (price_val.is_number()) {
+        order.filled_avg_price = price_val.get<double>();
+      } else if (price_val.is_string()) {
+        const auto &s = price_val.get_ref<const std::string &>();
+        if (!s.empty() && s != "null") {
+          std::size_t pos = 0;
+          try {
+            order.filled_avg_price = std::stod(s, &pos);
+          } catch (const std::exception &e) {
+            std::cerr << "AlpacaRestClient: Failed to parse filled_avg_price '"
+                      << s << "': " << e.what() << '\n';
+          }
+          if (pos != s.size()) {
+            std::cerr
+                << "AlpacaRestClient: Trailing chars in filled_avg_price '" << s
+                << "' for order " << order.id << '\n';
+            order.filled_avg_price = 0.0;
+          }
+        }
       }
     }
 
+    order.created_at = item.value("created_at", "");
     orders.push_back(std::move(order));
   }
 

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -194,14 +194,14 @@ AlpacaRestClient::queryOrders(std::string_view status_filter,
     return std::unexpected(OrderError{429, "Rate limited (dropped by policy)"});
   }
 
-  std::string url =
-      order_url_ + "?status=" + std::string(status_filter) + "&limit=500";
+  cpr::Parameters params{{"status", std::string(status_filter)},
+                         {"limit", "500"},
+                         {"direction", after.empty() ? "desc" : "asc"}};
   if (!after.empty()) {
-    url += "&after=" + std::string(after) + "&direction=asc";
-  } else {
-    url += "&direction=desc";
+    params.Add({"after", std::string(after)});
   }
-  session_->SetUrl(cpr::Url{url});
+  session_->SetUrl(cpr::Url{order_url_});
+  session_->SetParameters(params);
   session_->RemoveContent();
   const cpr::Response r = session_->Get();
   reapplyQuickAck();

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -3,6 +3,7 @@
 #include <cpr/curlholder.h>
 #include <cstring>
 #include <curl/curl.h>
+#include <iostream>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
 #include <string>
@@ -184,6 +185,75 @@ AlpacaRestClient::cancelOrder(std::string_view alpaca_order_id) {
 
   return std::unexpected(
       OrderError{r.status_code, "Error canceling order: " + r.text});
+}
+
+std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+AlpacaRestClient::queryOrders(std::string_view status_filter) {
+  if (!rate_limiter_.waitOrDrop()) {
+    return std::unexpected(OrderError{429, "Rate limited (dropped by policy)"});
+  }
+
+  session_->SetUrl(cpr::Url{order_url_ +
+                            "?status=" + std::string(status_filter) +
+                            "&limit=100&direction=desc"});
+  session_->RemoveContent();
+  const cpr::Response r = session_->Get();
+  reapplyQuickAck();
+  updateRateLimit(r);
+
+  if (r.status_code >= 400) {
+    return std::unexpected(
+        OrderError{r.status_code, "Error querying orders: " + r.text});
+  }
+
+  auto response = nlohmann::json::parse(r.text, nullptr, false);
+  if (!response.is_array()) {
+    return std::unexpected(
+        OrderError{r.status_code, "Invalid JSON array in response"});
+  }
+
+  std::vector<AlpacaOrderStatus> orders;
+  orders.reserve(response.size());
+  for (const auto &item : response) {
+    AlpacaOrderStatus order;
+    order.id = item.value("id", "");
+    order.symbol = item.value("symbol", "");
+    order.side = item.value("side", "");
+    order.status = item.value("status", "");
+
+    const auto qty_str = item.value("qty", "0");
+    const auto filled_str = item.value("filled_qty", "0");
+    {
+      auto [ptr, ec] = std::from_chars(
+          qty_str.data(), qty_str.data() + qty_str.size(), order.qty);
+      if (ec != std::errc{}) {
+        order.qty = 0;
+      }
+    }
+    {
+      auto [ptr, ec] = std::from_chars(filled_str.data(),
+                                       filled_str.data() + filled_str.size(),
+                                       order.filled_qty);
+      if (ec != std::errc{}) {
+        order.filled_qty = 0;
+      }
+    }
+
+    const auto avg_price_str = item.value("filled_avg_price", "");
+    if (!avg_price_str.empty() && avg_price_str != "null") {
+      try {
+        order.filled_avg_price = std::stod(avg_price_str);
+      } catch (const std::exception &e) {
+        std::cerr << "AlpacaRestClient: Failed to parse filled_avg_price '"
+                  << avg_price_str << "': " << e.what() << '\n';
+        order.filled_avg_price = 0.0;
+      }
+    }
+
+    orders.push_back(std::move(order));
+  }
+
+  return orders;
 }
 
 void AlpacaRestClient::reapplyQuickAck() {

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -259,15 +259,15 @@ AlpacaRestClient::queryOrders(std::string_view status_filter,
           std::size_t pos = 0;
           try {
             order.filled_avg_price = std::stod(s, &pos);
+            if (pos != s.size()) {
+              std::cerr << "AlpacaRestClient: Trailing chars in "
+                           "filled_avg_price '"
+                        << s << "' for order " << order.id << '\n';
+              order.filled_avg_price = 0.0;
+            }
           } catch (const std::exception &e) {
             std::cerr << "AlpacaRestClient: Failed to parse filled_avg_price '"
                       << s << "': " << e.what() << '\n';
-          }
-          if (pos != s.size()) {
-            std::cerr
-                << "AlpacaRestClient: Trailing chars in filled_avg_price '" << s
-                << "' for order " << order.id << '\n';
-            order.filled_avg_price = 0.0;
           }
         }
       }

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -188,14 +188,18 @@ AlpacaRestClient::cancelOrder(std::string_view alpaca_order_id) {
 }
 
 std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-AlpacaRestClient::queryOrders(std::string_view status_filter) {
+AlpacaRestClient::queryOrders(std::string_view status_filter,
+                              std::string_view after) {
   if (!rate_limiter_.waitOrDrop()) {
     return std::unexpected(OrderError{429, "Rate limited (dropped by policy)"});
   }
 
-  session_->SetUrl(cpr::Url{order_url_ +
-                            "?status=" + std::string(status_filter) +
-                            "&limit=100&direction=desc"});
+  std::string url = order_url_ + "?status=" + std::string(status_filter) +
+                    "&limit=500&direction=desc";
+  if (!after.empty()) {
+    url += "&after=" + std::string(after);
+  }
+  session_->SetUrl(cpr::Url{url});
   session_->RemoveContent();
   const cpr::Response r = session_->Get();
   reapplyQuickAck();
@@ -224,18 +228,22 @@ AlpacaRestClient::queryOrders(std::string_view status_filter) {
     const auto qty_str = item.value("qty", "0");
     const auto filled_str = item.value("filled_qty", "0");
     {
-      auto [ptr, ec] = std::from_chars(
-          qty_str.data(), qty_str.data() + qty_str.size(), order.qty);
-      if (ec != std::errc{}) {
-        order.qty = 0;
+      const auto *end = qty_str.data() + qty_str.size();
+      auto [ptr, ec] = std::from_chars(qty_str.data(), end, order.qty);
+      if (ec != std::errc{} || ptr != end) {
+        std::cerr << "AlpacaRestClient: Non-integer qty '" << qty_str
+                  << "' for order " << order.id << ", skipping" << '\n';
+        continue;
       }
     }
     {
-      auto [ptr, ec] = std::from_chars(filled_str.data(),
-                                       filled_str.data() + filled_str.size(),
-                                       order.filled_qty);
-      if (ec != std::errc{}) {
-        order.filled_qty = 0;
+      const auto *end = filled_str.data() + filled_str.size();
+      auto [ptr, ec] =
+          std::from_chars(filled_str.data(), end, order.filled_qty);
+      if (ec != std::errc{} || ptr != end) {
+        std::cerr << "AlpacaRestClient: Non-integer filled_qty '" << filled_str
+                  << "' for order " << order.id << ", skipping" << '\n';
+        continue;
       }
     }
 

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -17,7 +17,8 @@ void signalHandler(const int signum) {
 } // namespace
 
 TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
-                             std::unique_ptr<IRestClient> rest_client)
+                             std::unique_ptr<IRestClient> rest_client,
+                             std::unique_ptr<IRestClient> reconciliation_client)
     : is_running_(true), symbols_(symbols) {
   latency_tracker_ = std::make_unique<LatencyTracker>();
   position_manager_ = std::make_unique<PositionManager>();
@@ -42,9 +43,11 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
     throw std::runtime_error(
         "APCA_API_KEY_ID and APCA_API_SECRET_KEY must be set");
   }
+  reconciliation_client_ = std::move(reconciliation_client);
   fill_listener_ = std::make_unique<AlpacaFillListener>(
       position_manager_.get(), is_running_, api_key, api_secret,
-      pending_tracker_.get(), latency_tracker_.get());
+      pending_tracker_.get(), latency_tracker_.get(),
+      reconciliation_client_.get());
 
   ipc_address_ = getZmqMarketDataAddress();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,8 +9,10 @@ int main() {
     const std::vector<std::string> symbols = {"AAPL", "GOOGL", "AMZN"};
 
     auto alpaca_client = std::make_unique<AlpacaRestClient>();
+    auto reconciliation_client = std::make_unique<AlpacaRestClient>();
 
-    TradingEngine engine(symbols, std::move(alpaca_client));
+    TradingEngine engine(symbols, std::move(alpaca_client),
+                         std::move(reconciliation_client));
     engine.run();
   } catch (const std::exception &e) {
     std::cerr << "An exception occurred: " << e.what() << '\n';

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -673,8 +673,9 @@ TEST_F(AlpacaRestClientQueryOrdersTest, ThrottledQueryReturns429) {
   Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
 
   std::thread t([&]() { server.serve_one(); });
-  (void)client.placeOrder(order);
+  auto setup = client.placeOrder(order);
   t.join();
+  ASSERT_TRUE(setup.has_value());
 
   auto result = client.queryOrders("all", "");
   ASSERT_FALSE(result.has_value());

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -540,3 +540,143 @@ TEST_F(AlpacaRestClientRateLimitTest,
   ASSERT_FALSE(cancel.has_value());
   EXPECT_EQ(cancel.error().status_code, 429);
 }
+
+class AlpacaRestClientQueryOrdersTest : public AlpacaRestClientTestBase {};
+
+TEST_F(AlpacaRestClientQueryOrdersTest, ParsesFilledOrderArray) {
+  std::string body = R"([
+    {"id":"ord-1","symbol":"AAPL","side":"buy","status":"filled",
+     "qty":"100","filled_qty":"100","filled_avg_price":"150.25"},
+    {"id":"ord-2","symbol":"GOOGL","side":"sell","status":"canceled",
+     "qty":"50","filled_qty":"0"}
+  ])";
+  StubHttpServer server(200, body);
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  CapturedRequest req;
+  std::thread t([&]() { req = server.serve_one(); });
+  auto result = client.queryOrders("all", "");
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->size(), 2u);
+  EXPECT_EQ((*result)[0].id, "ord-1");
+  EXPECT_EQ((*result)[0].symbol, "AAPL");
+  EXPECT_EQ((*result)[0].side, "buy");
+  EXPECT_EQ((*result)[0].status, "filled");
+  EXPECT_EQ((*result)[0].qty, 100);
+  EXPECT_EQ((*result)[0].filled_qty, 100);
+  EXPECT_DOUBLE_EQ((*result)[0].filled_avg_price, 150.25);
+  EXPECT_EQ((*result)[1].id, "ord-2");
+  EXPECT_EQ((*result)[1].qty, 50);
+  EXPECT_EQ((*result)[1].filled_qty, 0);
+  EXPECT_DOUBLE_EQ((*result)[1].filled_avg_price, 0.0);
+}
+
+TEST_F(AlpacaRestClientQueryOrdersTest, ReturnsErrorOnHttpFailure) {
+  StubHttpServer server(500, R"({"message":"internal error"})");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.queryOrders("all", "");
+  t.join();
+
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().status_code, 500);
+}
+
+TEST_F(AlpacaRestClientQueryOrdersTest, ReturnsErrorOnNonArrayJson) {
+  StubHttpServer server(200, R"({"not":"an array"})");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.queryOrders("all", "");
+  t.join();
+
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(AlpacaRestClientQueryOrdersTest, SkipsOrderWithNonIntegerQty) {
+  std::string body = R"([
+    {"id":"bad","symbol":"X","side":"buy","status":"filled",
+     "qty":"1.5","filled_qty":"1"},
+    {"id":"good","symbol":"Y","side":"sell","status":"filled",
+     "qty":"10","filled_qty":"10","filled_avg_price":"99.00"}
+  ])";
+  StubHttpServer server(200, body);
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  std::thread t([&]() { server.serve_one(); });
+  auto result = client.queryOrders("all", "");
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->size(), 1u);
+  EXPECT_EQ((*result)[0].id, "good");
+}
+
+TEST_F(AlpacaRestClientQueryOrdersTest, ParsesNullFilledAvgPrice) {
+  std::string body =
+      R"([{"id":"ord-1","symbol":"AAPL","side":"buy","status":"new",
+     "qty":"100","filled_qty":"0","filled_avg_price":"null"}])";
+  StubHttpServer server(200, body);
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  CapturedRequest req;
+  std::thread t([&]() { req = server.serve_one(); });
+  auto result = client.queryOrders("all", "");
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->size(), 1u);
+  EXPECT_DOUBLE_EQ((*result)[0].filled_avg_price, 0.0);
+}
+
+TEST_F(AlpacaRestClientQueryOrdersTest, SendsAfterParamWhenProvided) {
+  StubHttpServer server(200, "[]");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  CapturedRequest req;
+  std::thread t([&]() { req = server.serve_one(); });
+  auto result = client.queryOrders("all", "2026-03-19T10:00:00Z");
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NE(req.path.find("after=2026-03-19T10"), std::string::npos);
+}
+
+TEST_F(AlpacaRestClientQueryOrdersTest, OmitsAfterParamWhenEmpty) {
+  StubHttpServer server(200, "[]");
+  point_client_to(server.port());
+  AlpacaRestClient client;
+
+  CapturedRequest req;
+  std::thread t([&]() { req = server.serve_one(); });
+  auto result = client.queryOrders("all", "");
+  t.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(req.path.find("after="), std::string::npos);
+}
+
+TEST_F(AlpacaRestClientQueryOrdersTest, ThrottledQueryReturns429) {
+  std::string header = "X-Ratelimit-Remaining: 0\r\n";
+  StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
+  point_client_to(server.port());
+  AlpacaRestClient client(10, ThrottlePolicy::Drop);
+  Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
+
+  std::thread t([&]() { server.serve_one(); });
+  (void)client.placeOrder(order);
+  t.join();
+
+  auto result = client.queryOrders("all", "");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().status_code, 429);
+}

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -1,4 +1,5 @@
 #include "AlpacaFillListener.hpp"
+#include "IRestClient.hpp"
 #include "LatencyTracker.hpp"
 #include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
@@ -611,4 +612,246 @@ TEST_F(FillListenerTrackerTest, CancelNotifiesTracker) {
   })");
 
   EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
+}
+
+// --- Reconciliation tests ---
+
+class MockReconciliationClient final : public IRestClient {
+public:
+  std::expected<OrderAck, OrderError>
+  placeOrder(const Order & /*order*/) override {
+    return OrderAck{"mock-id", "accepted"};
+  }
+
+  std::expected<void, OrderError>
+  cancelOrder(std::string_view /*alpaca_order_id*/) override {
+    return {};
+  }
+
+  std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view /*status_filter*/) override {
+    return orders_to_return;
+  }
+
+  std::vector<AlpacaOrderStatus> orders_to_return;
+};
+
+class FillListenerReconcileTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    position_manager_ = std::make_unique<PositionManager>();
+    position_manager_->registerSymbol("AAPL");
+    position_manager_->registerSymbol("GOOGL");
+    tracker_ = std::make_unique<PendingOrderTracker>();
+    mock_client_ = std::make_unique<MockReconciliationClient>();
+    listener_ = std::make_unique<AlpacaFillListener>(
+        position_manager_.get(), is_running_, "test_key", "test_secret",
+        tracker_.get(), nullptr, mock_client_.get());
+  }
+
+  void simulateReconnect() {
+    listener_->has_connected_ = true;
+    listener_->reconcileAfterReconnect();
+  }
+
+  void callHandleTradeUpdate(const std::string &json) {
+    listener_->handleTradeUpdate(json);
+  }
+
+  std::unique_ptr<PositionManager> position_manager_;
+  std::unique_ptr<PendingOrderTracker> tracker_;
+  std::unique_ptr<MockReconciliationClient> mock_client_;
+  std::atomic<bool> is_running_{true};
+  std::unique_ptr<AlpacaFillListener> listener_;
+};
+
+TEST_F(FillListenerReconcileTest, ReconcilesMissedFill) {
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Buy, "missed-fill-id");
+
+  mock_client_->orders_to_return = {
+      {"missed-fill-id", "AAPL", "buy", "filled", 100, 100, 150.25}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
+  EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
+}
+
+TEST_F(FillListenerReconcileTest, ReconcilesMissedCancel) {
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Buy, "missed-cancel-id");
+
+  mock_client_->orders_to_return = {
+      {"missed-cancel-id", "AAPL", "buy", "canceled", 100, 0, 0.0}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+  EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
+}
+
+TEST_F(FillListenerReconcileTest, SkipsAlreadyProcessedFill) {
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "fill",
+      "qty": "100",
+      "price": "150.25",
+      "order": {"symbol": "AAPL", "side": "buy", "id": "already-filled-id"}
+    }
+  })");
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
+
+  mock_client_->orders_to_return = {
+      {"already-filled-id", "AAPL", "buy", "filled", 100, 100, 150.25}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
+}
+
+TEST_F(FillListenerReconcileTest, ReconcilesMissedPartialFillRemainder) {
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  callHandleTradeUpdate(R"({
+    "stream": "trade_updates",
+    "data": {
+      "event": "partial_fill",
+      "qty": "60",
+      "price": "150.00",
+      "order": {"symbol": "AAPL", "side": "buy", "id": "partial-order-id"}
+    }
+  })");
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 60);
+
+  mock_client_->orders_to_return = {
+      {"partial-order-id", "AAPL", "buy", "filled", 100, 100, 150.40}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
+}
+
+TEST_F(FillListenerReconcileTest, HandlesQueryFailure) {
+  class FailingClient final : public IRestClient {
+  public:
+    std::expected<OrderAck, OrderError>
+    placeOrder(const Order & /*order*/) override {
+      return OrderAck{"mock-id", "accepted"};
+    }
+    std::expected<void, OrderError>
+    cancelOrder(std::string_view /*alpaca_order_id*/) override {
+      return {};
+    }
+    std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+    queryOrders(std::string_view /*status_filter*/) override {
+      return std::unexpected(OrderError{500, "Internal Server Error"});
+    }
+  };
+
+  auto fail_client = std::make_unique<FailingClient>();
+  listener_ = std::make_unique<AlpacaFillListener>(
+      position_manager_.get(), is_running_, "test_key", "test_secret",
+      tracker_.get(), nullptr, fail_client.get());
+
+  EXPECT_NO_THROW(simulateReconnect());
+}
+
+TEST_F(FillListenerReconcileTest, SkipsOrdersWithUnknownSide) {
+  mock_client_->orders_to_return = {
+      {"unknown-side-id", "AAPL", "short", "filled", 100, 100, 150.25}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 0);
+}
+
+TEST_F(FillListenerReconcileTest, ReconcilesSellFill) {
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Sell, 50, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Sell, "sell-fill-id");
+
+  mock_client_->orders_to_return = {
+      {"sell-fill-id", "AAPL", "sell", "filled", 50, 50, 155.00}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), -50);
+  EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Sell).has_value());
+}
+
+TEST_F(FillListenerReconcileTest, ReconcilesCancelAfterPartialFill) {
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  mock_client_->orders_to_return = {
+      {"cancel-partial-id", "AAPL", "buy", "canceled", 100, 40, 149.50}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 40);
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+}
+
+TEST_F(FillListenerReconcileTest, NoReconciliationWithoutClient) {
+  listener_ = std::make_unique<AlpacaFillListener>(
+      position_manager_.get(), is_running_, "test_key", "test_secret",
+      tracker_.get());
+
+  EXPECT_NO_THROW(simulateReconnect());
+}
+
+TEST_F(FillListenerReconcileTest, ReconcileMultipleOrders) {
+  Order buy_order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  buy_order.id = 1;
+  position_manager_->onOrderSent(buy_order);
+
+  Order sell_order = test_helpers::createOrder("GOOGL", OrderSide::Sell, 50, 0);
+  sell_order.id = 2;
+  position_manager_->onOrderSent(sell_order);
+
+  SymbolKey aapl_key{};
+  std::memcpy(aapl_key.value, "AAPL", 4);
+  tracker_->recordOrder(aapl_key, OrderSide::Buy, "aapl-fill-id");
+
+  SymbolKey googl_key{};
+  std::memcpy(googl_key.value, "GOOGL", 5);
+  tracker_->recordOrder(googl_key, OrderSide::Sell, "googl-cancel-id");
+
+  mock_client_->orders_to_return = {
+      {"aapl-fill-id", "AAPL", "buy", "filled", 100, 100, 150.25},
+      {"googl-cancel-id", "GOOGL", "sell", "canceled", 50, 0, 0.0}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
+  EXPECT_EQ(position_manager_->getPendingPosition("GOOGL"), 0);
+  EXPECT_FALSE(
+      tracker_->getExistingOrder(aapl_key, OrderSide::Buy).has_value());
+  EXPECT_FALSE(
+      tracker_->getExistingOrder(googl_key, OrderSide::Sell).has_value());
 }

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -684,23 +684,37 @@ TEST_F(FillListenerReconcileTest, ReconcilesMissedFill) {
   EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
 }
 
-TEST_F(FillListenerReconcileTest, ReconcilesMissedCancel) {
+struct TerminalCancelParam {
+  const char *status;
+};
+
+class ReconcileTerminalCancelTest
+    : public FillListenerReconcileTest,
+      public ::testing::WithParamInterface<TerminalCancelParam> {};
+
+TEST_P(ReconcileTerminalCancelTest, ClearsPositionAndTracker) {
+  const auto &[status] = GetParam();
   Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
   order.id = 1;
   position_manager_->onOrderSent(order);
 
   SymbolKey key{};
   std::memcpy(key.value, "AAPL", 4);
-  tracker_->recordOrder(key, OrderSide::Buy, "missed-cancel-id");
+  tracker_->recordOrder(key, OrderSide::Buy, "terminal-order-id");
 
   mock_client_->orders_to_return = {
-      {"missed-cancel-id", "AAPL", "buy", "canceled", 100, 0, 0.0}};
+      {"terminal-order-id", "AAPL", "buy", status, 100, 0, 0.0}};
 
   simulateReconnect();
 
   EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
   EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
 }
+
+INSTANTIATE_TEST_SUITE_P(TerminalStatuses, ReconcileTerminalCancelTest,
+                         ::testing::Values(TerminalCancelParam{"canceled"},
+                                           TerminalCancelParam{"expired"},
+                                           TerminalCancelParam{"rejected"}));
 
 TEST_F(FillListenerReconcileTest, SkipsAlreadyProcessedFill) {
   Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
@@ -856,22 +870,4 @@ TEST_F(FillListenerReconcileTest, ReconcileMultipleOrders) {
       tracker_->getExistingOrder(aapl_key, OrderSide::Buy).has_value());
   EXPECT_FALSE(
       tracker_->getExistingOrder(googl_key, OrderSide::Sell).has_value());
-}
-
-TEST_F(FillListenerReconcileTest, ReconcilesMissedRejected) {
-  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
-  order.id = 1;
-  position_manager_->onOrderSent(order);
-
-  SymbolKey key{};
-  std::memcpy(key.value, "AAPL", 4);
-  tracker_->recordOrder(key, OrderSide::Buy, "rejected-order-id");
-
-  mock_client_->orders_to_return = {
-      {"rejected-order-id", "AAPL", "buy", "rejected", 100, 0, 0.0}};
-
-  simulateReconnect();
-
-  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
-  EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
 }

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -676,7 +676,7 @@ TEST_F(FillListenerReconcileTest, ReconcilesMissedFill) {
   tracker_->recordOrder(key, OrderSide::Buy, "missed-fill-id");
 
   mock_client_->orders_to_return = {
-      {"missed-fill-id", "AAPL", "buy", "filled", 100, 100, 150.25}};
+      {"missed-fill-id", "AAPL", "buy", "filled", "", 100, 100, 150.25}};
 
   simulateReconnect();
 
@@ -703,7 +703,7 @@ TEST_P(ReconcileTerminalCancelTest, ClearsPositionAndTracker) {
   tracker_->recordOrder(key, OrderSide::Buy, "terminal-order-id");
 
   mock_client_->orders_to_return = {
-      {"terminal-order-id", "AAPL", "buy", status, 100, 0, 0.0}};
+      {"terminal-order-id", "AAPL", "buy", status, "", 100, 0, 0.0}};
 
   simulateReconnect();
 
@@ -734,7 +734,7 @@ TEST_F(FillListenerReconcileTest, SkipsAlreadyProcessedFill) {
   EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 100);
 
   mock_client_->orders_to_return = {
-      {"already-filled-id", "AAPL", "buy", "filled", 100, 100, 150.25}};
+      {"already-filled-id", "AAPL", "buy", "filled", "", 100, 100, 150.25}};
 
   simulateReconnect();
 
@@ -759,7 +759,7 @@ TEST_F(FillListenerReconcileTest, ReconcilesMissedPartialFillRemainder) {
   EXPECT_EQ(position_manager_->getFilledPosition("AAPL"), 60);
 
   mock_client_->orders_to_return = {
-      {"partial-order-id", "AAPL", "buy", "filled", 100, 100, 150.40}};
+      {"partial-order-id", "AAPL", "buy", "filled", "", 100, 100, 150.40}};
 
   simulateReconnect();
 
@@ -794,7 +794,7 @@ TEST_F(FillListenerReconcileTest, HandlesQueryFailure) {
 
 TEST_F(FillListenerReconcileTest, SkipsOrdersWithUnknownSide) {
   mock_client_->orders_to_return = {
-      {"unknown-side-id", "AAPL", "short", "filled", 100, 100, 150.25}};
+      {"unknown-side-id", "AAPL", "short", "filled", "", 100, 100, 150.25}};
 
   simulateReconnect();
 
@@ -811,7 +811,7 @@ TEST_F(FillListenerReconcileTest, ReconcilesSellFill) {
   tracker_->recordOrder(key, OrderSide::Sell, "sell-fill-id");
 
   mock_client_->orders_to_return = {
-      {"sell-fill-id", "AAPL", "sell", "filled", 50, 50, 155.00}};
+      {"sell-fill-id", "AAPL", "sell", "filled", "", 50, 50, 155.00}};
 
   simulateReconnect();
 
@@ -825,7 +825,7 @@ TEST_F(FillListenerReconcileTest, ReconcilesCancelAfterPartialFill) {
   position_manager_->onOrderSent(order);
 
   mock_client_->orders_to_return = {
-      {"cancel-partial-id", "AAPL", "buy", "canceled", 100, 40, 149.50}};
+      {"cancel-partial-id", "AAPL", "buy", "canceled", "", 100, 40, 149.50}};
 
   simulateReconnect();
 
@@ -859,8 +859,8 @@ TEST_F(FillListenerReconcileTest, ReconcileMultipleOrders) {
   tracker_->recordOrder(googl_key, OrderSide::Sell, "googl-cancel-id");
 
   mock_client_->orders_to_return = {
-      {"aapl-fill-id", "AAPL", "buy", "filled", 100, 100, 150.25},
-      {"googl-cancel-id", "GOOGL", "sell", "canceled", 50, 0, 0.0}};
+      {"aapl-fill-id", "AAPL", "buy", "filled", "", 100, 100, 150.25},
+      {"googl-cancel-id", "GOOGL", "sell", "canceled", "", 50, 0, 0.0}};
 
   simulateReconnect();
 

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -629,7 +629,8 @@ public:
   }
 
   std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view /*status_filter*/) override {
+  queryOrders(std::string_view /*status_filter*/,
+              std::string_view /*after*/) override {
     return orders_to_return;
   }
 
@@ -763,7 +764,8 @@ TEST_F(FillListenerReconcileTest, HandlesQueryFailure) {
       return {};
     }
     std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-    queryOrders(std::string_view /*status_filter*/) override {
+    queryOrders(std::string_view /*status_filter*/,
+                std::string_view /*after*/) override {
       return std::unexpected(OrderError{500, "Internal Server Error"});
     }
   };
@@ -854,4 +856,22 @@ TEST_F(FillListenerReconcileTest, ReconcileMultipleOrders) {
       tracker_->getExistingOrder(aapl_key, OrderSide::Buy).has_value());
   EXPECT_FALSE(
       tracker_->getExistingOrder(googl_key, OrderSide::Sell).has_value());
+}
+
+TEST_F(FillListenerReconcileTest, ReconcilesMissedRejected) {
+  Order order = test_helpers::createOrder("AAPL", OrderSide::Buy, 100, 0);
+  order.id = 1;
+  position_manager_->onOrderSent(order);
+
+  SymbolKey key{};
+  std::memcpy(key.value, "AAPL", 4);
+  tracker_->recordOrder(key, OrderSide::Buy, "rejected-order-id");
+
+  mock_client_->orders_to_return = {
+      {"rejected-order-id", "AAPL", "buy", "rejected", 100, 0, 0.0}};
+
+  simulateReconnect();
+
+  EXPECT_EQ(position_manager_->getPendingPosition("AAPL"), 0);
+  EXPECT_FALSE(tracker_->getExistingOrder(key, OrderSide::Buy).has_value());
 }

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -35,7 +35,8 @@ public:
   }
 
   std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view /*status_filter*/) override {
+  queryOrders(std::string_view /*status_filter*/,
+              std::string_view /*after*/) override {
     return std::vector<AlpacaOrderStatus>{};
   }
 
@@ -137,7 +138,8 @@ TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
       return {};
     }
     std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-    queryOrders(std::string_view /*status_filter*/) override {
+    queryOrders(std::string_view /*status_filter*/,
+                std::string_view /*after*/) override {
       return std::vector<AlpacaOrderStatus>{};
     }
 
@@ -195,7 +197,8 @@ TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
       return {};
     }
     std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-    queryOrders(std::string_view /*status_filter*/) override {
+    queryOrders(std::string_view /*status_filter*/,
+                std::string_view /*after*/) override {
       return std::vector<AlpacaOrderStatus>{};
     }
   };
@@ -226,7 +229,8 @@ public:
   }
 
   std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view /*status_filter*/) override {
+  queryOrders(std::string_view /*status_filter*/,
+              std::string_view /*after*/) override {
     return std::vector<AlpacaOrderStatus>{};
   }
 
@@ -252,7 +256,8 @@ public:
   }
 
   std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view /*status_filter*/) override {
+  queryOrders(std::string_view /*status_filter*/,
+              std::string_view /*after*/) override {
     return std::vector<AlpacaOrderStatus>{};
   }
 
@@ -387,7 +392,8 @@ public:
   }
 
   std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view /*status_filter*/) override {
+  queryOrders(std::string_view /*status_filter*/,
+              std::string_view /*after*/) override {
     return std::vector<AlpacaOrderStatus>{};
   }
 
@@ -413,7 +419,8 @@ public:
   }
 
   std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view /*status_filter*/) override {
+  queryOrders(std::string_view /*status_filter*/,
+              std::string_view /*after*/) override {
     return std::vector<AlpacaOrderStatus>{};
   }
 
@@ -581,7 +588,8 @@ TEST_F(CancelBeforeReplaceTest, DoesNotRecordFailedPlacement) {
       return {};
     }
     std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-    queryOrders(std::string_view /*status_filter*/) override {
+    queryOrders(std::string_view /*status_filter*/,
+                std::string_view /*after*/) override {
       return std::vector<AlpacaOrderStatus>{};
     }
   };

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -34,6 +34,11 @@ public:
     return {};
   }
 
+  std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view /*status_filter*/) override {
+    return std::vector<AlpacaOrderStatus>{};
+  }
+
   std::promise<void> *promise_to_fulfill = nullptr;
 };
 
@@ -131,6 +136,10 @@ TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
     cancelOrder(std::string_view /*alpaca_order_id*/) override {
       return {};
     }
+    std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+    queryOrders(std::string_view /*status_filter*/) override {
+      return std::vector<AlpacaOrderStatus>{};
+    }
 
   private:
     std::vector<uint64_t> &ids_;
@@ -185,6 +194,10 @@ TEST_F(OrderGatewayTest, ReleasesPendingOnRejection) {
     cancelOrder(std::string_view /*alpaca_order_id*/) override {
       return {};
     }
+    std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+    queryOrders(std::string_view /*status_filter*/) override {
+      return std::vector<AlpacaOrderStatus>{};
+    }
   };
 
   OrderGateway gateway(is_running, &order_queue,
@@ -212,6 +225,11 @@ public:
     return {};
   }
 
+  std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view /*status_filter*/) override {
+    return std::vector<AlpacaOrderStatus>{};
+  }
+
 private:
   std::promise<void> *promise_;
 };
@@ -231,6 +249,11 @@ public:
   std::expected<void, OrderError>
   cancelOrder(std::string_view /*alpaca_order_id*/) override {
     return {};
+  }
+
+  std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view /*status_filter*/) override {
+    return std::vector<AlpacaOrderStatus>{};
   }
 
 private:
@@ -363,6 +386,11 @@ public:
     return cancel_result_;
   }
 
+  std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view /*status_filter*/) override {
+    return std::vector<AlpacaOrderStatus>{};
+  }
+
   std::vector<Call> calls;
 
 private:
@@ -382,6 +410,11 @@ public:
   std::expected<void, OrderError>
   cancelOrder(std::string_view /*alpaca_order_id*/) override {
     throw std::runtime_error("cancel network error");
+  }
+
+  std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view /*status_filter*/) override {
+    return std::vector<AlpacaOrderStatus>{};
   }
 
   std::vector<std::string> place_ids;
@@ -546,6 +579,10 @@ TEST_F(CancelBeforeReplaceTest, DoesNotRecordFailedPlacement) {
     std::expected<void, OrderError>
     cancelOrder(std::string_view /*alpaca_order_id*/) override {
       return {};
+    }
+    std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+    queryOrders(std::string_view /*status_filter*/) override {
+      return std::vector<AlpacaOrderStatus>{};
     }
   };
 

--- a/tests/test_trading_engine.cpp
+++ b/tests/test_trading_engine.cpp
@@ -18,7 +18,8 @@ public:
   }
 
   std::expected<std::vector<AlpacaOrderStatus>, OrderError>
-  queryOrders(std::string_view /*status_filter*/) override {
+  queryOrders(std::string_view /*status_filter*/,
+              std::string_view /*after*/) override {
     return std::vector<AlpacaOrderStatus>{};
   }
 };

--- a/tests/test_trading_engine.cpp
+++ b/tests/test_trading_engine.cpp
@@ -16,6 +16,11 @@ public:
   cancelOrder(std::string_view /*alpaca_order_id*/) override {
     return {};
   }
+
+  std::expected<std::vector<AlpacaOrderStatus>, OrderError>
+  queryOrders(std::string_view /*status_filter*/) override {
+    return std::vector<AlpacaOrderStatus>{};
+  }
 };
 
 class TradingEngineTest : public ::testing::Test {


### PR DESCRIPTION
## Summary

- Add `queryOrders()` pure virtual to `IRestClient`, implement in `AlpacaRestClient` — queries `GET /v2/orders?status=all&limit=100&direction=desc`
- `AlpacaFillListener` tracks filled qty per order ID and completed order IDs to deduplicate against events already processed via WebSocket
- On reconnect (second+ auth success), `reconcileAfterReconnect()` diffs REST state against local tracking, processes only the delta — handles partial fill accumulation, cancel-after-partial-fill, and full missed fills/cancels
- `TradingEngine` accepts a second `IRestClient` for reconciliation (separate TCP session avoids thread contention with `OrderGateway`)
- All 9 mock `IRestClient` implementations updated for the new pure virtual
- 10 new tests covering missed fills, missed cancels, partial fill remainder, already-processed dedup, query failure, unknown side, sell fills, cancel-after-partial-fill, no-client graceful handling, and multi-order reconciliation

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic order reconciliation after websocket reconnects to detect and apply missed fills and cancellations.
  * New order-query API to fetch historical/filtered order statuses for reconciliation.
  * Optional reconciliation client wiring to enable post-reconnect recovery.

* **Bug Fixes / Reliability**
  * Improved handling of partial fills, cancellations and terminal states to avoid duplicate or missed position updates.

* **Tests**
  * Extensive tests covering reconciliation workflows, order-query parsing, and reconnect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->