### PR TITLE
Add --symbols CLI arg to override config file symbols

### DIFF
--- a/include/AppConfig.hpp
+++ b/include/AppConfig.hpp
@@ -49,3 +49,5 @@ struct AppConfig {
 
 [[nodiscard]] AppConfig
 loadConfig(const std::optional<std::string> &path = std::nullopt);
+
+void validateConfig(const AppConfig &config);

--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -67,7 +67,9 @@ void parseThreading(const nlohmann::json &j, ThreadingConfig &c) {
       th.value("consumer_core_start", c.consumer_core_start);
 }
 
-void validate(const AppConfig &config) {
+} // namespace
+
+void validateConfig(const AppConfig &config) {
   if (config.risk.max_position_per_symbol <= 0) {
     throw std::runtime_error(
         "Config: risk.max_position_per_symbol must be positive");
@@ -90,8 +92,6 @@ void validate(const AppConfig &config) {
     throw std::runtime_error("Config: trading.symbols contains duplicates");
   }
 }
-
-} // namespace
 
 AppConfig loadConfig(const std::optional<std::string> &path) {
   AppConfig config;
@@ -137,7 +137,7 @@ AppConfig loadConfig(const std::optional<std::string> &path) {
     config.zmq.market_data_address = getZmqMarketDataAddress();
   }
 
-  validate(config);
+  validateConfig(config);
 
   return config;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <optional>
 #include <spdlog/spdlog.h>
+#include <sstream>
 #include <string_view>
 
 int main(int argc, char *argv[]) {
@@ -12,16 +13,56 @@ int main(int argc, char *argv[]) {
     logging::init();
 
     std::optional<std::string> config_path;
+    std::optional<std::string> symbols_override;
     for (int i = 1; i < argc; ++i) {
-      if (std::string_view(argv[i]) == "--config") {
+      const std::string_view arg(argv[i]);
+      if (arg == "--config") {
         if (i + 1 >= argc) {
           throw std::runtime_error("--config requires a file path argument");
         }
         config_path = argv[++i];
+      } else if (arg == "--symbols") {
+        if (i + 1 >= argc) {
+          throw std::runtime_error("--symbols requires a comma-separated list");
+        }
+        symbols_override = argv[++i];
+      } else if (arg.starts_with("--")) {
+        throw std::runtime_error("Unknown option: " + std::string(arg));
       }
     }
 
-    const auto config = loadConfig(config_path);
+    auto config = loadConfig(config_path);
+
+    if (symbols_override) {
+      config.trading.symbols.clear();
+      std::istringstream stream(*symbols_override);
+      std::string symbol;
+      while (std::getline(stream, symbol, ',')) {
+        if (!symbol.empty()) {
+          if (symbol.size() > 8) {
+            throw std::runtime_error("Symbol '" + symbol +
+                                     "' exceeds 8-character limit");
+          }
+          config.trading.symbols.push_back(symbol);
+        }
+      }
+      if (config.trading.symbols.empty()) {
+        throw std::runtime_error("--symbols must specify at least one symbol");
+      }
+    }
+
+    validateConfig(config);
+
+    spdlog::info("Trading symbols: [{}]", [&config]() {
+      std::string s;
+      for (size_t i = 0; i < config.trading.symbols.size(); ++i) {
+        if (i > 0) {
+          s += ", ";
+        }
+        s += config.trading.symbols[i];
+      }
+      return s;
+    }());
 
     auto alpaca_client = std::make_unique<AlpacaRestClient>(
         config.alpaca.base_url, config.alpaca.rate_limit_threshold);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,76 +8,90 @@
 #include <sstream>
 #include <string_view>
 
+namespace {
+
+struct CliArgs {
+  std::optional<std::string> config_path;
+  std::optional<std::string> symbols;
+};
+
+[[nodiscard]] CliArgs parseArgs(int argc, char *argv[]) {
+  CliArgs args;
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view arg(argv[i]);
+    if (arg == "--config") {
+      if (i + 1 >= argc) {
+        throw std::runtime_error("--config requires a file path argument");
+      }
+      args.config_path = argv[++i];
+    } else if (arg == "--symbols") {
+      if (i + 1 >= argc) {
+        throw std::runtime_error("--symbols requires a comma-separated list");
+      }
+      args.symbols = argv[++i];
+    } else if (arg.starts_with("--")) {
+      throw std::runtime_error("Unknown option: " + std::string(arg));
+    }
+  }
+  return args;
+}
+
+void applySymbolsOverride(AppConfig &config, const std::string &csv) {
+  config.trading.symbols.clear();
+  std::istringstream stream(csv);
+  std::string symbol;
+  while (std::getline(stream, symbol, ',')) {
+    if (!symbol.empty()) {
+      if (symbol.size() > 8) {
+        throw std::runtime_error("Symbol '" + symbol +
+                                 "' exceeds 8-character limit");
+      }
+      config.trading.symbols.push_back(symbol);
+    }
+  }
+  if (config.trading.symbols.empty()) {
+    throw std::runtime_error("--symbols must specify at least one symbol");
+  }
+}
+
+void logSymbols(const AppConfig &config) {
+  std::string joined;
+  for (size_t i = 0; i < config.trading.symbols.size(); ++i) {
+    if (i > 0) {
+      joined += ", ";
+    }
+    joined += config.trading.symbols[i];
+  }
+  spdlog::info("Trading symbols: [{}]", joined);
+}
+
+} // namespace
+
 int main(int argc, char *argv[]) {
   try {
     logging::init();
 
-    std::optional<std::string> config_path;
-    std::optional<std::string> symbols_override;
-    for (int i = 1; i < argc; ++i) {
-      const std::string_view arg(argv[i]);
-      if (arg == "--config") {
-        if (i + 1 >= argc) {
-          throw std::runtime_error("--config requires a file path argument");
-        }
-        config_path = argv[++i];
-      } else if (arg == "--symbols") {
-        if (i + 1 >= argc) {
-          throw std::runtime_error("--symbols requires a comma-separated list");
-        }
-        symbols_override = argv[++i];
-      } else if (arg.starts_with("--")) {
-        throw std::runtime_error("Unknown option: " + std::string(arg));
-      }
+    const auto args = parseArgs(argc, argv);
+    auto config = loadConfig(args.config_path);
+    if (args.symbols) {
+      applySymbolsOverride(config, *args.symbols);
     }
-
-    auto config = loadConfig(config_path);
-
-    if (symbols_override) {
-      config.trading.symbols.clear();
-      std::istringstream stream(*symbols_override);
-      std::string symbol;
-      while (std::getline(stream, symbol, ',')) {
-        if (!symbol.empty()) {
-          if (symbol.size() > 8) {
-            throw std::runtime_error("Symbol '" + symbol +
-                                     "' exceeds 8-character limit");
-          }
-          config.trading.symbols.push_back(symbol);
-        }
-      }
-      if (config.trading.symbols.empty()) {
-        throw std::runtime_error("--symbols must specify at least one symbol");
-      }
-    }
-
     validateConfig(config);
+    logSymbols(config);
 
-    spdlog::info("Trading symbols: [{}]", [&config]() {
-      std::string s;
-      for (size_t i = 0; i < config.trading.symbols.size(); ++i) {
-        if (i > 0) {
-          s += ", ";
-        }
-        s += config.trading.symbols[i];
-      }
-      return s;
-    }());
-
-    auto alpaca_client = std::make_unique<AlpacaRestClient>(
+    auto rest = std::make_unique<AlpacaRestClient>(
         config.alpaca.base_url, config.alpaca.rate_limit_threshold);
-    auto reconciliation_client = std::make_unique<AlpacaRestClient>(
+    auto reconciliation = std::make_unique<AlpacaRestClient>(
         config.alpaca.base_url, config.alpaca.rate_limit_threshold);
 
-    TradingEngine engine(config, std::move(alpaca_client),
-                         std::move(reconciliation_client));
+    TradingEngine engine(config, std::move(rest), std::move(reconciliation));
     engine.run();
   } catch (const std::exception &e) {
-    spdlog::error("An exception occurred: {}", e.what());
+    spdlog::error("{}", e.what());
     logging::shutdown();
     return 1;
   } catch (...) {
-    spdlog::error("An unknown exception occurred.");
+    spdlog::error("Unknown fatal error");
     logging::shutdown();
     return 1;
   }


### PR DESCRIPTION
## Summary

- `--symbols AAPL,GOOGL,SPY` CLI arg overrides `config.trading.symbols`
- Symbol validation: max 8 chars (matches `char[8]` symbol buffer), no duplicates, at least one required
- Unknown CLI args (`--anything-unrecognized`) rejected with error
- `validateConfig()` exposed as public API so CLI overrides are validated after mutation
- Logs active symbols at startup for user feedback

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public configuration validation API.
  * Added a `--symbols` CLI option to override trading symbols with a comma-separated list.

* **Improvements**
  * Configuration validation now explicitly performed after loading and applying overrides.
  * Enhanced CLI parsing with per-symbol validation and rejection of empty results.
  * Added informational logging for final configured trading symbols.
  * Standardized and clarified error logging for failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->