### PR TITLE
Add ThreadGuard and future timeouts to all concurrency tests

### DIFF
--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -4,7 +4,9 @@
 #include "PendingOrderTracker.hpp"
 #include "PositionManager.hpp"
 #include "TestHelpers.hpp"
+#include "ThreadGuard.hpp"
 #include <cstring>
+#include <future>
 #include <gtest/gtest.h>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -465,7 +467,9 @@ TEST_F(FillListenerTest, StopDuringActiveProcessingCompletesCorrectly) {
   }
 
   std::atomic<int> processed{0};
-  std::thread processor([&]() {
+  std::promise<void> processor_finished;
+
+  ThreadGuard processor{std::thread([&]() {
     for (int i = 0; i < num_fills; ++i) {
       callHandleTradeUpdate(R"({
         "stream": "trade_updates",
@@ -478,14 +482,17 @@ TEST_F(FillListenerTest, StopDuringActiveProcessingCompletesCorrectly) {
       })");
       processed.fetch_add(1, std::memory_order_relaxed);
     }
-  });
+    processor_finished.set_value();
+  })};
 
   while (processed.load(std::memory_order_relaxed) < 5) {
     std::this_thread::yield();
   }
   listener_->stop();
 
-  processor.join();
+  auto status =
+      processor_finished.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
 
   const int64_t filled = position_manager_->getFilledPosition("AAPL");
   const int64_t pending = position_manager_->getPendingPosition("AAPL");

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -1,5 +1,4 @@
 #include "LatencyTracker.hpp"
-#include "ThreadGuard.hpp"
 #include <atomic>
 #include <filesystem>
 #include <fstream>

--- a/tests/test_latency_tracker.cpp
+++ b/tests/test_latency_tracker.cpp
@@ -1,7 +1,9 @@
 #include "LatencyTracker.hpp"
+#include "ThreadGuard.hpp"
 #include <atomic>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <gtest/gtest.h>
 #include <string>
 #include <thread>
@@ -52,6 +54,8 @@ TEST_F(LatencyTrackerTest, ConcurrentRecordFromMultipleThreads) {
   constexpr int samples_per_thread = 10000;
 
   std::atomic<bool> start{false};
+  std::atomic<int> done_count{0};
+  std::promise<void> all_done;
   std::vector<std::thread> threads;
   threads.reserve(num_threads);
 
@@ -64,10 +68,18 @@ TEST_F(LatencyTrackerTest, ConcurrentRecordFromMultipleThreads) {
                         static_cast<uint64_t>(t + 1) * 1000 +
                             static_cast<uint64_t>(i));
       }
+      if (done_count.fetch_add(1, std::memory_order_acq_rel) + 1 ==
+          num_threads) {
+        all_done.set_value();
+      }
     });
   }
 
   start.store(true, std::memory_order_release);
+
+  auto status = all_done.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
+
   for (auto &t : threads) {
     t.join();
   }

--- a/tests/test_lockfree_mpsc_queue.cpp
+++ b/tests/test_lockfree_mpsc_queue.cpp
@@ -224,7 +224,7 @@ TEST_F(LockFreeMPSCQueueTest, StressTestHighContention) {
   })};
 
   auto status =
-      consumer_finished.get_future().wait_for(std::chrono::seconds(5));
+      consumer_finished.get_future().wait_for(std::chrono::seconds(30));
   ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
 
   for (auto &t : producers) {

--- a/tests/test_lockfree_mpsc_queue.cpp
+++ b/tests/test_lockfree_mpsc_queue.cpp
@@ -1,7 +1,9 @@
 #include "LockFreeMPSCQueue.hpp"
+#include "ThreadGuard.hpp"
 #include <algorithm>
 #include <atomic>
 #include <cstring>
+#include <future>
 #include <gtest/gtest.h>
 #include <set>
 #include <thread>
@@ -68,18 +70,22 @@ TEST_F(LockFreeMPSCQueueTest, InterleavedPushPop) {
 TEST_F(LockFreeMPSCQueueTest, WaitAndPopBlocks) {
   std::atomic<bool> consumer_done{false};
   int consumed_value = 0;
+  std::promise<void> consumer_finished;
 
-  std::thread consumer([&]() {
+  ThreadGuard consumer{std::thread([&]() {
     queue.wait_and_pop(consumed_value);
     consumer_done.store(true);
-  });
+    consumer_finished.set_value();
+  })};
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
   EXPECT_FALSE(consumer_done.load());
 
   queue.push(999);
 
-  consumer.join();
+  auto status =
+      consumer_finished.get_future().wait_for(std::chrono::seconds(2));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
   EXPECT_TRUE(consumer_done.load());
   EXPECT_EQ(consumed_value, 999);
 }
@@ -87,16 +93,24 @@ TEST_F(LockFreeMPSCQueueTest, WaitAndPopBlocks) {
 TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopReturnsOnData) {
   std::atomic<bool> running{true};
   int value = 0;
+  bool got = false;
+  std::promise<void> consumer_finished;
 
-  std::thread producer([&]() {
+  ThreadGuard producer{std::thread([&]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     queue.push(42);
-  });
+  })};
 
-  EXPECT_TRUE(queue.wait_and_pop(value, running));
+  ThreadGuard consumer{std::thread([&]() {
+    got = queue.wait_and_pop(value, running);
+    consumer_finished.set_value();
+  })};
+
+  auto status =
+      consumer_finished.get_future().wait_for(std::chrono::seconds(2));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
+  EXPECT_TRUE(got);
   EXPECT_EQ(value, 42);
-
-  producer.join();
 }
 
 TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopExitsOnStop) {
@@ -104,17 +118,22 @@ TEST_F(LockFreeMPSCQueueTest, StoppableWaitAndPopExitsOnStop) {
   std::atomic<bool> consumer_exited{false};
   bool got = true;
   int value = 0;
+  std::promise<void> consumer_finished;
 
-  std::thread consumer([&]() {
+  ThreadGuard consumer{std::thread([&]() {
     got = queue.wait_and_pop(value, running);
     consumer_exited.store(true);
-  });
+    consumer_finished.set_value();
+  })};
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
   EXPECT_FALSE(consumer_exited.load());
 
   running.store(false);
-  consumer.join();
+
+  auto status =
+      consumer_finished.get_future().wait_for(std::chrono::seconds(2));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
   EXPECT_TRUE(consumer_exited.load());
   EXPECT_FALSE(got);
 }
@@ -127,6 +146,7 @@ TEST_F(LockFreeMPSCQueueTest, MultiProducerSingleConsumer) {
   std::vector<std::thread> producers;
   producers.reserve(num_producers);
   std::atomic<bool> start{false};
+  std::promise<void> consumer_finished;
 
   for (int p = 0; p < num_producers; ++p) {
     producers.emplace_back([&, p]() {
@@ -145,13 +165,20 @@ TEST_F(LockFreeMPSCQueueTest, MultiProducerSingleConsumer) {
   std::set<int> received;
   int consumed_count = 0;
 
-  while (consumed_count < total_items) {
-    int value;
-    if (queue.try_pop(value)) {
-      received.insert(value);
-      ++consumed_count;
+  ThreadGuard consumer{std::thread([&]() {
+    while (consumed_count < total_items) {
+      int value;
+      if (queue.try_pop(value)) {
+        received.insert(value);
+        ++consumed_count;
+      }
     }
-  }
+    consumer_finished.set_value();
+  })};
+
+  auto status =
+      consumer_finished.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
 
   for (auto &t : producers) {
     t.join();
@@ -171,6 +198,7 @@ TEST_F(LockFreeMPSCQueueTest, StressTestHighContention) {
   std::vector<std::thread> producers;
   producers.reserve(num_producers);
   std::atomic<int> production_counter{0};
+  std::promise<void> consumer_finished;
 
   for (int p = 0; p < num_producers; ++p) {
     producers.emplace_back([&]() {
@@ -185,12 +213,19 @@ TEST_F(LockFreeMPSCQueueTest, StressTestHighContention) {
   std::vector<int> received;
   received.reserve(total_items);
 
-  while (received.size() < total_items) {
-    int value;
-    if (queue.try_pop(value)) {
-      received.push_back(value);
+  ThreadGuard consumer{std::thread([&]() {
+    while (received.size() < static_cast<size_t>(total_items)) {
+      int value;
+      if (queue.try_pop(value)) {
+        received.push_back(value);
+      }
     }
-  }
+    consumer_finished.set_value();
+  })};
+
+  auto status =
+      consumer_finished.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
 
   for (auto &t : producers) {
     t.join();
@@ -206,8 +241,9 @@ TEST_F(LockFreeMPSCQueueTest, StressTestHighContention) {
 
 TEST_F(LockFreeMPSCQueueTest, MixedPushPopWithDelay) {
   std::atomic<bool> producer_done{false};
+  std::promise<void> consumer_finished;
 
-  std::thread producer([&]() {
+  ThreadGuard producer{std::thread([&]() {
     for (int i = 0; i < 1000; ++i) {
       queue.push(i);
       if (i % 100 == 0) {
@@ -215,21 +251,26 @@ TEST_F(LockFreeMPSCQueueTest, MixedPushPopWithDelay) {
       }
     }
     producer_done.store(true);
-  });
+  })};
 
   int consumed_count = 0;
   int last_value = -1;
 
-  while (!producer_done.load() || consumed_count < 1000) {
-    int value;
-    if (queue.try_pop(value)) {
-      EXPECT_GT(value, last_value);
-      last_value = value;
-      ++consumed_count;
+  ThreadGuard consumer{std::thread([&]() {
+    while (!producer_done.load() || consumed_count < 1000) {
+      int value;
+      if (queue.try_pop(value)) {
+        EXPECT_GT(value, last_value);
+        last_value = value;
+        ++consumed_count;
+      }
     }
-  }
+    consumer_finished.set_value();
+  })};
 
-  producer.join();
+  auto status =
+      consumer_finished.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
   EXPECT_EQ(consumed_count, 1000);
 }
 

--- a/tests/test_order_cooldown.cpp
+++ b/tests/test_order_cooldown.cpp
@@ -1,6 +1,8 @@
 #include "OrderCooldown.hpp"
+#include "ThreadGuard.hpp"
 #include "Utils.hpp"
 #include <cstring>
+#include <future>
 #include <gtest/gtest.h>
 #include <thread>
 #include <vector>
@@ -81,6 +83,8 @@ TEST_F(OrderCooldownTest, ConcurrentDifferentSymbols) {
 
   std::atomic<bool> start{false};
   std::atomic<int> total_approved{0};
+  std::atomic<int> done_count{0};
+  std::promise<void> all_done;
   std::vector<std::thread> threads;
   threads.reserve(kNumThreads);
 
@@ -99,10 +103,17 @@ TEST_F(OrderCooldownTest, ConcurrentDifferentSymbols) {
         }
       }
       total_approved.fetch_add(approved, std::memory_order_relaxed);
+      if (done_count.fetch_add(1, std::memory_order_acq_rel) + 1 ==
+          kNumThreads) {
+        all_done.set_value();
+      }
     });
   }
 
   start.store(true, std::memory_order_release);
+
+  auto status = all_done.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
 
   for (auto &t : threads) {
     t.join();

--- a/tests/test_order_cooldown.cpp
+++ b/tests/test_order_cooldown.cpp
@@ -1,5 +1,4 @@
 #include "OrderCooldown.hpp"
-#include "ThreadGuard.hpp"
 #include "Utils.hpp"
 #include <cstring>
 #include <future>

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -162,7 +162,6 @@ TEST_F(OrderGatewayTest, AssignsSequentialOrderIdsWhileRunning) {
   while (call_count.load(std::memory_order_acquire) < 2) {
   }
   is_running.store(false);
-  guard.t.join();
 
   ASSERT_EQ(received_ids.size(), 2);
   EXPECT_EQ(received_ids[0], 1);
@@ -292,17 +291,18 @@ TEST_P(GatewayMainLoopExceptionTest, LogsCorrectError) {
   std::stringstream captured;
   auto *original = std::cerr.rdbuf(captured.rdbuf());
 
-  ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
+  {
+    ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
 
-  Order order{};
-  order.id = 1;
-  order_queue.push(order);
+    Order order{};
+    order.id = 1;
+    order_queue.push(order);
 
-  const auto status = future.wait_for(std::chrono::seconds(2));
-  ASSERT_EQ(status, std::future_status::ready);
-  is_running.store(false);
+    const auto status = future.wait_for(std::chrono::seconds(2));
+    ASSERT_EQ(status, std::future_status::ready);
+    is_running.store(false);
+  }
 
-  guard.t.join();
   std::cerr.rdbuf(original);
 
   EXPECT_TRUE(captured.str().find(expected_substr) != std::string::npos);
@@ -625,7 +625,6 @@ TEST_F(OrderGatewayTest, RecordsLatencyMetricsWhileRunning) {
   auto status = future.wait_for(std::chrono::seconds(2));
   ASSERT_EQ(status, std::future_status::ready);
   is_running.store(false);
-  guard.t.join();
 
   EXPECT_EQ(tracker.count(LatencyMetric::MpscQueue), 1);
   EXPECT_EQ(tracker.count(LatencyMetric::EndToEnd), 1);

--- a/tests/test_pending_order_tracker.cpp
+++ b/tests/test_pending_order_tracker.cpp
@@ -138,8 +138,4 @@ TEST_F(PendingOrderTrackerTest, ConcurrentAccess) {
   const auto status = future.wait_for(std::chrono::seconds(5));
   ASSERT_EQ(status, std::future_status::ready)
       << "ConcurrentAccess test timed out — possible deadlock";
-
-  writer1.t.join();
-  writer2.t.join();
-  reader.t.join();
 }

--- a/tests/test_position_manager.cpp
+++ b/tests/test_position_manager.cpp
@@ -1,6 +1,8 @@
 #include "PositionManager.hpp"
 #include "TestHelpers.hpp"
+#include "ThreadGuard.hpp"
 #include "Utils.hpp"
+#include <future>
 #include <gtest/gtest.h>
 #include <thread>
 #include <vector>
@@ -163,17 +165,27 @@ TEST_F(PositionManagerTest, FilledAndPendingIndependent) {
 }
 
 TEST_F(PositionManagerTest, ConcurrentFillsForSameSymbol) {
-  std::vector<std::thread> threads;
-  threads.reserve(4);
+  constexpr int kThreads = 4;
+  std::atomic<int> done_count{0};
+  std::promise<void> all_done;
 
-  for (int i = 0; i < 4; ++i) {
-    threads.emplace_back([this]() {
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([this, &done_count, &all_done]() {
       const Fill fill = createFill("AAPL", OrderSide::Buy, 1);
       for (int j = 0; j < 250; ++j) {
         pm.onFill(fill);
       }
+      if (done_count.fetch_add(1, std::memory_order_acq_rel) + 1 == kThreads) {
+        all_done.set_value();
+      }
     });
   }
+
+  auto status = all_done.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
 
   for (auto &t : threads) {
     t.join();
@@ -212,10 +224,14 @@ TEST_F(PositionManagerTest, DoubleRegisterDoesNotResetState) {
 TEST_F(PositionManagerTest, ConcurrentOrderSentAndFill) {
   constexpr int orders_per_thread = 500;
   constexpr int num_sender_threads = 4;
+  constexpr int total_threads = num_sender_threads + 1;
 
   std::atomic<bool> start{false};
+  std::atomic<int> done_count{0};
+  std::promise<void> all_done;
+
   std::vector<std::thread> threads;
-  threads.reserve(num_sender_threads + 1);
+  threads.reserve(total_threads);
 
   for (int t = 0; t < num_sender_threads; ++t) {
     threads.emplace_back([&]() {
@@ -223,6 +239,10 @@ TEST_F(PositionManagerTest, ConcurrentOrderSentAndFill) {
       }
       for (int i = 0; i < orders_per_thread; ++i) {
         pm.onOrderSent(createOrder("AAPL", OrderSide::Buy, 1, 1000));
+      }
+      if (done_count.fetch_add(1, std::memory_order_acq_rel) + 1 ==
+          total_threads) {
+        all_done.set_value();
       }
     });
   }
@@ -233,9 +253,16 @@ TEST_F(PositionManagerTest, ConcurrentOrderSentAndFill) {
     for (int i = 0; i < num_sender_threads * orders_per_thread; ++i) {
       pm.onFill(createFill("AAPL", OrderSide::Buy, 1));
     }
+    if (done_count.fetch_add(1, std::memory_order_acq_rel) + 1 ==
+        total_threads) {
+      all_done.set_value();
+    }
   });
 
   start.store(true, std::memory_order_release);
+
+  auto status = all_done.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout — possible deadlock";
 
   for (auto &t : threads) {
     t.join();

--- a/tests/test_position_manager.cpp
+++ b/tests/test_position_manager.cpp
@@ -1,7 +1,5 @@
 #include "PositionManager.hpp"
 #include "TestHelpers.hpp"
-#include "ThreadGuard.hpp"
-#include "Utils.hpp"
 #include <future>
 #include <gtest/gtest.h>
 #include <thread>


### PR DESCRIPTION
## Summary

- Add `std::future` timeouts with `ASSERT_EQ(status, ready)` to every concurrency test that previously used raw `thread.join()` with no hang detection
- Fix 4 double-join bugs where `guard.t.join()` was called explicitly before ThreadGuard destructor
- Scope ThreadGuard lifetime with blocks where stderr capture requires deterministic join ordering

**Tests hardened (UNSAFE -> timeout-protected):**
- `test_position_manager`: ConcurrentFillsForSameSymbol, ConcurrentOrderSentAndFill
- `test_lockfree_mpsc_queue`: WaitAndPopBlocks, StoppableWaitAndPopReturnsOnData, StoppableWaitAndPopExitsOnStop, MultiProducerSingleConsumer, StressTestHighContention, MixedPushPopWithDelay
- `test_latency_tracker`: ConcurrentRecordFromMultipleThreads
- `test_order_cooldown`: ConcurrentDifferentSymbols
- `test_fill_listener`: StopDuringActiveProcessingCompletesCorrectly

**Double-join bugs fixed:**
- `test_order_gateway`: AssignSequentialOrderIds, LogsCorrectError, RecordsLatencyMetrics
- `test_pending_order_tracker`: ConcurrentAccess

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved concurrency test reliability by adding explicit completion synchronization and bounded waits to detect deadlocks.
  * Added timeout-based assertions so stalled tests fail fast instead of hanging indefinitely.
  * Strengthened thread lifecycle handling with safer guard-based patterns and reduced reliance on blocking joins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->