### PR TITLE
Add spdlog structured logging, replace all cout/cerr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ target_link_libraries(
 target_compile_definitions(
     paper_money
     PRIVATE
-        $<IF:$<CONFIG:Release>,SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO,SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
+        $<IF:$<CONFIG:Debug>,SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE,SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
 )
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ find_package(TBB CONFIG REQUIRED)
 find_package(ixwebsocket CONFIG REQUIRED)
 find_package(msgpack-cxx CONFIG REQUIRED)
 find_package(hdr_histogram CONFIG REQUIRED)
+find_package(spdlog CONFIG REQUIRED)
 
 file(GLOB_RECURSE SOURCES src/*.cpp)
 file(GLOB_RECURSE HEADERS include/*.hpp)
@@ -102,7 +103,14 @@ target_link_libraries(
             TBB::tbb
             ixwebsocket::ixwebsocket
             msgpack-cxx
-            hdr_histogram::hdr_histogram_static)
+            hdr_histogram::hdr_histogram_static
+            spdlog::spdlog)
+
+target_compile_definitions(
+    paper_money
+    PRIVATE
+        $<IF:$<CONFIG:Release>,SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO,SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
+)
 
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
@@ -130,7 +138,10 @@ target_link_libraries(
            TBB::tbb
            ixwebsocket::ixwebsocket
            msgpack-cxx
-           hdr_histogram::hdr_histogram_static)
+           hdr_histogram::hdr_histogram_static
+           spdlog::spdlog)
+
+target_compile_definitions(rich_on_tests PRIVATE SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
 if(SANITIZER_ACTIVE AND NOT MSVC)
     target_compile_options(rich_on_tests PRIVATE ${SANITIZER_FLAGS})

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -12,6 +12,10 @@
 #include <variant>
 #include <vector>
 
+namespace spdlog {
+class logger;
+} // namespace spdlog
+
 struct FillEvent {
   char symbol[8];
   OrderSide side;
@@ -118,4 +122,6 @@ private:
   void upsertFilledQty(std::string_view order_id, int64_t qty);
   [[nodiscard]] bool isCompleted(std::string_view order_id) const noexcept;
   void markCompleted(std::string_view order_id);
+
+  spdlog::logger *logger_;
 };

--- a/include/AlpacaWebSocketSource.hpp
+++ b/include/AlpacaWebSocketSource.hpp
@@ -9,6 +9,10 @@
 #include <thread>
 #include <vector>
 
+namespace spdlog {
+class logger;
+} // namespace spdlog
+
 class AlpacaWebSocketSource {
 public:
   using RawDataFn = void (*)(void *, std::span<const char>);
@@ -47,6 +51,7 @@ private:
   std::thread thread_;
   RawDataFn on_data_fn_ = nullptr;
   void *on_data_ctx_ = nullptr;
+  spdlog::logger *logger_;
 };
 
 static_assert(MarketDataSourceLike<AlpacaWebSocketSource>,

--- a/include/Logging.hpp
+++ b/include/Logging.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace logging {
+
+/// Call once from main(), before any threads are spawned.
+void init();
+
+/// Register all named loggers with null sinks (for test binaries).
+void initForTests();
+
+/// Flush all loggers and drop the spdlog registry.
+void shutdown();
+
+} // namespace logging

--- a/include/MarketEventConsumer.hpp
+++ b/include/MarketEventConsumer.hpp
@@ -7,8 +7,8 @@
 #include "Utils.hpp"
 #include <atomic>
 #include <cstring>
-#include <iostream>
 #include <memory>
+#include <spdlog/spdlog.h>
 #include <string>
 #include <zmq.hpp>
 
@@ -37,8 +37,9 @@ public:
                       std::string_view(symbol_, symbol.size()));
       subscriber_.connect(address);
     } catch (const zmq::error_t &e) {
-      std::cerr << "MarketEventConsumer for " << symbol_
-                << " ZMQ error during construction: " << e.what() << '\n';
+      spdlog::get("system")->error(
+          "MarketEventConsumer for {} ZMQ error during construction: {}",
+          symbol_, e.what());
       throw;
     }
   }

--- a/include/OrderGateway.hpp
+++ b/include/OrderGateway.hpp
@@ -6,6 +6,10 @@
 #include <atomic>
 #include <memory>
 
+namespace spdlog {
+class logger;
+} // namespace spdlog
+
 class LatencyTracker;
 class PendingOrderTracker;
 class PositionManager;
@@ -31,4 +35,5 @@ private:
   PendingOrderTracker *pending_tracker_;
   LatencyTracker *latency_tracker_;
   uint64_t order_id_counter_ = 0;
+  spdlog::logger *logger_;
 };

--- a/include/ThreadPinning.hpp
+++ b/include/ThreadPinning.hpp
@@ -3,4 +3,4 @@
 #include <cstdint>
 #include <thread>
 
-void pin_thread_to_core(std::thread &t, uint32_t core_id);
+[[nodiscard]] bool pin_thread_to_core(std::thread &t, uint32_t core_id);

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -18,6 +18,10 @@
 #include <type_traits>
 #include <vector>
 
+namespace spdlog {
+class logger;
+} // namespace spdlog
+
 class IFillListener;
 
 struct OrderQueuePusher {
@@ -79,4 +83,5 @@ private:
   std::unique_ptr<IRestClient> reconciliation_client_;
   std::unique_ptr<IFillListener> fill_listener_;
   std::unique_ptr<AlpacaPipeline> market_publisher_;
+  spdlog::logger *logger_;
 };

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -207,8 +207,11 @@ void AlpacaFillListener::start() {
       [this](const ix::WebSocketMessagePtr &msg) { onMessage(msg); });
 
   thread_ = std::thread(&ix::WebSocket::run, &ws_);
-  pin_thread_to_core(thread_, 0);
-  logger_->info("Pinned FillListener thread to CPU Core 0");
+  if (pin_thread_to_core(thread_, 0)) {
+    logger_->info("Pinned FillListener thread to CPU Core 0");
+  } else {
+    logger_->warn("Failed to pin FillListener thread to CPU Core 0");
+  }
 }
 
 void AlpacaFillListener::stop() {

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -7,9 +7,9 @@
 #include <chrono>
 #include <cstring>
 #include <ctime>
-#include <iostream>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <spdlog/spdlog.h>
 #include <stdexcept>
 #include <thread>
 
@@ -56,7 +56,7 @@ void copyOrderId(char (&dest)[48], const std::string &src) {
       return val.get<int64_t>();
     }
   } catch (const std::exception &e) {
-    std::cerr << "FillListener: parseQty failed: " << e.what() << '\n';
+    spdlog::get("fills")->warn("parseQty failed: {}", e.what());
   }
   return std::nullopt;
 }
@@ -70,7 +70,7 @@ void copyOrderId(char (&dest)[48], const std::string &src) {
       return val.get<double>();
     }
   } catch (const std::exception &e) {
-    std::cerr << "FillListener: parsePrice failed: " << e.what() << '\n';
+    spdlog::get("fills")->warn("parsePrice failed: {}", e.what());
   }
   return std::nullopt;
 }
@@ -188,7 +188,8 @@ AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
     : position_manager_(position_manager), pending_tracker_(pending_tracker),
       latency_tracker_(latency_tracker),
       reconciliation_client_(reconciliation_client), is_running_(is_running),
-      api_key_(api_key), api_secret_(api_secret) {
+      api_key_(api_key), api_secret_(api_secret),
+      logger_(spdlog::get("fills").get()) {
   if (position_manager_ == nullptr) {
     throw std::invalid_argument(
         "AlpacaFillListener: position_manager must not be null");
@@ -207,7 +208,7 @@ void AlpacaFillListener::start() {
 
   thread_ = std::thread(&ix::WebSocket::run, &ws_);
   pin_thread_to_core(thread_, 0);
-  std::cout << "Pinned FillListener thread to CPU Core 0" << '\n';
+  logger_->info("Pinned FillListener thread to CPU Core 0");
 }
 
 void AlpacaFillListener::stop() {
@@ -225,11 +226,9 @@ void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
   switch (msg->type) {
   case ix::WebSocketMessageType::Open:
     if (has_connected_) {
-      std::cout << "FillListener: WebSocket reconnected — will reconcile after "
-                   "auth"
-                << '\n';
+      logger_->info("WebSocket reconnected — will reconcile after auth");
     } else {
-      std::cout << "FillListener: WebSocket connected" << '\n';
+      logger_->info("WebSocket connected");
     }
     sendAuth();
     break;
@@ -239,13 +238,11 @@ void AlpacaFillListener::onMessage(const ix::WebSocketMessagePtr &msg) {
     break;
 
   case ix::WebSocketMessageType::Error:
-    std::cerr << "FillListener: WebSocket error: " << msg->errorInfo.reason
-              << '\n';
+    logger_->error("WebSocket error: {}", msg->errorInfo.reason);
     break;
 
   case ix::WebSocketMessageType::Close:
-    std::cout << "FillListener: WebSocket closed (code=" << msg->closeInfo.code
-              << ")" << '\n';
+    logger_->info("WebSocket closed (code={})", msg->closeInfo.code);
     break;
 
   default:
@@ -270,7 +267,7 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
   try {
     parsed = nlohmann::json::parse(json);
   } catch (const nlohmann::json::parse_error &) {
-    std::cerr << "FillListener: Failed to parse message" << '\n';
+    logger_->error("Failed to parse message");
     return;
   }
 
@@ -296,7 +293,7 @@ void AlpacaFillListener::handleTradeUpdate(const std::string &json) {
 void AlpacaFillListener::handleAuthorization(const nlohmann::json &parsed) {
   if (parsed.contains("data") && parsed["data"].contains("status") &&
       parsed["data"]["status"] == "authorized") {
-    std::cout << "FillListener: Authorized" << '\n';
+    logger_->info("Authorized");
     sendSubscribe();
     if (has_connected_) {
       reconcileAfterReconnect();
@@ -305,14 +302,14 @@ void AlpacaFillListener::handleAuthorization(const nlohmann::json &parsed) {
     }
     has_connected_ = true;
   } else {
-    std::cerr << "FillListener: Authorization failed" << '\n';
+    logger_->error("Authorization failed");
   }
 }
 
 void AlpacaFillListener::handleListening(const nlohmann::json &parsed) {
   if (!parsed.contains("data") || !parsed["data"].contains("streams") ||
       !parsed["data"]["streams"].is_array()) {
-    std::cerr << "FillListener: Malformed listening response" << '\n';
+    logger_->warn("Malformed listening response");
     return;
   }
 
@@ -325,9 +322,9 @@ void AlpacaFillListener::handleListening(const nlohmann::json &parsed) {
     }
   }
   if (found) {
-    std::cout << "FillListener: Subscribed to trade_updates" << '\n';
+    logger_->info("Subscribed to trade_updates");
   } else {
-    std::cerr << "FillListener: trade_updates not in streams list" << '\n';
+    logger_->warn("trade_updates not in streams list");
   }
 }
 
@@ -358,12 +355,11 @@ void AlpacaFillListener::processFillEvent(const FillEvent &fill_event) {
     std::memcpy(key.value, fill_event.symbol, kSymbolCapacity);
     pending_tracker_->onOrderCompleted(key, fill_event.side, order_id);
   }
-  std::cout << "FillListener: "
-            << (fill_event.is_partial ? "Partial fill" : "Fill")
-            << " processed ("
-            << std::string_view(fill_event.symbol,
-                                strnlen(fill_event.symbol, kSymbolCapacity))
-            << " qty=" << fill_event.quantity << ")" << '\n';
+  logger_->info("{} processed ({} qty={})",
+                fill_event.is_partial ? "Partial fill" : "Fill",
+                std::string_view(fill_event.symbol,
+                                 strnlen(fill_event.symbol, kSymbolCapacity)),
+                fill_event.quantity);
 }
 
 void AlpacaFillListener::processCancelEvent(const CancelEvent &cancel_event) {
@@ -387,21 +383,20 @@ void AlpacaFillListener::processCancelEvent(const CancelEvent &cancel_event) {
     std::memcpy(key.value, cancel_event.symbol, kSymbolCapacity);
     pending_tracker_->onOrderCompleted(key, cancel_event.side, order_id);
   }
-  std::cout << "FillListener: Cancel processed ("
-            << std::string_view(cancel_event.symbol,
-                                strnlen(cancel_event.symbol, kSymbolCapacity))
-            << " qty=" << cancel_event.quantity << ")" << '\n';
+  logger_->info("Cancel processed ({} qty={})",
+                std::string_view(cancel_event.symbol,
+                                 strnlen(cancel_event.symbol, kSymbolCapacity)),
+                cancel_event.quantity);
 }
 
 void AlpacaFillListener::reconcileAfterReconnect() {
   if (reconciliation_client_ == nullptr) {
-    std::cerr << "FillListener: No reconciliation client — skipping "
-                 "post-reconnect reconciliation"
-              << '\n';
+    logger_->warn(
+        "No reconciliation client — skipping post-reconnect reconciliation");
     return;
   }
 
-  std::cout << "FillListener: Starting post-reconnect reconciliation" << '\n';
+  logger_->info("Starting post-reconnect reconciliation");
 
   constexpr int64_t kPageSize = 500;
   int64_t reconciled_fills = 0;
@@ -411,9 +406,8 @@ void AlpacaFillListener::reconcileAfterReconnect() {
   for (;;) {
     auto result = reconciliation_client_->queryOrders("all", cursor);
     if (!result) {
-      std::cerr << "FillListener: Reconciliation query failed (HTTP "
-                << result.error().status_code << "): " << result.error().message
-                << '\n';
+      logger_->error("Reconciliation query failed (HTTP {}): {}",
+                     result.error().status_code, result.error().message);
       break;
     }
 
@@ -447,9 +441,8 @@ void AlpacaFillListener::reconcileAfterReconnect() {
     }
   }
 
-  std::cout << "FillListener: Reconciliation complete (fills="
-            << reconciled_fills << " cancels=" << reconciled_cancels << ")"
-            << '\n';
+  logger_->info("Reconciliation complete (fills={} cancels={})",
+                reconciled_fills, reconciled_cancels);
 }
 
 int64_t AlpacaFillListener::reconcileFill(const AlpacaOrderStatus &alpaca_order,
@@ -480,9 +473,8 @@ int64_t AlpacaFillListener::reconcileFill(const AlpacaOrderStatus &alpaca_order,
     }
   }
 
-  std::cout << "FillListener: Reconciled fill (" << alpaca_order.symbol
-            << " qty=" << remaining
-            << " avg_price=" << alpaca_order.filled_avg_price << ")" << '\n';
+  logger_->info("Reconciled fill ({} qty={} avg_price={})", alpaca_order.symbol,
+                remaining, alpaca_order.filled_avg_price);
   return 1;
 }
 
@@ -524,9 +516,8 @@ AlpacaFillListener::reconcileCancel(const AlpacaOrderStatus &alpaca_order,
     pending_tracker_->onOrderCompleted(key, side, alpaca_order.id);
   }
 
-  std::cout << "FillListener: Reconciled cancel (" << alpaca_order.symbol
-            << " filled=" << missed_fills << " unfilled=" << unfilled << ")"
-            << '\n';
+  logger_->info("Reconciled cancel ({} filled={} unfilled={})",
+                alpaca_order.symbol, missed_fills, unfilled);
   return 1;
 }
 

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -3,8 +3,8 @@
 #include <cpr/curlholder.h>
 #include <cstring>
 #include <curl/curl.h>
-#include <iostream>
 #include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
 #include <stdexcept>
 #include <string>
 
@@ -233,8 +233,8 @@ AlpacaRestClient::queryOrders(std::string_view status_filter,
       const auto *end = qty_str.data() + qty_str.size();
       auto [ptr, ec] = std::from_chars(qty_str.data(), end, order.qty);
       if (ec != std::errc{} || ptr != end) {
-        std::cerr << "AlpacaRestClient: Non-integer qty '" << qty_str
-                  << "' for order " << order.id << ", skipping" << '\n';
+        spdlog::get("rest")->warn("Non-integer qty '{}' for order {}, skipping",
+                                  qty_str, order.id);
         continue;
       }
     }
@@ -243,8 +243,9 @@ AlpacaRestClient::queryOrders(std::string_view status_filter,
       auto [ptr, ec] =
           std::from_chars(filled_str.data(), end, order.filled_qty);
       if (ec != std::errc{} || ptr != end) {
-        std::cerr << "AlpacaRestClient: Non-integer filled_qty '" << filled_str
-                  << "' for order " << order.id << ", skipping" << '\n';
+        spdlog::get("rest")->warn(
+            "Non-integer filled_qty '{}' for order {}, skipping", filled_str,
+            order.id);
         continue;
       }
     }
@@ -260,14 +261,14 @@ AlpacaRestClient::queryOrders(std::string_view status_filter,
           try {
             order.filled_avg_price = std::stod(s, &pos);
             if (pos != s.size()) {
-              std::cerr << "AlpacaRestClient: Trailing chars in "
-                           "filled_avg_price '"
-                        << s << "' for order " << order.id << '\n';
+              spdlog::get("rest")->warn(
+                  "Trailing chars in filled_avg_price '{}' for order {}", s,
+                  order.id);
               order.filled_avg_price = 0.0;
             }
           } catch (const std::exception &e) {
-            std::cerr << "AlpacaRestClient: Failed to parse filled_avg_price '"
-                      << s << "': " << e.what() << '\n';
+            spdlog::get("rest")->warn(
+                "Failed to parse filled_avg_price '{}': {}", s, e.what());
           }
         }
       }

--- a/src/AlpacaWebSocketSource.cpp
+++ b/src/AlpacaWebSocketSource.cpp
@@ -16,7 +16,8 @@ AlpacaWebSocketSource::AlpacaWebSocketSource(std::string api_key,
                                              std::atomic<bool> &is_running)
     : api_key_(std::move(api_key)), api_secret_(std::move(api_secret)),
       symbols_(std::move(symbols)), is_running_(&is_running),
-      ws_(std::make_unique<ix::WebSocket>()) {}
+      ws_(std::make_unique<ix::WebSocket>()),
+      logger_(spdlog::get("market").get()) {}
 
 AlpacaWebSocketSource::~AlpacaWebSocketSource() { stop(); }
 
@@ -36,9 +37,9 @@ void AlpacaWebSocketSource::start() {
 
   thread_ = std::thread(&ix::WebSocket::run, ws_.get());
   if (pin_thread_to_core(thread_, 1)) {
-    spdlog::get("market")->info("Pinned to CPU core 1");
+    logger_->info("Pinned to CPU core 1");
   } else {
-    spdlog::get("market")->warn("Failed to pin to CPU core 1");
+    logger_->warn("Failed to pin to CPU core 1");
   }
 }
 
@@ -58,7 +59,7 @@ void AlpacaWebSocketSource::onMessage(const ix::WebSocketMessagePtr &msg) {
 
   switch (msg->type) {
   case ix::WebSocketMessageType::Open:
-    spdlog::get("market")->info("Connected");
+    logger_->info("Connected");
     sendAuth();
     break;
 
@@ -70,11 +71,11 @@ void AlpacaWebSocketSource::onMessage(const ix::WebSocketMessagePtr &msg) {
     break;
 
   case ix::WebSocketMessageType::Error:
-    spdlog::get("market")->error("WebSocket error: {}", msg->errorInfo.reason);
+    logger_->error("WebSocket error: {}", msg->errorInfo.reason);
     break;
 
   case ix::WebSocketMessageType::Close:
-    spdlog::get("market")->info("Closed (code={})", msg->closeInfo.code);
+    logger_->info("Closed (code={})", msg->closeInfo.code);
     break;
 
   default:
@@ -106,5 +107,5 @@ void AlpacaWebSocketSource::sendSubscribe() {
   pk.pack("trades");
   pk.pack(symbols_);
   ws_->sendBinary(std::string(buffer.data(), buffer.size()));
-  spdlog::get("market")->info("Subscribed to {} symbols", symbols_.size());
+  logger_->info("Subscribed to {} symbols", symbols_.size());
 }

--- a/src/AlpacaWebSocketSource.cpp
+++ b/src/AlpacaWebSocketSource.cpp
@@ -35,8 +35,11 @@ void AlpacaWebSocketSource::start() {
       [this](const ix::WebSocketMessagePtr &msg) { onMessage(msg); });
 
   thread_ = std::thread(&ix::WebSocket::run, ws_.get());
-  pin_thread_to_core(thread_, 1);
-  spdlog::get("market")->info("Pinned to CPU core 1");
+  if (pin_thread_to_core(thread_, 1)) {
+    spdlog::get("market")->info("Pinned to CPU core 1");
+  } else {
+    spdlog::get("market")->warn("Failed to pin to CPU core 1");
+  }
 }
 
 void AlpacaWebSocketSource::stop() {

--- a/src/AlpacaWebSocketSource.cpp
+++ b/src/AlpacaWebSocketSource.cpp
@@ -1,7 +1,7 @@
 #include "AlpacaWebSocketSource.hpp"
 #include "ThreadPinning.hpp"
-#include <iostream>
 #include <msgpack.hpp>
+#include <spdlog/spdlog.h>
 
 namespace {
 constexpr const char *kDataStreamUrl =
@@ -36,7 +36,7 @@ void AlpacaWebSocketSource::start() {
 
   thread_ = std::thread(&ix::WebSocket::run, ws_.get());
   pin_thread_to_core(thread_, 1);
-  std::cout << "AlpacaWebSocketSource: pinned to CPU core 1" << '\n';
+  spdlog::get("market")->info("Pinned to CPU core 1");
 }
 
 void AlpacaWebSocketSource::stop() {
@@ -55,7 +55,7 @@ void AlpacaWebSocketSource::onMessage(const ix::WebSocketMessagePtr &msg) {
 
   switch (msg->type) {
   case ix::WebSocketMessageType::Open:
-    std::cout << "AlpacaWebSocketSource: connected" << '\n';
+    spdlog::get("market")->info("Connected");
     sendAuth();
     break;
 
@@ -67,13 +67,11 @@ void AlpacaWebSocketSource::onMessage(const ix::WebSocketMessagePtr &msg) {
     break;
 
   case ix::WebSocketMessageType::Error:
-    std::cerr << "AlpacaWebSocketSource: error: " << msg->errorInfo.reason
-              << '\n';
+    spdlog::get("market")->error("WebSocket error: {}", msg->errorInfo.reason);
     break;
 
   case ix::WebSocketMessageType::Close:
-    std::cout << "AlpacaWebSocketSource: closed (code=" << msg->closeInfo.code
-              << ")" << '\n';
+    spdlog::get("market")->info("Closed (code={})", msg->closeInfo.code);
     break;
 
   default:
@@ -105,6 +103,5 @@ void AlpacaWebSocketSource::sendSubscribe() {
   pk.pack("trades");
   pk.pack(symbols_);
   ws_->sendBinary(std::string(buffer.data(), buffer.size()));
-  std::cout << "AlpacaWebSocketSource: subscribed to " << symbols_.size()
-            << " symbols" << '\n';
+  spdlog::get("market")->info("Subscribed to {} symbols", symbols_.size());
 }

--- a/src/LatencyTracker.cpp
+++ b/src/LatencyTracker.cpp
@@ -3,7 +3,7 @@
 #include <fstream>
 #include <hdr/hdr_histogram.h>
 #include <iomanip>
-#include <iostream>
+#include <spdlog/spdlog.h>
 #include <sstream>
 #include <stdexcept>
 
@@ -77,9 +77,10 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   const char *name = kMetricNames[idx];
   const char *desc = kMetricDescriptions[idx];
 
+  auto *log = spdlog::get("latency").get();
+
   if (h->total_count == 0) {
-    std::cout << "\n=== " << desc << " ===\n";
-    std::cout << "  (no samples recorded)\n";
+    log->info("=== {} === (no samples recorded)", desc);
     return;
   }
 
@@ -90,9 +91,6 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   const auto min_val = hdr_min(h);
   const auto max_val = hdr_max(h);
   const auto mean_val = hdr_mean(h);
-
-  std::cout << "\n=== " << desc << " ===\n";
-  std::cout << "  Samples: " << h->total_count << '\n';
 
   auto fmt = [](int64_t nanos) -> std::string {
     std::ostringstream oss;
@@ -111,13 +109,10 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
     return oss.str();
   };
 
-  std::cout << "  Min:     " << fmt(min_val) << '\n';
-  std::cout << "  Mean:    " << fmt(static_cast<int64_t>(mean_val)) << '\n';
-  std::cout << "  p50:     " << fmt(p50) << '\n';
-  std::cout << "  p90:     " << fmt(p90) << '\n';
-  std::cout << "  p99:     " << fmt(p99) << '\n';
-  std::cout << "  p99.9:   " << fmt(p999) << '\n';
-  std::cout << "  Max:     " << fmt(max_val) << '\n';
+  log->info("=== {} === samples={}", desc, h->total_count);
+  log->info("  Min={} Mean={} p50={} p90={} p99={} p99.9={} Max={}",
+            fmt(min_val), fmt(static_cast<int64_t>(mean_val)), fmt(p50),
+            fmt(p90), fmt(p99), fmt(p999), fmt(max_val));
 
   const std::string filepath = output_dir + "/latency_" + name + ".txt";
   std::ofstream file(filepath);
@@ -132,18 +127,18 @@ void LatencyTracker::dumpOne(LatencyMetric metric,
   file << "p99:     " << fmt(p99) << '\n';
   file << "p99.9:   " << fmt(p999) << '\n';
   file << "Max:     " << fmt(max_val) << '\n';
-  std::cout << "  Written: " << filepath << '\n';
+  log->info("  Written: {}", filepath);
 }
 
 void LatencyTracker::dump(const std::string &output_dir) const {
-  std::cout << "\n"
-            << "========================================\n"
-            << "  LATENCY REPORT\n"
-            << "========================================\n";
+  auto *log = spdlog::get("latency").get();
+  log->info("======================================== LATENCY REPORT "
+            "========================================");
 
   for (size_t i = 0; i < kMetricCount; ++i) {
     dumpOne(static_cast<LatencyMetric>(i), output_dir);
   }
 
-  std::cout << "========================================\n";
+  log->info("=============================================================="
+            "==========================");
 }

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -1,0 +1,53 @@
+#include "Logging.hpp"
+#include <array>
+#include <spdlog/async.h>
+#include <spdlog/sinks/null_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+namespace {
+
+constexpr std::array kLoggerNames = {"engine", "gateway", "fills",  "rest",
+                                     "market", "zmq",     "system", "latency"};
+
+} // namespace
+
+namespace logging {
+
+void init() {
+  spdlog::init_thread_pool(8192, 1);
+
+  auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+  console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [%^%l%$] %v");
+
+  for (const auto *name : kLoggerNames) {
+    auto logger = std::make_shared<spdlog::async_logger>(
+        name, console_sink, spdlog::thread_pool(),
+        spdlog::async_overflow_policy::overrun_oldest);
+    logger->set_level(spdlog::level::trace);
+    spdlog::register_logger(logger);
+  }
+
+  spdlog::set_default_logger(spdlog::get("system"));
+}
+
+void initForTests() {
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+
+  for (const auto *name : kLoggerNames) {
+    if (spdlog::get(name)) {
+      continue;
+    }
+    auto logger = std::make_shared<spdlog::logger>(name, null_sink);
+    logger->set_level(spdlog::level::trace);
+    spdlog::register_logger(logger);
+  }
+
+  if (!spdlog::default_logger()->name().empty()) {
+    spdlog::set_default_logger(spdlog::get("system"));
+  }
+}
+
+void shutdown() { spdlog::shutdown(); }
+
+} // namespace logging

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -43,9 +43,7 @@ void initForTests() {
     spdlog::register_logger(logger);
   }
 
-  if (!spdlog::default_logger()->name().empty()) {
-    spdlog::set_default_logger(spdlog::get("system"));
-  }
+  spdlog::set_default_logger(spdlog::get("system"));
 }
 
 void shutdown() { spdlog::shutdown(); }

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -18,7 +18,7 @@ void init() {
   spdlog::init_thread_pool(8192, 1);
 
   auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-  console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [%^%l%$] %v");
+  console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%F] [%n] [%^%l%$] %v");
 
   for (const auto *name : kLoggerNames) {
     auto logger = std::make_shared<spdlog::async_logger>(

--- a/src/OrderGateway.cpp
+++ b/src/OrderGateway.cpp
@@ -5,7 +5,7 @@
 #include "SymbolKey.hpp"
 #include "Utils.hpp"
 #include <cstring>
-#include <iostream>
+#include <spdlog/spdlog.h>
 #include <stdexcept>
 
 OrderGateway::OrderGateway(std::atomic<bool> &is_running,
@@ -16,7 +16,8 @@ OrderGateway::OrderGateway(std::atomic<bool> &is_running,
                            LatencyTracker *latency_tracker)
     : is_running_(is_running), order_queue_(order_queue),
       rest_client_(std::move(rest_client)), position_manager_(position_manager),
-      pending_tracker_(pending_tracker), latency_tracker_(latency_tracker) {
+      pending_tracker_(pending_tracker), latency_tracker_(latency_tracker),
+      logger_(spdlog::get("gateway").get()) {
   if (order_queue_ == nullptr) {
     throw std::invalid_argument("OrderGateway: order_queue must not be null");
   }
@@ -40,28 +41,25 @@ void OrderGateway::executeOrder(const Order &order) {
       try {
         auto cancel_result = rest_client_->cancelOrder(prev_id->view());
         if (cancel_result) {
-          std::cerr << "OrderGateway: Canceled previous order "
-                    << prev_id->view() << '\n';
+          logger_->info("Canceled previous order {}", prev_id->view());
           cancel_accepted = true;
         } else {
           const auto code = cancel_result.error().status_code;
-          std::cerr << "OrderGateway: Cancel returned HTTP " << code << " for "
-                    << prev_id->view() << ": " << cancel_result.error().message
-                    << '\n';
+          logger_->warn("Cancel returned HTTP {} for {}: {}", code,
+                        prev_id->view(), cancel_result.error().message);
           if (code == 422) {
             cancel_accepted = true;
           }
         }
       } catch (const std::exception &e) {
-        std::cerr << "OrderGateway: Exception canceling order "
-                  << prev_id->view() << ": " << e.what() << '\n';
+        logger_->error("Exception canceling order {}: {}", prev_id->view(),
+                       e.what());
       } catch (...) {
-        std::cerr << "OrderGateway: Unknown error canceling order "
-                  << prev_id->view() << '\n';
+        logger_->error("Unknown error canceling order {}", prev_id->view());
       }
       if (!cancel_accepted) {
-        std::cerr << "OrderGateway: Skipping new order — cancel for "
-                  << prev_id->view() << " did not reach Alpaca" << '\n';
+        logger_->warn("Skipping new order — cancel for {} did not reach Alpaca",
+                      prev_id->view());
         position_manager_->onOrderCancelled(order);
         return;
       }
@@ -71,8 +69,8 @@ void OrderGateway::executeOrder(const Order &order) {
   try {
     auto result = rest_client_->placeOrder(order);
     if (result) {
-      std::cerr << "OrderGateway: Placed order " << result->client_order_id
-                << " status=" << result->status << '\n';
+      logger_->info("Placed order {} status={}", result->client_order_id,
+                    result->status);
       if (pending_tracker_) {
         pending_tracker_->recordOrder(key, order.side, result->client_order_id);
       }
@@ -80,15 +78,15 @@ void OrderGateway::executeOrder(const Order &order) {
         latency_tracker_->recordOrderSubmit(result->client_order_id);
       }
     } else {
-      std::cerr << "OrderGateway: Rejected (HTTP " << result.error().status_code
-                << "): " << result.error().message << '\n';
+      logger_->warn("Rejected (HTTP {}): {}", result.error().status_code,
+                    result.error().message);
       position_manager_->onOrderCancelled(order);
     }
   } catch (const std::exception &e) {
-    std::cerr << "OrderGateway: Exception placing order: " << e.what() << '\n';
+    logger_->error("Exception placing order: {}", e.what());
     position_manager_->onOrderCancelled(order);
   } catch (...) {
-    std::cerr << "OrderGateway: Unknown error placing order" << '\n';
+    logger_->error("Unknown error placing order");
     position_manager_->onOrderCancelled(order);
   }
 }

--- a/src/ThreadPinning.cpp
+++ b/src/ThreadPinning.cpp
@@ -1,5 +1,5 @@
 #include "ThreadPinning.hpp"
-#include <iostream>
+#include <spdlog/spdlog.h>
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -13,8 +13,8 @@
 void pin_thread_to_core(std::thread &t, uint32_t core_id) {
 #if defined(__linux__) || defined(__gnu_linux__)
   if (core_id >= CPU_SETSIZE) {
-    std::cerr << "Error: core_id " << core_id << " exceeds CPU_SETSIZE ("
-              << CPU_SETSIZE << ")\n";
+    spdlog::get("system")->error("core_id {} exceeds CPU_SETSIZE ({})", core_id,
+                                 CPU_SETSIZE);
     return;
   }
   cpu_set_t cpuset;
@@ -22,18 +22,18 @@ void pin_thread_to_core(std::thread &t, uint32_t core_id) {
   CPU_SET(core_id, &cpuset);
   if (pthread_setaffinity_np(t.native_handle(), sizeof(cpu_set_t), &cpuset) !=
       0) {
-    std::cerr << "Error calling pthread_setaffinity_np\n";
+    spdlog::get("system")->error("pthread_setaffinity_np failed");
   }
 #elif defined(_WIN32)
   if (core_id >= 64) {
-    std::cerr << "Error: core_id " << core_id
-              << " exceeds 64-bit affinity mask limit" << '\n';
+    spdlog::get("system")->error(
+        "core_id {} exceeds 64-bit affinity mask limit", core_id);
     return;
   }
   if (const DWORD_PTR mask = 1ULL << core_id;
       SetThreadAffinityMask(t.native_handle(), mask) == 0) {
-    std::cerr << "Error calling SetThreadAffinityMask: " << GetLastError()
-              << '\n';
+    spdlog::get("system")->error("SetThreadAffinityMask failed: {}",
+                                 GetLastError());
   }
 #elif defined(__APPLE__)
   // THREAD_AFFINITY_POLICY is only a scheduling hint (same-tag threads
@@ -44,12 +44,12 @@ void pin_thread_to_core(std::thread &t, uint32_t core_id) {
   if (thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY,
                         (thread_policy_t)&policy,
                         THREAD_AFFINITY_POLICY_COUNT) != KERN_SUCCESS) {
-    std::cerr << "Warning: thread_policy_set affinity hint failed for core "
-              << core_id << '\n';
+    spdlog::get("system")->warn(
+        "thread_policy_set affinity hint failed for core {}", core_id);
   }
 #else
   (void)t;
   (void)core_id;
-  std::cerr << "Warning: CPU pinning not supported on this platform." << '\n';
+  spdlog::get("system")->warn("CPU pinning not supported on this platform");
 #endif
 }

--- a/src/ThreadPinning.cpp
+++ b/src/ThreadPinning.cpp
@@ -10,31 +10,36 @@
 #include <mach/thread_policy.h>
 #endif
 
-void pin_thread_to_core(std::thread &t, uint32_t core_id) {
+bool pin_thread_to_core(std::thread &t, uint32_t core_id) {
 #if defined(__linux__) || defined(__gnu_linux__)
   if (core_id >= CPU_SETSIZE) {
     spdlog::get("system")->error("core_id {} exceeds CPU_SETSIZE ({})", core_id,
                                  CPU_SETSIZE);
-    return;
+    return false;
   }
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(core_id, &cpuset);
   if (pthread_setaffinity_np(t.native_handle(), sizeof(cpu_set_t), &cpuset) !=
       0) {
-    spdlog::get("system")->error("pthread_setaffinity_np failed");
+    spdlog::get("system")->error("pthread_setaffinity_np failed for core {}",
+                                 core_id);
+    return false;
   }
+  return true;
 #elif defined(_WIN32)
   if (core_id >= 64) {
     spdlog::get("system")->error(
         "core_id {} exceeds 64-bit affinity mask limit", core_id);
-    return;
+    return false;
   }
   if (const DWORD_PTR mask = 1ULL << core_id;
       SetThreadAffinityMask(t.native_handle(), mask) == 0) {
-    spdlog::get("system")->error("SetThreadAffinityMask failed: {}",
-                                 GetLastError());
+    spdlog::get("system")->error("SetThreadAffinityMask failed for core {}: {}",
+                                 core_id, GetLastError());
+    return false;
   }
+  return true;
 #elif defined(__APPLE__)
   // THREAD_AFFINITY_POLICY is only a scheduling hint (same-tag threads
   // share L2 cache). It does not pin to a specific core, and on Apple
@@ -46,10 +51,13 @@ void pin_thread_to_core(std::thread &t, uint32_t core_id) {
                         THREAD_AFFINITY_POLICY_COUNT) != KERN_SUCCESS) {
     spdlog::get("system")->warn(
         "thread_policy_set affinity hint failed for core {}", core_id);
+    return false;
   }
+  return true;
 #else
   (void)t;
   (void)core_id;
   spdlog::get("system")->warn("CPU pinning not supported on this platform");
+  return false;
 #endif
 }

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -80,8 +80,11 @@ void TradingEngine::setup_signal_handler() {
 
 void TradingEngine::launch_gateway() {
   order_gateway_thread_ = std::thread(&OrderGateway::run, order_gateway_.get());
-  pin_thread_to_core(order_gateway_thread_, 0);
-  logger_->info("Pinned OrderGateway thread to CPU Core 0");
+  if (pin_thread_to_core(order_gateway_thread_, 0)) {
+    logger_->info("Pinned OrderGateway thread to CPU Core 0");
+  } else {
+    logger_->warn("Failed to pin OrderGateway thread to CPU Core 0");
+  }
 }
 
 void TradingEngine::launch_consumers() {
@@ -104,8 +107,12 @@ void TradingEngine::launch_consumers() {
         {std::thread(&ConsumerType::run, consumer.get()), std::move(consumer)});
 
     uint32_t core_id = max_cores > 0 ? (i + 2) % max_cores : i + 2;
-    pin_thread_to_core(consumer_threads_.back().thread, core_id);
-    logger_->info("Pinned thread for {} to CPU Core {}", symbol, core_id);
+    if (pin_thread_to_core(consumer_threads_.back().thread, core_id)) {
+      logger_->info("Pinned thread for {} to CPU Core {}", symbol, core_id);
+    } else {
+      logger_->warn("Failed to pin thread for {} to CPU Core {}", symbol,
+                    core_id);
+    }
   }
 }
 

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -4,7 +4,7 @@
 #include "Utils.hpp"
 #include <csignal>
 #include <cstdlib>
-#include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace {
 std::atomic<bool> *g_is_running_ptr = nullptr;
@@ -19,7 +19,8 @@ void signalHandler(const int signum) {
 TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
                              std::unique_ptr<IRestClient> rest_client,
                              std::unique_ptr<IRestClient> reconciliation_client)
-    : is_running_(true), symbols_(symbols) {
+    : is_running_(true), symbols_(symbols),
+      logger_(spdlog::get("engine").get()) {
   latency_tracker_ = std::make_unique<LatencyTracker>();
   position_manager_ = std::make_unique<PositionManager>();
   for (const auto &symbol : symbols_) {
@@ -62,13 +63,13 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
 }
 
 TradingEngine::~TradingEngine() {
-  std::cout << "TradingEngine destructor: Starting shutdown..." << '\n';
+  logger_->info("Starting shutdown...");
   if (is_running_.load()) {
     stop();
   }
   shutdown();
   g_is_running_ptr = nullptr;
-  std::cout << "TradingEngine destructor: Shutdown complete." << '\n';
+  logger_->info("Shutdown complete.");
 }
 
 void TradingEngine::setup_signal_handler() {
@@ -80,15 +81,15 @@ void TradingEngine::setup_signal_handler() {
 void TradingEngine::launch_gateway() {
   order_gateway_thread_ = std::thread(&OrderGateway::run, order_gateway_.get());
   pin_thread_to_core(order_gateway_thread_, 0);
-  std::cout << "Pinned OrderGateway thread to CPU Core 0" << '\n';
+  logger_->info("Pinned OrderGateway thread to CPU Core 0");
 }
 
 void TradingEngine::launch_consumers() {
   const uint32_t max_cores = std::thread::hardware_concurrency();
   if (max_cores > 0 && symbols_.size() + 2 > max_cores) {
-    std::cerr << "Warning: " << symbols_.size()
-              << " symbols + 2 reserved cores exceeds " << max_cores
-              << " available cores; thread pinning will wrap" << '\n';
+    logger_->warn("{} symbols + 2 reserved cores exceeds {} available cores; "
+                  "thread pinning will wrap",
+                  symbols_.size(), max_cores);
   }
 
   for (uint32_t i = 0; i < symbols_.size(); ++i) {
@@ -104,8 +105,7 @@ void TradingEngine::launch_consumers() {
 
     uint32_t core_id = max_cores > 0 ? (i + 2) % max_cores : i + 2;
     pin_thread_to_core(consumer_threads_.back().thread, core_id);
-    std::cout << "Pinned thread for " << symbol << " to CPU Core " << core_id
-              << '\n';
+    logger_->info("Pinned thread for {} to CPU Core {}", symbol, core_id);
   }
 }
 
@@ -140,24 +140,24 @@ void TradingEngine::shutdown() {
     try {
       latency_tracker_->dump(".");
     } catch (const std::exception &e) {
-      std::cerr << "Latency tracker dump failed: " << e.what() << '\n';
+      logger_->error("Latency tracker dump failed: {}", e.what());
     } catch (...) {
-      std::cerr << "Latency tracker dump failed with unknown error" << '\n';
+      logger_->error("Latency tracker dump failed with unknown error");
     }
   }
 }
 
 void TradingEngine::run() {
-  std::cout << "Starting trading engine..." << '\n';
+  logger_->info("Starting trading engine...");
   fill_listener_->start();
-  std::cout << "FillListener started" << '\n';
+  logger_->info("FillListener started");
   market_publisher_->start();
-  std::cout << "MarketPublisher started" << '\n';
+  logger_->info("MarketPublisher started");
   launch_gateway();
   launch_consumers();
   main_loop();
 
-  std::cout << "Main loop exited. Shutting down threads..." << '\n';
+  logger_->info("Main loop exited. Shutting down threads...");
   shutdown();
 }
 

--- a/src/ZmqMarketEventSink.cpp
+++ b/src/ZmqMarketEventSink.cpp
@@ -1,7 +1,7 @@
 #include "ZmqMarketEventSink.hpp"
 #include <algorithm>
 #include <filesystem>
-#include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace {
 constexpr std::size_t kSymbolCapacity = 8;
@@ -22,7 +22,7 @@ void ZmqMarketEventSink::start() {
   zmq_pub_.set(zmq::sockopt::sndhwm, 1000000);
   zmq_pub_.set(zmq::sockopt::linger, 0);
   zmq_pub_.bind(zmq_address_);
-  std::cout << "ZmqMarketEventSink: bound to " << zmq_address_ << '\n';
+  spdlog::get("zmq")->info("Bound to {}", zmq_address_);
 }
 
 void ZmqMarketEventSink::stop() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,12 @@
 #include "AlpacaRestClient.hpp"
+#include "Logging.hpp"
 #include "TradingEngine.hpp"
-#include <iostream>
 #include <memory>
+#include <spdlog/spdlog.h>
 #include <vector>
 
 int main() {
+  logging::init();
   try {
     const std::vector<std::string> symbols = {"AAPL", "GOOGL", "AMZN"};
 
@@ -15,11 +17,14 @@ int main() {
                          std::move(reconciliation_client));
     engine.run();
   } catch (const std::exception &e) {
-    std::cerr << "An exception occurred: " << e.what() << '\n';
+    spdlog::error("An exception occurred: {}", e.what());
+    logging::shutdown();
     return 1;
   } catch (...) {
-    std::cerr << "An unknown exception occurred." << '\n';
+    spdlog::error("An unknown exception occurred.");
+    logging::shutdown();
     return 1;
   }
+  logging::shutdown();
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,8 +6,8 @@
 #include <vector>
 
 int main() {
-  logging::init();
   try {
+    logging::init();
     const std::vector<std::string> symbols = {"AAPL", "GOOGL", "AMZN"};
 
     auto alpaca_client = std::make_unique<AlpacaRestClient>();

--- a/tests/TestHelpers.hpp
+++ b/tests/TestHelpers.hpp
@@ -4,8 +4,34 @@
 #include "Order.hpp"
 #include <algorithm>
 #include <cstring>
+#include <spdlog/sinks/ringbuffer_sink.h>
+#include <spdlog/spdlog.h>
 
 namespace test_helpers {
+
+/// Replace a named logger with a ringbuffer sink for test assertions.
+/// The global test environment (TestLoggingSetup.cpp) must have run first.
+[[nodiscard]] inline auto installTestSink(const char *logger_name,
+                                          size_t capacity = 128) {
+  auto sink = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(capacity);
+  auto logger = std::make_shared<spdlog::logger>(logger_name, sink);
+  logger->set_level(spdlog::level::trace);
+  spdlog::drop(logger_name);
+  spdlog::register_logger(logger);
+  return sink;
+}
+
+/// Check if any formatted log message in the sink contains the given substring.
+[[nodiscard]] inline bool
+sinkContains(const std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> &sink,
+             const std::string &substr) {
+  for (const auto &msg : sink->last_formatted()) {
+    if (msg.find(substr) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
 
 [[nodiscard]] inline Order createOrder(const char *symbol, const OrderSide side,
                                        const int64_t qty,

--- a/tests/TestLoggingSetup.cpp
+++ b/tests/TestLoggingSetup.cpp
@@ -1,0 +1,17 @@
+#include "Logging.hpp"
+#include <gtest/gtest.h>
+
+namespace {
+
+class LoggingEnvironment : public ::testing::Environment {
+public:
+  void SetUp() override { logging::initForTests(); }
+  void TearDown() override { logging::shutdown(); }
+};
+
+// Register before RUN_ALL_TESTS is called by gtest_main.
+// NOLINTNEXTLINE(cert-err58-cpp)
+auto *const kEnv =
+    ::testing::AddGlobalTestEnvironment(new LoggingEnvironment());
+
+} // namespace

--- a/tests/test_fill_listener.cpp
+++ b/tests/test_fill_listener.cpp
@@ -10,7 +10,6 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <nlohmann/json.hpp>
-#include <sstream>
 #include <string>
 #include <thread>
 
@@ -264,8 +263,7 @@ TEST_F(FillListenerTest, RejectsUnknownSide) {
 }
 
 TEST_F(FillListenerTest, RejectsInvalidQtyString) {
-  std::ostringstream captured;
-  auto *old_buf = std::cerr.rdbuf(captured.rdbuf());
+  auto sink = test_helpers::installTestSink("fills");
 
   const auto update = parse(R"({
     "stream": "trade_updates",
@@ -280,15 +278,12 @@ TEST_F(FillListenerTest, RejectsInvalidQtyString) {
     }
   })");
 
-  std::cerr.rdbuf(old_buf);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
-  EXPECT_NE(captured.str().find("FillListener: parseQty failed:"),
-            std::string::npos);
+  EXPECT_TRUE(test_helpers::sinkContains(sink, "parseQty failed:"));
 }
 
 TEST_F(FillListenerTest, RejectsInvalidPriceString) {
-  std::ostringstream captured;
-  auto *old_buf = std::cerr.rdbuf(captured.rdbuf());
+  auto sink = test_helpers::installTestSink("fills");
 
   const auto update = parse(R"({
     "stream": "trade_updates",
@@ -303,10 +298,8 @@ TEST_F(FillListenerTest, RejectsInvalidPriceString) {
     }
   })");
 
-  std::cerr.rdbuf(old_buf);
   EXPECT_TRUE(std::holds_alternative<std::monostate>(update));
-  EXPECT_NE(captured.str().find("FillListener: parsePrice failed:"),
-            std::string::npos);
+  EXPECT_TRUE(test_helpers::sinkContains(sink, "parsePrice failed:"));
 }
 
 TEST_F(FillListenerTest, ParsesNumericQtyAndPrice) {

--- a/tests/test_logging.cpp
+++ b/tests/test_logging.cpp
@@ -1,0 +1,71 @@
+#include "Logging.hpp"
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
+class LoggingTest : public ::testing::Test {
+protected:
+  void SetUp() override { spdlog::drop_all(); }
+
+  void TearDown() override {
+    spdlog::drop_all();
+    logging::initForTests();
+  }
+};
+
+TEST_F(LoggingTest, InitRegistersAllNamedLoggers) {
+  logging::init();
+
+  EXPECT_NE(spdlog::get("engine"), nullptr);
+  EXPECT_NE(spdlog::get("gateway"), nullptr);
+  EXPECT_NE(spdlog::get("fills"), nullptr);
+  EXPECT_NE(spdlog::get("rest"), nullptr);
+  EXPECT_NE(spdlog::get("market"), nullptr);
+  EXPECT_NE(spdlog::get("zmq"), nullptr);
+  EXPECT_NE(spdlog::get("system"), nullptr);
+  EXPECT_NE(spdlog::get("latency"), nullptr);
+
+  logging::shutdown();
+}
+
+TEST_F(LoggingTest, InitSetsDefaultLoggerToSystem) {
+  logging::init();
+
+  EXPECT_EQ(spdlog::default_logger()->name(), "system");
+
+  logging::shutdown();
+}
+
+TEST_F(LoggingTest, InitForTestsRegistersAllNamedLoggers) {
+  logging::initForTests();
+
+  EXPECT_NE(spdlog::get("engine"), nullptr);
+  EXPECT_NE(spdlog::get("gateway"), nullptr);
+  EXPECT_NE(spdlog::get("fills"), nullptr);
+  EXPECT_NE(spdlog::get("rest"), nullptr);
+  EXPECT_NE(spdlog::get("market"), nullptr);
+  EXPECT_NE(spdlog::get("zmq"), nullptr);
+  EXPECT_NE(spdlog::get("system"), nullptr);
+  EXPECT_NE(spdlog::get("latency"), nullptr);
+}
+
+TEST_F(LoggingTest, InitForTestsSetsDefaultLoggerToSystem) {
+  logging::initForTests();
+
+  EXPECT_EQ(spdlog::default_logger()->name(), "system");
+}
+
+TEST_F(LoggingTest, InitForTestsSkipsAlreadyRegisteredLoggers) {
+  logging::initForTests();
+  auto original = spdlog::get("gateway");
+
+  logging::initForTests();
+  EXPECT_EQ(spdlog::get("gateway"), original);
+}
+
+TEST_F(LoggingTest, ShutdownDropsAllLoggers) {
+  logging::initForTests();
+  ASSERT_NE(spdlog::get("engine"), nullptr);
+
+  logging::shutdown();
+  EXPECT_EQ(spdlog::get("engine"), nullptr);
+}

--- a/tests/test_order_gateway.cpp
+++ b/tests/test_order_gateway.cpp
@@ -13,7 +13,6 @@
 #include <future>
 #include <gtest/gtest.h>
 #include <memory>
-#include <sstream>
 #include <thread>
 
 class MockRestClient final : public IRestClient {
@@ -302,12 +301,10 @@ TEST_P(GatewayMainLoopExceptionTest, LogsCorrectError) {
   std::promise<void> promise;
   auto future = promise.get_future();
 
+  auto sink = test_helpers::installTestSink("gateway");
   auto client = factory(&promise);
   OrderGateway gateway(is_running, &order_queue, std::move(client),
                        &position_manager_);
-
-  std::stringstream captured;
-  auto *original = std::cerr.rdbuf(captured.rdbuf());
 
   {
     ThreadGuard guard{std::thread(&OrderGateway::run, &gateway)};
@@ -321,9 +318,7 @@ TEST_P(GatewayMainLoopExceptionTest, LogsCorrectError) {
     is_running.store(false);
   }
 
-  std::cerr.rdbuf(original);
-
-  EXPECT_TRUE(captured.str().find(expected_substr) != std::string::npos);
+  EXPECT_TRUE(test_helpers::sinkContains(sink, expected_substr));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -332,12 +327,12 @@ INSTANTIATE_TEST_SUITE_P(
         MainLoopExceptionParam{[](std::promise<void> *p) {
                                  return std::make_unique<ThrowingRestClient>(p);
                                },
-                               "OrderGateway: Exception placing order:"},
+                               "Exception placing order:"},
         MainLoopExceptionParam{
             [](std::promise<void> *p) {
               return std::make_unique<WildThrowingRestClient>(p);
             },
-            "OrderGateway: Unknown error placing order"}));
+            "Unknown error placing order"}));
 
 struct ShutdownExceptionParam {
   std::function<std::unique_ptr<IRestClient>()> factory;
@@ -359,18 +354,14 @@ TEST_P(GatewayShutdownExceptionTest, LogsCorrectError) {
   order.id = 1;
   order_queue.push(order);
 
+  auto sink = test_helpers::installTestSink("gateway");
   auto client = factory();
   OrderGateway gateway(is_running, &order_queue, std::move(client),
                        &position_manager_);
 
-  std::stringstream captured;
-  auto *original = std::cerr.rdbuf(captured.rdbuf());
-
   gateway.run();
 
-  std::cerr.rdbuf(original);
-
-  EXPECT_TRUE(captured.str().find(expected_substr) != std::string::npos);
+  EXPECT_TRUE(test_helpers::sinkContains(sink, expected_substr));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -378,10 +369,10 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         ShutdownExceptionParam{
             []() { return std::make_unique<ThrowingRestClient>(); },
-            "OrderGateway: Exception placing order:"},
+            "Exception placing order:"},
         ShutdownExceptionParam{
             []() { return std::make_unique<WildThrowingRestClient>(); },
-            "OrderGateway: Unknown error placing order"}));
+            "Unknown error placing order"}));
 
 namespace {
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,7 +12,8 @@
     "tbb",
     "ixwebsocket",
     "msgpack",
-    "hdr-histogram"
+    "hdr-histogram",
+    "spdlog"
   ],
   "builtin-baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1"
 }


### PR DESCRIPTION
## Summary

- Replace all 71 `std::cout`/`std::cerr` instances across 10 source files and 1 header with spdlog async loggers
- 8 named loggers (`engine`, `gateway`, `fills`, `rest`, `market`, `zmq`, `system`, `latency`) sharing one async thread pool (8K queue, `overrun_oldest` overflow policy)
- `SPDLOG_ACTIVE_LEVEL` set via CMake: `SPDLOG_LEVEL_TRACE` in Debug, `SPDLOG_LEVEL_INFO` in Release — trace/debug macros compile to zero instructions in Release
- OrderGateway (outer hot path): 9 synchronous stderr syscalls replaced with non-blocking async spdlog calls
- Tests adapted from `std::cerr.rdbuf()` capture to spdlog `ringbuffer_sink_mt`
- Zero `#include <iostream>` remaining in production code

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, timestamped structured logging with per-component loggers and build/runtime verbosity control.

* **Chores**
  * Replaced console prints with structured logs across the application; added logging lifecycle init/shutdown and test-friendly null sinks.
  * Build updated to include the logging library and enable target-specific verbosity.

* **Tests**
  * Added tests and test helpers to validate logging setup and capture log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->