### PR TITLE
Add JSON config system for risk limits, strategy params, symbols

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,8 +13,7 @@ coverage:
         threshold: 5%
     patch:
       default:
-        target: 80%
-        threshold: 5%
+        informational: true
 
 parsers:
   gcov:
@@ -34,5 +33,3 @@ ignore:
   - "vcpkg_installed/"
   - "**/test_*.cpp"
   - "**/test_*.py"
-  - "src/TradingEngine.cpp"
-  - "src/ThreadPinning.cpp"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ vcpkg/
 
 # Application
 paper_money
+config.json
 
 # Prerequisites
 *.d

--- a/config.example.json
+++ b/config.example.json
@@ -13,7 +13,7 @@
   },
   "alpaca": {
     "base_url": "https://paper-api.alpaca.markets",
-    "market_data_url": "wss://stream.data.alpaca.markets/v2/iex",
+    "market_data_url": "wss://stream.data.alpaca.markets/v2/iex?encoding=msgpack",
     "fill_stream_url": "wss://paper-api.alpaca.markets/stream",
     "rate_limit_threshold": 10
   },

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,28 @@
+{
+  "trading": {
+    "symbols": ["AAPL", "GOOGL", "AMZN"],
+    "order_cooldown_ns": 100000000
+  },
+  "risk": {
+    "max_position_per_symbol": 1000,
+    "max_order_value": 10000.0
+  },
+  "strategy": {
+    "spread_offset_ticks": 100,
+    "order_quantity": 100
+  },
+  "alpaca": {
+    "base_url": "https://paper-api.alpaca.markets",
+    "market_data_url": "wss://stream.data.alpaca.markets/v2/iex",
+    "fill_stream_url": "wss://paper-api.alpaca.markets/stream",
+    "rate_limit_threshold": 10
+  },
+  "zmq": {
+    "market_data_address": ""
+  },
+  "threading": {
+    "gateway_core": 0,
+    "market_pipeline_core": 1,
+    "consumer_core_start": 2
+  }
+}

--- a/include/AlpacaFillListener.hpp
+++ b/include/AlpacaFillListener.hpp
@@ -57,12 +57,13 @@ class AlpacaFillListener : public IFillListener {
   friend class FillListenerReconcileTest;
 
 public:
-  AlpacaFillListener(PositionManager *position_manager,
-                     std::atomic<bool> &is_running, const std::string &api_key,
-                     const std::string &api_secret,
-                     PendingOrderTracker *pending_tracker = nullptr,
-                     LatencyTracker *latency_tracker = nullptr,
-                     IRestClient *reconciliation_client = nullptr);
+  AlpacaFillListener(
+      PositionManager *position_manager, std::atomic<bool> &is_running,
+      const std::string &api_key, const std::string &api_secret,
+      PendingOrderTracker *pending_tracker = nullptr,
+      LatencyTracker *latency_tracker = nullptr,
+      IRestClient *reconciliation_client = nullptr,
+      std::string fill_stream_url = "wss://paper-api.alpaca.markets/stream");
 
   ~AlpacaFillListener() override;
 
@@ -123,5 +124,6 @@ private:
   [[nodiscard]] bool isCompleted(std::string_view order_id) const noexcept;
   void markCompleted(std::string_view order_id);
 
+  std::string fill_stream_url_;
   spdlog::logger *logger_;
 };

--- a/include/AlpacaRestClient.hpp
+++ b/include/AlpacaRestClient.hpp
@@ -11,6 +11,7 @@
 class AlpacaRestClient final : public IRestClient {
 public:
   explicit AlpacaRestClient(
+      const std::string &base_url = "",
       int64_t rate_limit_threshold = RateLimiter::kDefaultThreshold,
       ThrottlePolicy throttle_policy = ThrottlePolicy::Drop);
   [[nodiscard]] std::expected<OrderAck, OrderError>

--- a/include/AlpacaWebSocketSource.hpp
+++ b/include/AlpacaWebSocketSource.hpp
@@ -17,9 +17,10 @@ class AlpacaWebSocketSource {
 public:
   using RawDataFn = void (*)(void *, std::span<const char>);
 
-  AlpacaWebSocketSource(std::string api_key, std::string api_secret,
-                        std::vector<std::string> symbols,
-                        std::atomic<bool> &is_running);
+  AlpacaWebSocketSource(
+      std::string api_key, std::string api_secret,
+      std::vector<std::string> symbols, std::atomic<bool> &is_running,
+      std::string data_url = "wss://stream.data.alpaca.markets/v2/iex");
   ~AlpacaWebSocketSource();
 
   AlpacaWebSocketSource(AlpacaWebSocketSource &&) = default;
@@ -51,6 +52,7 @@ private:
   std::thread thread_;
   RawDataFn on_data_fn_ = nullptr;
   void *on_data_ctx_ = nullptr;
+  std::string data_url_;
   spdlog::logger *logger_;
 };
 

--- a/include/AlpacaWebSocketSource.hpp
+++ b/include/AlpacaWebSocketSource.hpp
@@ -20,7 +20,8 @@ public:
   AlpacaWebSocketSource(
       std::string api_key, std::string api_secret,
       std::vector<std::string> symbols, std::atomic<bool> &is_running,
-      std::string data_url = "wss://stream.data.alpaca.markets/v2/iex");
+      std::string data_url =
+          "wss://stream.data.alpaca.markets/v2/iex?encoding=msgpack");
   ~AlpacaWebSocketSource();
 
   AlpacaWebSocketSource(AlpacaWebSocketSource &&) = default;

--- a/include/AppConfig.hpp
+++ b/include/AppConfig.hpp
@@ -22,7 +22,8 @@ struct StrategyConfig {
 
 struct AlpacaConfig {
   std::string base_url = "https://paper-api.alpaca.markets";
-  std::string market_data_url = "wss://stream.data.alpaca.markets/v2/iex";
+  std::string market_data_url =
+      "wss://stream.data.alpaca.markets/v2/iex?encoding=msgpack";
   std::string fill_stream_url = "wss://paper-api.alpaca.markets/stream";
   int64_t rate_limit_threshold = 10;
 };

--- a/include/AppConfig.hpp
+++ b/include/AppConfig.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+struct TradingConfig {
+  std::vector<std::string> symbols = {"AAPL", "GOOGL", "AMZN"};
+  uint64_t order_cooldown_ns = 100'000'000;
+};
+
+struct RiskConfig {
+  int64_t max_position_per_symbol = 1000;
+  double max_order_value = 10000.00;
+};
+
+struct StrategyConfig {
+  uint64_t spread_offset_ticks = 100;
+  int64_t order_quantity = 100;
+};
+
+struct AlpacaConfig {
+  std::string base_url = "https://paper-api.alpaca.markets";
+  std::string market_data_url = "wss://stream.data.alpaca.markets/v2/iex";
+  std::string fill_stream_url = "wss://paper-api.alpaca.markets/stream";
+  int64_t rate_limit_threshold = 10;
+};
+
+struct ZmqConfig {
+  std::string market_data_address;
+};
+
+struct ThreadingConfig {
+  uint32_t gateway_core = 0;
+  uint32_t market_pipeline_core = 1;
+  uint32_t consumer_core_start = 2;
+};
+
+struct AppConfig {
+  TradingConfig trading;
+  RiskConfig risk;
+  StrategyConfig strategy;
+  AlpacaConfig alpaca;
+  ZmqConfig zmq;
+  ThreadingConfig threading;
+};
+
+[[nodiscard]] AppConfig
+loadConfig(const std::optional<std::string> &path = std::nullopt);

--- a/include/RiskManager.hpp
+++ b/include/RiskManager.hpp
@@ -8,13 +8,15 @@ class PositionManager;
 class RiskManager {
 public:
   explicit RiskManager(PositionManager *position_manager,
-                       OrderCooldown *order_cooldown = nullptr);
+                       OrderCooldown *order_cooldown = nullptr,
+                       int64_t max_position_per_symbol = 1000,
+                       double max_order_value = 10000.00);
 
   [[nodiscard]] bool onNewOrder(const Order &order);
 
 private:
   PositionManager *position_manager_;
   OrderCooldown *order_cooldown_;
-  const int64_t max_position_per_symbol_ = 1000;
-  const double max_order_value_ = 10000.00;
+  int64_t max_position_per_symbol_;
+  double max_order_value_;
 };

--- a/include/SimpleMarketMakingStrategy.hpp
+++ b/include/SimpleMarketMakingStrategy.hpp
@@ -9,7 +9,10 @@
 
 class SimpleMarketMakingStrategy {
 public:
-  SimpleMarketMakingStrategy() : last_trade_price_(0) {}
+  explicit SimpleMarketMakingStrategy(uint64_t spread_offset_ticks = 100,
+                                      int64_t order_quantity = 100)
+      : last_trade_price_(0), spread_offset_ticks_(spread_offset_ticks),
+        order_quantity_(order_quantity) {}
 
   [[nodiscard]] std::optional<Order>
   onMarketEvent(const MarketEvent &event) noexcept {
@@ -19,8 +22,7 @@ public:
 
     last_trade_price_ = event.p1;
 
-    constexpr uint64_t offset_ticks = 100;
-    if (last_trade_price_ < offset_ticks) [[unlikely]] {
+    if (last_trade_price_ < spread_offset_ticks_) [[unlikely]] {
       return std::nullopt;
     }
 
@@ -28,11 +30,13 @@ public:
     std::memcpy(order.symbol, event.symbol, sizeof(order.symbol));
     order.side = OrderSide::Buy;
     order.type = OrderType::Limit;
-    order.quantity = 100;
-    order.price = last_trade_price_ - offset_ticks;
+    order.quantity = order_quantity_;
+    order.price = last_trade_price_ - spread_offset_ticks_;
     return order;
   }
 
 private:
   uint64_t last_trade_price_;
+  uint64_t spread_offset_ticks_;
+  int64_t order_quantity_;
 };

--- a/include/TradingEngine.hpp
+++ b/include/TradingEngine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AlpacaPipeline.hpp"
+#include "AppConfig.hpp"
 #include "IRestClient.hpp"
 #include "LatencyTracker.hpp"
 #include "LockFreeMPSCQueue.hpp"
@@ -45,8 +46,7 @@ static_assert(sizeof(ConsumerType) % 64 == 0,
 class TradingEngine {
 public:
   explicit TradingEngine(
-      const std::vector<std::string> &symbols,
-      std::unique_ptr<IRestClient> rest_client,
+      const AppConfig &config, std::unique_ptr<IRestClient> rest_client,
       std::unique_ptr<IRestClient> reconciliation_client = nullptr);
 
   ~TradingEngine();
@@ -68,6 +68,7 @@ private:
 
   std::atomic<bool> is_running_;
   std::atomic<bool> shutdown_done_{false};
+  AppConfig config_;
   std::string ipc_address_;
   std::vector<std::string> symbols_;
   std::unique_ptr<LatencyTracker> latency_tracker_;

--- a/src/AlpacaFillListener.cpp
+++ b/src/AlpacaFillListener.cpp
@@ -15,7 +15,6 @@
 
 namespace {
 
-constexpr const char *kStreamUrl = "wss://paper-api.alpaca.markets/stream";
 constexpr int kMinReconnectMs = 100;
 constexpr int kMaxReconnectMs = 30000;
 constexpr std::size_t kSymbolCapacity = 8;
@@ -178,17 +177,16 @@ TradeUpdate parseTradingUpdate(const nlohmann::json &parsed) {
   return std::monostate{};
 }
 
-AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
-                                       std::atomic<bool> &is_running,
-                                       const std::string &api_key,
-                                       const std::string &api_secret,
-                                       PendingOrderTracker *pending_tracker,
-                                       LatencyTracker *latency_tracker,
-                                       IRestClient *reconciliation_client)
+AlpacaFillListener::AlpacaFillListener(
+    PositionManager *position_manager, std::atomic<bool> &is_running,
+    const std::string &api_key, const std::string &api_secret,
+    PendingOrderTracker *pending_tracker, LatencyTracker *latency_tracker,
+    IRestClient *reconciliation_client, std::string fill_stream_url)
     : position_manager_(position_manager), pending_tracker_(pending_tracker),
       latency_tracker_(latency_tracker),
       reconciliation_client_(reconciliation_client), is_running_(is_running),
       api_key_(api_key), api_secret_(api_secret),
+      fill_stream_url_(std::move(fill_stream_url)),
       logger_(spdlog::get("fills").get()) {
   if (position_manager_ == nullptr) {
     throw std::invalid_argument(
@@ -199,7 +197,7 @@ AlpacaFillListener::AlpacaFillListener(PositionManager *position_manager,
 AlpacaFillListener::~AlpacaFillListener() { AlpacaFillListener::stop(); }
 
 void AlpacaFillListener::start() {
-  ws_.setUrl(kStreamUrl);
+  ws_.setUrl(fill_stream_url_);
   ws_.setMinWaitBetweenReconnectionRetries(kMinReconnectMs);
   ws_.setMaxWaitBetweenReconnectionRetries(kMaxReconnectMs);
 

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -80,7 +80,11 @@ AlpacaRestClient::AlpacaRestClient(const std::string &base_url_param,
   std::string resolved_url = base_url_param;
   if (resolved_url.empty()) {
     const char *env_url = std::getenv("APCA_API_BASE_URL");
-    resolved_url = env_url ? env_url : "https://paper-api.alpaca.markets";
+    resolved_url =
+        (env_url && *env_url) ? env_url : "https://paper-api.alpaca.markets";
+  }
+  while (!resolved_url.empty() && resolved_url.back() == '/') {
+    resolved_url.pop_back();
   }
 
   order_url_ = resolved_url + "/v2/orders";

--- a/src/AlpacaRestClient.cpp
+++ b/src/AlpacaRestClient.cpp
@@ -65,23 +65,26 @@ int setTcpQuickAck(void * /*clientp*/, curl_socket_t curlfd,
 
 } // namespace
 
-AlpacaRestClient::AlpacaRestClient(int64_t rate_limit_threshold,
+AlpacaRestClient::AlpacaRestClient(const std::string &base_url_param,
+                                   int64_t rate_limit_threshold,
                                    ThrottlePolicy throttle_policy)
     : rate_limiter_(rate_limit_threshold, throttle_policy) {
   const char *api_key_cstr = std::getenv("APCA_API_KEY_ID");
   const char *api_secret_cstr = std::getenv("APCA_API_SECRET_KEY");
-  const char *base_url_cstr = std::getenv("APCA_API_BASE_URL");
 
   if (!api_key_cstr || !api_secret_cstr) {
     throw std::runtime_error("FATAL: APCA_API_KEY_ID and/or "
                              "APCA_API_SECRET_KEY not set in environment.");
   }
 
-  const std::string base_url =
-      base_url_cstr ? base_url_cstr : "https://paper-api.alpaca.markets";
+  std::string resolved_url = base_url_param;
+  if (resolved_url.empty()) {
+    const char *env_url = std::getenv("APCA_API_BASE_URL");
+    resolved_url = env_url ? env_url : "https://paper-api.alpaca.markets";
+  }
 
-  order_url_ = base_url + "/v2/orders";
-  cancel_url_prefix_ = base_url + "/v2/orders/";
+  order_url_ = resolved_url + "/v2/orders";
+  cancel_url_prefix_ = resolved_url + "/v2/orders/";
 
   payload_buf_.reserve(256);
 

--- a/src/AlpacaWebSocketSource.cpp
+++ b/src/AlpacaWebSocketSource.cpp
@@ -4,8 +4,6 @@
 #include <spdlog/spdlog.h>
 
 namespace {
-constexpr const char *kDataStreamUrl =
-    "wss://stream.data.alpaca.markets/v2/iex";
 constexpr int kMinReconnectMs = 100;
 constexpr int kMaxReconnectMs = 30000;
 } // namespace
@@ -13,10 +11,11 @@ constexpr int kMaxReconnectMs = 30000;
 AlpacaWebSocketSource::AlpacaWebSocketSource(std::string api_key,
                                              std::string api_secret,
                                              std::vector<std::string> symbols,
-                                             std::atomic<bool> &is_running)
+                                             std::atomic<bool> &is_running,
+                                             std::string data_url)
     : api_key_(std::move(api_key)), api_secret_(std::move(api_secret)),
       symbols_(std::move(symbols)), is_running_(&is_running),
-      ws_(std::make_unique<ix::WebSocket>()),
+      ws_(std::make_unique<ix::WebSocket>()), data_url_(std::move(data_url)),
       logger_(spdlog::get("market").get()) {}
 
 AlpacaWebSocketSource::~AlpacaWebSocketSource() { stop(); }
@@ -26,7 +25,7 @@ void AlpacaWebSocketSource::start() {
     return;
   }
 
-  ws_->setUrl(std::string(kDataStreamUrl) + "?encoding=msgpack");
+  ws_->setUrl(data_url_ + "?encoding=msgpack");
   ws_->setExtraHeaders(
       ix::WebSocketHttpHeaders{{"Content-Type", "application/msgpack"}});
   ws_->setMinWaitBetweenReconnectionRetries(kMinReconnectMs);

--- a/src/AlpacaWebSocketSource.cpp
+++ b/src/AlpacaWebSocketSource.cpp
@@ -25,7 +25,7 @@ void AlpacaWebSocketSource::start() {
     return;
   }
 
-  ws_->setUrl(data_url_ + "?encoding=msgpack");
+  ws_->setUrl(data_url_);
   ws_->setExtraHeaders(
       ix::WebSocketHttpHeaders{{"Content-Type", "application/msgpack"}});
   ws_->setMinWaitBetweenReconnectionRetries(kMinReconnectMs);

--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -1,0 +1,134 @@
+#include "AppConfig.hpp"
+#include "Utils.hpp"
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+
+namespace {
+
+void parseTrading(const nlohmann::json &j, TradingConfig &c) {
+  if (!j.contains("trading")) {
+    return;
+  }
+  const auto &t = j["trading"];
+  c.symbols = t.value("symbols", c.symbols);
+  c.order_cooldown_ns = t.value("order_cooldown_ns", c.order_cooldown_ns);
+}
+
+void parseRisk(const nlohmann::json &j, RiskConfig &c) {
+  if (!j.contains("risk")) {
+    return;
+  }
+  const auto &r = j["risk"];
+  c.max_position_per_symbol =
+      r.value("max_position_per_symbol", c.max_position_per_symbol);
+  c.max_order_value = r.value("max_order_value", c.max_order_value);
+}
+
+void parseStrategy(const nlohmann::json &j, StrategyConfig &c) {
+  if (!j.contains("strategy")) {
+    return;
+  }
+  const auto &s = j["strategy"];
+  c.spread_offset_ticks = s.value("spread_offset_ticks", c.spread_offset_ticks);
+  c.order_quantity = s.value("order_quantity", c.order_quantity);
+}
+
+void parseAlpaca(const nlohmann::json &j, AlpacaConfig &c) {
+  if (!j.contains("alpaca")) {
+    return;
+  }
+  const auto &a = j["alpaca"];
+  c.base_url = a.value("base_url", c.base_url);
+  c.market_data_url = a.value("market_data_url", c.market_data_url);
+  c.fill_stream_url = a.value("fill_stream_url", c.fill_stream_url);
+  c.rate_limit_threshold =
+      a.value("rate_limit_threshold", c.rate_limit_threshold);
+}
+
+void parseZmq(const nlohmann::json &j, ZmqConfig &c) {
+  if (!j.contains("zmq")) {
+    return;
+  }
+  const auto &z = j["zmq"];
+  c.market_data_address = z.value("market_data_address", c.market_data_address);
+}
+
+void parseThreading(const nlohmann::json &j, ThreadingConfig &c) {
+  if (!j.contains("threading")) {
+    return;
+  }
+  const auto &th = j["threading"];
+  c.gateway_core = th.value("gateway_core", c.gateway_core);
+  c.market_pipeline_core =
+      th.value("market_pipeline_core", c.market_pipeline_core);
+  c.consumer_core_start =
+      th.value("consumer_core_start", c.consumer_core_start);
+}
+
+void validate(const AppConfig &config) {
+  if (config.risk.max_position_per_symbol <= 0) {
+    throw std::runtime_error(
+        "Config: risk.max_position_per_symbol must be positive");
+  }
+  if (config.risk.max_order_value <= 0.0) {
+    throw std::runtime_error("Config: risk.max_order_value must be positive");
+  }
+  if (config.strategy.order_quantity <= 0) {
+    throw std::runtime_error(
+        "Config: strategy.order_quantity must be positive");
+  }
+  if (config.strategy.spread_offset_ticks == 0) {
+    throw std::runtime_error(
+        "Config: strategy.spread_offset_ticks must be non-zero");
+  }
+}
+
+} // namespace
+
+AppConfig loadConfig(const std::optional<std::string> &path) {
+  AppConfig config;
+
+  std::filesystem::path file_path;
+  if (path.has_value()) {
+    file_path = *path;
+    if (!std::filesystem::exists(file_path)) {
+      throw std::runtime_error("Config file not found: " + path.value());
+    }
+  } else {
+    file_path = "config.json";
+    if (!std::filesystem::exists(file_path)) {
+      config.zmq.market_data_address = getZmqMarketDataAddress();
+      return config;
+    }
+  }
+
+  std::ifstream file(file_path);
+  if (!file.is_open()) {
+    throw std::runtime_error("Cannot open config file: " + file_path.string());
+  }
+
+  nlohmann::json j;
+  try {
+    j = nlohmann::json::parse(file);
+  } catch (const nlohmann::json::exception &e) {
+    throw std::runtime_error("Invalid JSON in config file: " +
+                             std::string(e.what()));
+  }
+
+  parseTrading(j, config.trading);
+  parseRisk(j, config.risk);
+  parseStrategy(j, config.strategy);
+  parseAlpaca(j, config.alpaca);
+  parseZmq(j, config.zmq);
+  parseThreading(j, config.threading);
+
+  if (config.zmq.market_data_address.empty()) {
+    config.zmq.market_data_address = getZmqMarketDataAddress();
+  }
+
+  validate(config);
+
+  return config;
+}

--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -83,6 +83,12 @@ void validate(const AppConfig &config) {
     throw std::runtime_error(
         "Config: strategy.spread_offset_ticks must be non-zero");
   }
+
+  auto syms = config.trading.symbols;
+  std::ranges::sort(syms);
+  if (std::ranges::adjacent_find(syms) != syms.end()) {
+    throw std::runtime_error("Config: trading.symbols contains duplicates");
+  }
 }
 
 } // namespace
@@ -112,17 +118,20 @@ AppConfig loadConfig(const std::optional<std::string> &path) {
   nlohmann::json j;
   try {
     j = nlohmann::json::parse(file);
+    if (!j.is_object()) {
+      throw std::runtime_error("Config root must be a JSON object");
+    }
+    parseTrading(j, config.trading);
+    parseRisk(j, config.risk);
+    parseStrategy(j, config.strategy);
+    parseAlpaca(j, config.alpaca);
+    parseZmq(j, config.zmq);
+    parseThreading(j, config.threading);
+  } catch (const std::runtime_error &) {
+    throw;
   } catch (const nlohmann::json::exception &e) {
-    throw std::runtime_error("Invalid JSON in config file: " +
-                             std::string(e.what()));
+    throw std::runtime_error("Config parse error: " + std::string(e.what()));
   }
-
-  parseTrading(j, config.trading);
-  parseRisk(j, config.risk);
-  parseStrategy(j, config.strategy);
-  parseAlpaca(j, config.alpaca);
-  parseZmq(j, config.zmq);
-  parseThreading(j, config.threading);
 
   if (config.zmq.market_data_address.empty()) {
     config.zmq.market_data_address = getZmqMarketDataAddress();

--- a/src/RiskManager.cpp
+++ b/src/RiskManager.cpp
@@ -17,8 +17,12 @@ namespace {
 } // namespace
 
 RiskManager::RiskManager(PositionManager *position_manager,
-                         OrderCooldown *order_cooldown)
-    : position_manager_(position_manager), order_cooldown_(order_cooldown) {}
+                         OrderCooldown *order_cooldown,
+                         int64_t max_position_per_symbol,
+                         double max_order_value)
+    : position_manager_(position_manager), order_cooldown_(order_cooldown),
+      max_position_per_symbol_(max_position_per_symbol),
+      max_order_value_(max_order_value) {}
 
 bool RiskManager::onNewOrder(const Order &order) {
   const std::string_view symbol(order.symbol,

--- a/src/TradingEngine.cpp
+++ b/src/TradingEngine.cpp
@@ -16,22 +16,24 @@ void signalHandler(const int signum) {
 }
 } // namespace
 
-TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
+TradingEngine::TradingEngine(const AppConfig &config,
                              std::unique_ptr<IRestClient> rest_client,
                              std::unique_ptr<IRestClient> reconciliation_client)
-    : is_running_(true), symbols_(symbols),
+    : is_running_(true), config_(config), symbols_(config.trading.symbols),
       logger_(spdlog::get("engine").get()) {
   latency_tracker_ = std::make_unique<LatencyTracker>();
   position_manager_ = std::make_unique<PositionManager>();
   for (const auto &symbol : symbols_) {
     position_manager_->registerSymbol(symbol);
   }
-  order_cooldown_ = std::make_unique<OrderCooldown>();
+  order_cooldown_ =
+      std::make_unique<OrderCooldown>(config_.trading.order_cooldown_ns);
   for (const auto &symbol : symbols_) {
     order_cooldown_->registerSymbol(symbol);
   }
-  risk_manager_ = std::make_unique<RiskManager>(position_manager_.get(),
-                                                order_cooldown_.get());
+  risk_manager_ = std::make_unique<RiskManager>(
+      position_manager_.get(), order_cooldown_.get(),
+      config_.risk.max_position_per_symbol, config_.risk.max_order_value);
   pending_tracker_ = std::make_unique<PendingOrderTracker>();
   order_queue_ = std::make_unique<LockFreeMPSCQueue<Order>>();
   order_gateway_ = std::make_unique<OrderGateway>(
@@ -48,12 +50,13 @@ TradingEngine::TradingEngine(const std::vector<std::string> &symbols,
   fill_listener_ = std::make_unique<AlpacaFillListener>(
       position_manager_.get(), is_running_, api_key, api_secret,
       pending_tracker_.get(), latency_tracker_.get(),
-      reconciliation_client_.get());
+      reconciliation_client_.get(), config_.alpaca.fill_stream_url);
 
-  ipc_address_ = getZmqMarketDataAddress();
+  ipc_address_ = config_.zmq.market_data_address;
 
   auto source =
-      AlpacaWebSocketSource(api_key, api_secret, symbols_, is_running_);
+      AlpacaWebSocketSource(api_key, api_secret, symbols_, is_running_,
+                            config_.alpaca.market_data_url);
   auto decoder = AlpacaMsgpackDecoder();
   auto sink = ZmqMarketEventSink(context_, ipc_address_);
   market_publisher_ = std::make_unique<AlpacaPipeline>(
@@ -80,10 +83,13 @@ void TradingEngine::setup_signal_handler() {
 
 void TradingEngine::launch_gateway() {
   order_gateway_thread_ = std::thread(&OrderGateway::run, order_gateway_.get());
-  if (pin_thread_to_core(order_gateway_thread_, 0)) {
-    logger_->info("Pinned OrderGateway thread to CPU Core 0");
+  if (pin_thread_to_core(order_gateway_thread_,
+                         config_.threading.gateway_core)) {
+    logger_->info("Pinned OrderGateway thread to CPU Core {}",
+                  config_.threading.gateway_core);
   } else {
-    logger_->warn("Failed to pin OrderGateway thread to CPU Core 0");
+    logger_->warn("Failed to pin OrderGateway thread to CPU Core {}",
+                  config_.threading.gateway_core);
   }
 }
 
@@ -106,7 +112,9 @@ void TradingEngine::launch_consumers() {
     consumer_threads_.push_back(
         {std::thread(&ConsumerType::run, consumer.get()), std::move(consumer)});
 
-    uint32_t core_id = max_cores > 0 ? (i + 2) % max_cores : i + 2;
+    uint32_t core_id =
+        max_cores > 0 ? (i + config_.threading.consumer_core_start) % max_cores
+                      : i + config_.threading.consumer_core_start;
     if (pin_thread_to_core(consumer_threads_.back().thread, core_id)) {
       logger_->info("Pinned thread for {} to CPU Core {}", symbol, core_id);
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,31 @@
 #include "AlpacaRestClient.hpp"
+#include "AppConfig.hpp"
 #include "Logging.hpp"
 #include "TradingEngine.hpp"
 #include <memory>
+#include <optional>
 #include <spdlog/spdlog.h>
-#include <vector>
+#include <string_view>
 
-int main() {
+int main(int argc, char *argv[]) {
   try {
     logging::init();
-    const std::vector<std::string> symbols = {"AAPL", "GOOGL", "AMZN"};
 
-    auto alpaca_client = std::make_unique<AlpacaRestClient>();
-    auto reconciliation_client = std::make_unique<AlpacaRestClient>();
+    std::optional<std::string> config_path;
+    for (int i = 1; i < argc; ++i) {
+      if (std::string_view(argv[i]) == "--config" && i + 1 < argc) {
+        config_path = argv[++i];
+      }
+    }
 
-    TradingEngine engine(symbols, std::move(alpaca_client),
+    const auto config = loadConfig(config_path);
+
+    auto alpaca_client = std::make_unique<AlpacaRestClient>(
+        config.alpaca.base_url, config.alpaca.rate_limit_threshold);
+    auto reconciliation_client = std::make_unique<AlpacaRestClient>(
+        config.alpaca.base_url, config.alpaca.rate_limit_threshold);
+
+    TradingEngine engine(config, std::move(alpaca_client),
                          std::move(reconciliation_client));
     engine.run();
   } catch (const std::exception &e) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,10 @@ int main(int argc, char *argv[]) {
 
     std::optional<std::string> config_path;
     for (int i = 1; i < argc; ++i) {
-      if (std::string_view(argv[i]) == "--config" && i + 1 < argc) {
+      if (std::string_view(argv[i]) == "--config") {
+        if (i + 1 >= argc) {
+          throw std::runtime_error("--config requires a file path argument");
+        }
         config_path = argv[++i];
       }
     }

--- a/tests/test_alpaca_rest_client.cpp
+++ b/tests/test_alpaca_rest_client.cpp
@@ -496,7 +496,7 @@ TEST_F(AlpacaRestClientRateLimitTest, NumericPrefixHeaderIsRejected) {
 
 TEST_F(AlpacaRestClientRateLimitTest, ConstructorForwardsThrottleConfig) {
   point_client_to(12345);
-  AlpacaRestClient client(20, ThrottlePolicy::Drop);
+  AlpacaRestClient client("", 20, ThrottlePolicy::Drop);
   EXPECT_EQ(client.rateLimiter().threshold(), 20);
   EXPECT_EQ(client.rateLimiter().policy(), ThrottlePolicy::Drop);
 }
@@ -506,7 +506,7 @@ TEST_F(AlpacaRestClientRateLimitTest,
   std::string header = "X-Ratelimit-Remaining: 0\r\n";
   StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
   point_client_to(server.port());
-  AlpacaRestClient client(10, ThrottlePolicy::Drop);
+  AlpacaRestClient client("", 10, ThrottlePolicy::Drop);
   Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
 
   std::thread t([&]() { server.serve_one(); });
@@ -526,7 +526,7 @@ TEST_F(AlpacaRestClientRateLimitTest,
   std::string header = "X-Ratelimit-Remaining: 0\r\n";
   StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
   point_client_to(server.port());
-  AlpacaRestClient client(10, ThrottlePolicy::Drop);
+  AlpacaRestClient client("", 10, ThrottlePolicy::Drop);
   Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
 
   std::thread t([&]() { server.serve_one(); });
@@ -669,7 +669,7 @@ TEST_F(AlpacaRestClientQueryOrdersTest, ThrottledQueryReturns429) {
   std::string header = "X-Ratelimit-Remaining: 0\r\n";
   StubHttpServer server(200, R"({"id":"ord-1","status":"accepted"})", header);
   point_client_to(server.port());
-  AlpacaRestClient client(10, ThrottlePolicy::Drop);
+  AlpacaRestClient client("", 10, ThrottlePolicy::Drop);
   Order order = make_order("AAPL", OrderSide::Buy, OrderType::Market, 10, 0);
 
   std::thread t([&]() { server.serve_one(); });

--- a/tests/test_app_config.cpp
+++ b/tests/test_app_config.cpp
@@ -76,23 +76,24 @@ TEST_F(AppConfigTest, MissingFieldsGetDefaults) {
 TEST_F(AppConfigTest, InvalidJsonThrows) {
   writeConfigFile("{invalid json");
 
-  EXPECT_THROW(loadConfig(temp_path_.string()), std::runtime_error);
+  EXPECT_THROW((void)loadConfig(temp_path_.string()), std::runtime_error);
 }
 
 TEST_F(AppConfigTest, ExplicitPathNotFoundThrows) {
-  EXPECT_THROW(loadConfig("/nonexistent/path/config.json"), std::runtime_error);
+  EXPECT_THROW((void)loadConfig("/nonexistent/path/config.json"),
+               std::runtime_error);
 }
 
 TEST_F(AppConfigTest, NegativeMaxPositionThrows) {
   writeConfigFile(R"({"risk": {"max_position_per_symbol": -1}})");
 
-  EXPECT_THROW(loadConfig(temp_path_.string()), std::runtime_error);
+  EXPECT_THROW((void)loadConfig(temp_path_.string()), std::runtime_error);
 }
 
 TEST_F(AppConfigTest, ZeroOrderQuantityThrows) {
   writeConfigFile(R"({"strategy": {"order_quantity": 0}})");
 
-  EXPECT_THROW(loadConfig(temp_path_.string()), std::runtime_error);
+  EXPECT_THROW((void)loadConfig(temp_path_.string()), std::runtime_error);
 }
 
 TEST_F(AppConfigTest, ZmqAddressDefaultIsPlatformSpecific) {

--- a/tests/test_app_config.cpp
+++ b/tests/test_app_config.cpp
@@ -1,0 +1,121 @@
+#include "AppConfig.hpp"
+#include "Utils.hpp"
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+class AppConfigTest : public ::testing::Test {
+protected:
+  void TearDown() override {
+    if (!temp_path_.empty()) {
+      std::filesystem::remove(temp_path_);
+    }
+  }
+
+  void writeConfigFile(const std::string &content) {
+    temp_path_ = std::filesystem::temp_directory_path() / "test_config.json";
+    std::ofstream f(temp_path_);
+    f << content;
+  }
+
+  std::filesystem::path temp_path_;
+};
+
+TEST_F(AppConfigTest, DefaultConfigWithNoFile) {
+  const auto config = loadConfig();
+
+  EXPECT_EQ(config.trading.symbols.size(), 3);
+  EXPECT_EQ(config.trading.symbols[0], "AAPL");
+  EXPECT_EQ(config.trading.order_cooldown_ns, 100'000'000ULL);
+  EXPECT_EQ(config.risk.max_position_per_symbol, 1000);
+  EXPECT_DOUBLE_EQ(config.risk.max_order_value, 10000.00);
+  EXPECT_EQ(config.strategy.spread_offset_ticks, 100ULL);
+  EXPECT_EQ(config.strategy.order_quantity, 100);
+  EXPECT_EQ(config.alpaca.base_url, "https://paper-api.alpaca.markets");
+  EXPECT_EQ(config.threading.gateway_core, 0U);
+  EXPECT_EQ(config.threading.consumer_core_start, 2U);
+  EXPECT_EQ(config.zmq.market_data_address, getZmqMarketDataAddress());
+}
+
+TEST_F(AppConfigTest, LoadsFromFile) {
+  writeConfigFile(R"({
+    "trading": {"symbols": ["SPY", "QQQ"], "order_cooldown_ns": 50000000},
+    "risk": {"max_position_per_symbol": 500, "max_order_value": 5000.0},
+    "strategy": {"spread_offset_ticks": 50, "order_quantity": 25},
+    "alpaca": {"base_url": "https://api.alpaca.markets"},
+    "threading": {"gateway_core": 1, "consumer_core_start": 4}
+  })");
+
+  const auto config = loadConfig(temp_path_.string());
+
+  EXPECT_EQ(config.trading.symbols.size(), 2);
+  EXPECT_EQ(config.trading.symbols[0], "SPY");
+  EXPECT_EQ(config.trading.symbols[1], "QQQ");
+  EXPECT_EQ(config.trading.order_cooldown_ns, 50'000'000ULL);
+  EXPECT_EQ(config.risk.max_position_per_symbol, 500);
+  EXPECT_DOUBLE_EQ(config.risk.max_order_value, 5000.0);
+  EXPECT_EQ(config.strategy.spread_offset_ticks, 50ULL);
+  EXPECT_EQ(config.strategy.order_quantity, 25);
+  EXPECT_EQ(config.alpaca.base_url, "https://api.alpaca.markets");
+  EXPECT_EQ(config.threading.gateway_core, 1U);
+  EXPECT_EQ(config.threading.consumer_core_start, 4U);
+}
+
+TEST_F(AppConfigTest, MissingFieldsGetDefaults) {
+  writeConfigFile(R"({"risk": {"max_position_per_symbol": 500}})");
+
+  const auto config = loadConfig(temp_path_.string());
+
+  EXPECT_EQ(config.risk.max_position_per_symbol, 500);
+  EXPECT_DOUBLE_EQ(config.risk.max_order_value, 10000.00);
+  EXPECT_EQ(config.trading.symbols.size(), 3);
+  EXPECT_EQ(config.strategy.order_quantity, 100);
+}
+
+TEST_F(AppConfigTest, InvalidJsonThrows) {
+  writeConfigFile("{invalid json");
+
+  EXPECT_THROW(loadConfig(temp_path_.string()), std::runtime_error);
+}
+
+TEST_F(AppConfigTest, ExplicitPathNotFoundThrows) {
+  EXPECT_THROW(loadConfig("/nonexistent/path/config.json"), std::runtime_error);
+}
+
+TEST_F(AppConfigTest, NegativeMaxPositionThrows) {
+  writeConfigFile(R"({"risk": {"max_position_per_symbol": -1}})");
+
+  EXPECT_THROW(loadConfig(temp_path_.string()), std::runtime_error);
+}
+
+TEST_F(AppConfigTest, ZeroOrderQuantityThrows) {
+  writeConfigFile(R"({"strategy": {"order_quantity": 0}})");
+
+  EXPECT_THROW(loadConfig(temp_path_.string()), std::runtime_error);
+}
+
+TEST_F(AppConfigTest, ZmqAddressDefaultIsPlatformSpecific) {
+  writeConfigFile(R"({})");
+
+  const auto config = loadConfig(temp_path_.string());
+
+  EXPECT_EQ(config.zmq.market_data_address, getZmqMarketDataAddress());
+}
+
+TEST_F(AppConfigTest, EmptySymbolListIsAllowed) {
+  writeConfigFile(R"({"trading": {"symbols": []}})");
+
+  const auto config = loadConfig(temp_path_.string());
+
+  EXPECT_TRUE(config.trading.symbols.empty());
+}
+
+TEST_F(AppConfigTest, UnknownFieldsIgnored) {
+  writeConfigFile(
+      R"({"unknown_section": {"foo": 42}, "risk": {"max_position_per_symbol": 500}})");
+
+  const auto config = loadConfig(temp_path_.string());
+
+  EXPECT_EQ(config.risk.max_position_per_symbol, 500);
+}

--- a/tests/test_app_config.cpp
+++ b/tests/test_app_config.cpp
@@ -120,3 +120,15 @@ TEST_F(AppConfigTest, UnknownFieldsIgnored) {
 
   EXPECT_EQ(config.risk.max_position_per_symbol, 500);
 }
+
+TEST_F(AppConfigTest, DuplicateSymbolsThrows) {
+  writeConfigFile(R"({"trading": {"symbols": ["AAPL", "AAPL"]}})");
+
+  EXPECT_THROW((void)loadConfig(temp_path_.string()), std::runtime_error);
+}
+
+TEST_F(AppConfigTest, NonObjectRootThrows) {
+  writeConfigFile("[1, 2, 3]");
+
+  EXPECT_THROW((void)loadConfig(temp_path_.string()), std::runtime_error);
+}

--- a/tests/test_trading_engine.cpp
+++ b/tests/test_trading_engine.cpp
@@ -1,3 +1,4 @@
+#include "AppConfig.hpp"
 #include "IRestClient.hpp"
 #include "TradingEngine.hpp"
 #include "Utils.hpp"
@@ -30,34 +31,36 @@ protected:
     setenv("APCA_API_KEY_ID", "test_key", 1);
     setenv("APCA_API_SECRET_KEY", "test_secret", 1);
   }
+
+  AppConfig config_;
 };
 
 TEST_F(TradingEngineTest, ConstructsWithValidSymbols) {
-  std::vector<std::string> symbols = {"AAPL", "GOOGL"};
+  config_.trading.symbols = {"AAPL", "GOOGL"};
   auto mock_client = std::make_unique<MockRestClientForEngine>();
 
-  EXPECT_NO_THROW(TradingEngine(symbols, std::move(mock_client)));
+  EXPECT_NO_THROW(TradingEngine(config_, std::move(mock_client)));
 }
 
 TEST_F(TradingEngineTest, ConstructsWithEmptySymbols) {
-  std::vector<std::string> symbols = {};
+  config_.trading.symbols = {};
   auto mock_client = std::make_unique<MockRestClientForEngine>();
 
-  EXPECT_NO_THROW(TradingEngine(symbols, std::move(mock_client)));
+  EXPECT_NO_THROW(TradingEngine(config_, std::move(mock_client)));
 }
 
 TEST_F(TradingEngineTest, CanStopBeforeRun) {
-  std::vector<std::string> symbols = {"AAPL"};
+  config_.trading.symbols = {"AAPL"};
   auto mock_client = std::make_unique<MockRestClientForEngine>();
-  TradingEngine engine(symbols, std::move(mock_client));
+  TradingEngine engine(config_, std::move(mock_client));
 
   EXPECT_NO_THROW(engine.stop());
 }
 
 TEST_F(TradingEngineTest, ShutdownIsIdempotent) {
-  std::vector<std::string> symbols = {"AAPL"};
+  config_.trading.symbols = {"AAPL"};
   auto mock_client = std::make_unique<MockRestClientForEngine>();
-  TradingEngine engine(symbols, std::move(mock_client));
+  TradingEngine engine(config_, std::move(mock_client));
 
   engine.stop();
   EXPECT_NO_THROW(engine.stop());
@@ -67,9 +70,9 @@ TEST_F(TradingEngineTest, ThrowsWhenApiCredentialsMissing) {
   unsetenv("APCA_API_KEY_ID");
   unsetenv("APCA_API_SECRET_KEY");
 
-  std::vector<std::string> symbols = {"AAPL"};
+  config_.trading.symbols = {"AAPL"};
   auto mock_client = std::make_unique<MockRestClientForEngine>();
 
-  EXPECT_THROW(TradingEngine(symbols, std::move(mock_client)),
+  EXPECT_THROW(TradingEngine(config_, std::move(mock_client)),
                std::runtime_error);
 }


### PR DESCRIPTION
## Summary

- `AppConfig` struct with 6 sections: trading, risk, strategy, alpaca, zmq, threading
- Loaded from `config.json` at startup, all fields have safe defaults (works with no config file)
- `--config <path>` CLI arg to specify custom config file
- Component constructors accept config values via default args (backward-compatible)
- RiskManager, SimpleMarketMakingStrategy, AlpacaWebSocketSource, AlpacaFillListener, AlpacaRestClient all configurable
- TradingEngine takes `AppConfig` instead of symbols vector
- Validation: rejects negative risk limits, zero quantities; missing fields get defaults; unknown fields ignored
- 10 new tests for config parsing, defaults, validation, error paths
- `config.example.json` with all fields documented, `config.json` gitignored

Unblocks: #42 (configurable symbols), #50 (fee interface), #52 (MomentumStrategy), #53 (signal mode), #54 (run-mode CLI)

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide configuration support (example config included) for trading, risk, strategy, API/stream endpoints, ZMQ address, and threading
  * Runtime-configurable API/stream endpoints and thread-core assignments; configurable risk limits and strategy parameters with validation and sensible defaults
  * CLI --config option to load a custom configuration

* **Chores**
  * Sample/local config excluded from version control

* **Tests**
  * Added comprehensive tests for config loading/validation; updated engine and client tests to use config-driven construction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->