### PR TITLE
Add cost basis and realized PnL to PositionManager

### DIFF
--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -24,6 +24,8 @@ public:
   [[nodiscard]] int64_t getPendingPosition(std::string_view symbol) const;
   [[nodiscard]] int64_t
   getTotalExposure(std::string_view symbol) const noexcept;
+  [[nodiscard]] int64_t getCostBasis(std::string_view symbol) const;
+  [[nodiscard]] int64_t getRealizedPnl(std::string_view symbol) const;
 
 private:
   static constexpr uint64_t kEmptySlot = UINT64_MAX;
@@ -33,9 +35,16 @@ private:
     std::atomic<uint64_t> key{kEmptySlot};
     std::atomic<int64_t> filled{0};
     std::atomic<int64_t> pending{0};
+    char pad0_[40]{};
+
+    std::atomic<int64_t> cost_basis_total{0};
+    std::atomic<int64_t> realized_pnl{0};
+    char pad1_[48]{};
   };
 
-  static_assert(sizeof(Entry) == 64, "Entry must be one cache line");
+  static_assert(sizeof(std::atomic<uint64_t>) == 8, "Unexpected atomic size");
+  static_assert(sizeof(std::atomic<int64_t>) == 8, "Unexpected atomic size");
+  static_assert(sizeof(Entry) == 128, "Entry must be two cache lines");
   static_assert(alignof(Entry) == 64, "Entry must be cache-line aligned");
 
   static_assert(sizeof(Order::symbol) == 8,

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -87,4 +87,9 @@ private:
   [[nodiscard]] Entry *findOrInsert(uint64_t symbol_key) noexcept;
   [[nodiscard]] Entry *findMutable(uint64_t symbol_key) noexcept;
   [[nodiscard]] const Entry *find(uint64_t symbol_key) const noexcept;
+
+  void applyBuyFill(Entry &entry, int64_t price_scaled, int64_t qty,
+                    int64_t current_filled);
+  void applySellFill(Entry &entry, int64_t price_scaled, int64_t qty,
+                     int64_t current_filled);
 };

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -24,8 +24,8 @@ public:
   [[nodiscard]] int64_t getPendingPosition(std::string_view symbol) const;
   [[nodiscard]] int64_t
   getTotalExposure(std::string_view symbol) const noexcept;
-  [[nodiscard]] int64_t getCostBasis(std::string_view symbol) const;
-  [[nodiscard]] int64_t getRealizedPnl(std::string_view symbol) const;
+  [[nodiscard]] int64_t getCostBasis(std::string_view symbol) const noexcept;
+  [[nodiscard]] int64_t getRealizedPnl(std::string_view symbol) const noexcept;
 
 private:
   static constexpr uint64_t kEmptySlot = UINT64_MAX;

--- a/include/PositionManager.hpp
+++ b/include/PositionManager.hpp
@@ -89,7 +89,7 @@ private:
   [[nodiscard]] const Entry *find(uint64_t symbol_key) const noexcept;
 
   void applyBuyFill(Entry &entry, int64_t price_scaled, int64_t qty,
-                    int64_t current_filled);
+                    int64_t current_filled) noexcept;
   void applySellFill(Entry &entry, int64_t price_scaled, int64_t qty,
-                     int64_t current_filled);
+                     int64_t current_filled) noexcept;
 };

--- a/src/PositionManager.cpp
+++ b/src/PositionManager.cpp
@@ -84,7 +84,8 @@ void PositionManager::onFill(const Fill &fill) {
 }
 
 void PositionManager::applyBuyFill(Entry &entry, int64_t price_scaled,
-                                   int64_t qty, int64_t current_filled) {
+                                   int64_t qty,
+                                   int64_t current_filled) noexcept {
   if (current_filled < 0) {
     const int64_t short_qty = -current_filled;
     const int64_t cover_qty = (std::min)(qty, short_qty);
@@ -110,7 +111,8 @@ void PositionManager::applyBuyFill(Entry &entry, int64_t price_scaled,
 }
 
 void PositionManager::applySellFill(Entry &entry, int64_t price_scaled,
-                                    int64_t qty, int64_t current_filled) {
+                                    int64_t qty,
+                                    int64_t current_filled) noexcept {
   if (current_filled > 0) {
     const int64_t sell_qty = (std::min)(qty, current_filled);
     if (sell_qty > 0) {

--- a/src/PositionManager.cpp
+++ b/src/PositionManager.cpp
@@ -77,53 +77,61 @@ void PositionManager::onFill(const Fill &fill) {
   const int64_t current_filled = entry->filled.load(std::memory_order_relaxed);
 
   if (fill.side == OrderSide::Buy) {
-    if (current_filled < 0) {
-      const int64_t short_qty = -current_filled;
-      const int64_t cover_qty = (std::min)(qty, short_qty);
-      if (cover_qty > 0) {
-        const int64_t cost_basis =
-            entry->cost_basis_total.load(std::memory_order_relaxed);
-        const int64_t cost_removed = cost_basis * cover_qty / current_filled;
-        const int64_t pnl = cost_removed - price_scaled * cover_qty;
-        entry->realized_pnl.fetch_add(pnl, std::memory_order_relaxed);
-        entry->cost_basis_total.fetch_add(cost_removed,
-                                          std::memory_order_relaxed);
-      }
-      const int64_t open_qty = qty - cover_qty;
-      if (open_qty > 0) {
-        entry->cost_basis_total.fetch_add(price_scaled * open_qty,
-                                          std::memory_order_relaxed);
-      }
-    } else {
-      entry->cost_basis_total.fetch_add(price_scaled * qty,
-                                        std::memory_order_relaxed);
-    }
-    entry->filled.fetch_add(qty, std::memory_order_relaxed);
-    entry->pending.fetch_sub(qty, std::memory_order_relaxed);
+    applyBuyFill(*entry, price_scaled, qty, current_filled);
   } else {
-    if (current_filled > 0) {
-      const int64_t sell_qty = (std::min)(qty, current_filled);
-      if (sell_qty > 0) {
-        const int64_t cost_basis =
-            entry->cost_basis_total.load(std::memory_order_relaxed);
-        const int64_t cost_removed = cost_basis * sell_qty / current_filled;
-        const int64_t pnl = price_scaled * sell_qty - cost_removed;
-        entry->realized_pnl.fetch_add(pnl, std::memory_order_relaxed);
-        entry->cost_basis_total.fetch_sub(cost_removed,
-                                          std::memory_order_relaxed);
-      }
-      const int64_t short_qty = qty - sell_qty;
-      if (short_qty > 0) {
-        entry->cost_basis_total.fetch_sub(price_scaled * short_qty,
-                                          std::memory_order_relaxed);
-      }
-    } else {
-      entry->cost_basis_total.fetch_sub(price_scaled * qty,
-                                        std::memory_order_relaxed);
-    }
-    entry->filled.fetch_sub(qty, std::memory_order_relaxed);
-    entry->pending.fetch_add(qty, std::memory_order_relaxed);
+    applySellFill(*entry, price_scaled, qty, current_filled);
   }
+}
+
+void PositionManager::applyBuyFill(Entry &entry, int64_t price_scaled,
+                                   int64_t qty, int64_t current_filled) {
+  if (current_filled < 0) {
+    const int64_t short_qty = -current_filled;
+    const int64_t cover_qty = (std::min)(qty, short_qty);
+    if (cover_qty > 0) {
+      const int64_t cost_basis =
+          entry.cost_basis_total.load(std::memory_order_relaxed);
+      const int64_t cost_removed = cost_basis * cover_qty / current_filled;
+      const int64_t pnl = cost_removed - price_scaled * cover_qty;
+      entry.realized_pnl.fetch_add(pnl, std::memory_order_relaxed);
+      entry.cost_basis_total.fetch_add(cost_removed, std::memory_order_relaxed);
+    }
+    const int64_t open_qty = qty - cover_qty;
+    if (open_qty > 0) {
+      entry.cost_basis_total.fetch_add(price_scaled * open_qty,
+                                       std::memory_order_relaxed);
+    }
+  } else {
+    entry.cost_basis_total.fetch_add(price_scaled * qty,
+                                     std::memory_order_relaxed);
+  }
+  entry.filled.fetch_add(qty, std::memory_order_relaxed);
+  entry.pending.fetch_sub(qty, std::memory_order_relaxed);
+}
+
+void PositionManager::applySellFill(Entry &entry, int64_t price_scaled,
+                                    int64_t qty, int64_t current_filled) {
+  if (current_filled > 0) {
+    const int64_t sell_qty = (std::min)(qty, current_filled);
+    if (sell_qty > 0) {
+      const int64_t cost_basis =
+          entry.cost_basis_total.load(std::memory_order_relaxed);
+      const int64_t cost_removed = cost_basis * sell_qty / current_filled;
+      const int64_t pnl = price_scaled * sell_qty - cost_removed;
+      entry.realized_pnl.fetch_add(pnl, std::memory_order_relaxed);
+      entry.cost_basis_total.fetch_sub(cost_removed, std::memory_order_relaxed);
+    }
+    const int64_t short_qty = qty - sell_qty;
+    if (short_qty > 0) {
+      entry.cost_basis_total.fetch_sub(price_scaled * short_qty,
+                                       std::memory_order_relaxed);
+    }
+  } else {
+    entry.cost_basis_total.fetch_sub(price_scaled * qty,
+                                     std::memory_order_relaxed);
+  }
+  entry.filled.fetch_sub(qty, std::memory_order_relaxed);
+  entry.pending.fetch_add(qty, std::memory_order_relaxed);
 }
 
 void PositionManager::onOrderSent(const Order &order) noexcept {

--- a/src/PositionManager.cpp
+++ b/src/PositionManager.cpp
@@ -188,7 +188,7 @@ PositionManager::getTotalExposure(std::string_view symbol) const noexcept {
          entry->pending.load(std::memory_order_relaxed);
 }
 
-int64_t PositionManager::getCostBasis(std::string_view symbol) const {
+int64_t PositionManager::getCostBasis(std::string_view symbol) const noexcept {
   const Entry *entry = find(symbolToKey(symbol));
   if (!entry) {
     return 0;
@@ -196,7 +196,8 @@ int64_t PositionManager::getCostBasis(std::string_view symbol) const {
   return entry->cost_basis_total.load(std::memory_order_relaxed);
 }
 
-int64_t PositionManager::getRealizedPnl(std::string_view symbol) const {
+int64_t
+PositionManager::getRealizedPnl(std::string_view symbol) const noexcept {
   const Entry *entry = find(symbolToKey(symbol));
   if (!entry) {
     return 0;

--- a/src/PositionManager.cpp
+++ b/src/PositionManager.cpp
@@ -1,4 +1,5 @@
 #include "PositionManager.hpp"
+#include <cmath>
 
 PositionManager::Entry *
 PositionManager::findOrInsert(uint64_t symbol_key) noexcept {
@@ -71,13 +72,58 @@ void PositionManager::onFill(const Fill &fill) {
     return;
   }
 
-  int64_t delta = fill.quantity;
-  if (fill.side == OrderSide::Sell) {
-    delta = -delta;
-  }
+  const auto price_scaled = std::llround(fill.price * SCALING_FACTOR);
+  const int64_t qty = fill.quantity;
+  const int64_t current_filled = entry->filled.load(std::memory_order_relaxed);
 
-  entry->filled.fetch_add(delta, std::memory_order_relaxed);
-  entry->pending.fetch_sub(delta, std::memory_order_relaxed);
+  if (fill.side == OrderSide::Buy) {
+    if (current_filled < 0) {
+      const int64_t short_qty = -current_filled;
+      const int64_t cover_qty = (std::min)(qty, short_qty);
+      if (cover_qty > 0) {
+        const int64_t cost_basis =
+            entry->cost_basis_total.load(std::memory_order_relaxed);
+        const int64_t cost_removed = cost_basis * cover_qty / current_filled;
+        const int64_t pnl = cost_removed - price_scaled * cover_qty;
+        entry->realized_pnl.fetch_add(pnl, std::memory_order_relaxed);
+        entry->cost_basis_total.fetch_add(cost_removed,
+                                          std::memory_order_relaxed);
+      }
+      const int64_t open_qty = qty - cover_qty;
+      if (open_qty > 0) {
+        entry->cost_basis_total.fetch_add(price_scaled * open_qty,
+                                          std::memory_order_relaxed);
+      }
+    } else {
+      entry->cost_basis_total.fetch_add(price_scaled * qty,
+                                        std::memory_order_relaxed);
+    }
+    entry->filled.fetch_add(qty, std::memory_order_relaxed);
+    entry->pending.fetch_sub(qty, std::memory_order_relaxed);
+  } else {
+    if (current_filled > 0) {
+      const int64_t sell_qty = (std::min)(qty, current_filled);
+      if (sell_qty > 0) {
+        const int64_t cost_basis =
+            entry->cost_basis_total.load(std::memory_order_relaxed);
+        const int64_t cost_removed = cost_basis * sell_qty / current_filled;
+        const int64_t pnl = price_scaled * sell_qty - cost_removed;
+        entry->realized_pnl.fetch_add(pnl, std::memory_order_relaxed);
+        entry->cost_basis_total.fetch_sub(cost_removed,
+                                          std::memory_order_relaxed);
+      }
+      const int64_t short_qty = qty - sell_qty;
+      if (short_qty > 0) {
+        entry->cost_basis_total.fetch_sub(price_scaled * short_qty,
+                                          std::memory_order_relaxed);
+      }
+    } else {
+      entry->cost_basis_total.fetch_sub(price_scaled * qty,
+                                        std::memory_order_relaxed);
+    }
+    entry->filled.fetch_sub(qty, std::memory_order_relaxed);
+    entry->pending.fetch_add(qty, std::memory_order_relaxed);
+  }
 }
 
 void PositionManager::onOrderSent(const Order &order) noexcept {
@@ -132,4 +178,20 @@ PositionManager::getTotalExposure(std::string_view symbol) const noexcept {
   }
   return entry->filled.load(std::memory_order_relaxed) +
          entry->pending.load(std::memory_order_relaxed);
+}
+
+int64_t PositionManager::getCostBasis(std::string_view symbol) const {
+  const Entry *entry = find(symbolToKey(symbol));
+  if (!entry) {
+    return 0;
+  }
+  return entry->cost_basis_total.load(std::memory_order_relaxed);
+}
+
+int64_t PositionManager::getRealizedPnl(std::string_view symbol) const {
+  const Entry *entry = find(symbolToKey(symbol));
+  if (!entry) {
+    return 0;
+  }
+  return entry->realized_pnl.load(std::memory_order_relaxed);
 }

--- a/tests/TestHelpers.hpp
+++ b/tests/TestHelpers.hpp
@@ -47,13 +47,15 @@ sinkContains(const std::shared_ptr<spdlog::sinks::ringbuffer_sink_mt> &sink,
 }
 
 [[nodiscard]] inline Fill createFill(const char *symbol, const OrderSide side,
-                                     const int64_t qty) {
+                                     const int64_t qty,
+                                     const double price = 0.0) {
   Fill fill{};
   std::memset(fill.symbol, 0, sizeof(fill.symbol));
   const auto len = (std::min)(std::strlen(symbol), sizeof(fill.symbol));
   std::memcpy(fill.symbol, symbol, len);
   fill.side = side;
   fill.quantity = qty;
+  fill.price = price;
   return fill;
 }
 

--- a/tests/test_position_manager.cpp
+++ b/tests/test_position_manager.cpp
@@ -1,6 +1,7 @@
 #include "PositionManager.hpp"
 #include "TestHelpers.hpp"
 #include "ThreadGuard.hpp"
+#include <cmath>
 #include <future>
 #include <gtest/gtest.h>
 #include <vector>
@@ -285,4 +286,153 @@ TEST_F(PositionManagerTest, SequentialOrderFillCancelFlow) {
   EXPECT_EQ(pm.getFilledPosition("AAPL"), 100);
   EXPECT_EQ(pm.getPendingPosition("AAPL"), 0);
   EXPECT_EQ(pm.getTotalExposure("AAPL"), 100);
+}
+
+TEST_F(PositionManagerTest, NewPositionHasZeroPnl) {
+  EXPECT_EQ(pm.getCostBasis("AAPL"), 0);
+  EXPECT_EQ(pm.getRealizedPnl("AAPL"), 0);
+}
+
+TEST_F(PositionManagerTest, MultipleBuysWeightedAverage) {
+  pm.onFill(createFill("AAPL", OrderSide::Buy, 50, 100.0));
+  pm.onFill(createFill("AAPL", OrderSide::Buy, 50, 200.0));
+  pm.onFill(createFill("AAPL", OrderSide::Sell, 100, 175.0));
+
+  EXPECT_EQ(pm.getRealizedPnl("AAPL"), 25LL * SCALING_FACTOR * 100);
+  EXPECT_EQ(pm.getCostBasis("AAPL"), 0);
+}
+
+TEST_F(PositionManagerTest, PnlAccumulatesAcrossMultipleTrades) {
+  pm.onFill(createFill("AAPL", OrderSide::Buy, 100, 100.0));
+  pm.onFill(createFill("AAPL", OrderSide::Sell, 100, 110.0));
+  pm.onFill(createFill("AAPL", OrderSide::Buy, 100, 120.0));
+  pm.onFill(createFill("AAPL", OrderSide::Sell, 100, 125.0));
+
+  const int64_t expected_pnl =
+      (10LL * SCALING_FACTOR * 100) + (5LL * SCALING_FACTOR * 100);
+  EXPECT_EQ(pm.getRealizedPnl("AAPL"), expected_pnl);
+  EXPECT_EQ(pm.getCostBasis("AAPL"), 0);
+}
+
+struct PnLTestParam {
+  const char *name;
+  OrderSide side;
+  int64_t quantity;
+  double price;
+  int64_t expected_filled;
+  int64_t expected_cost_basis;
+  int64_t expected_realized_pnl;
+};
+
+class PositionManagerPnLTest
+    : public PositionManagerTest,
+      public ::testing::WithParamInterface<PnLTestParam> {};
+
+TEST_P(PositionManagerPnLTest, SingleFillPnl) {
+  const auto &p = GetParam();
+  pm.onFill(createFill("AAPL", p.side, p.quantity, p.price));
+
+  EXPECT_EQ(pm.getFilledPosition("AAPL"), p.expected_filled);
+  EXPECT_EQ(pm.getCostBasis("AAPL"), p.expected_cost_basis);
+  EXPECT_EQ(pm.getRealizedPnl("AAPL"), p.expected_realized_pnl);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PnLCases, PositionManagerPnLTest,
+    ::testing::Values(PnLTestParam{"BuyOpensLong", OrderSide::Buy, 100, 150.0,
+                                   100, 150LL * SCALING_FACTOR * 100, 0},
+                      PnLTestParam{"SellOpensShort", OrderSide::Sell, 100,
+                                   150.0, -100, -150LL * SCALING_FACTOR * 100,
+                                   0},
+                      PnLTestParam{"SmallBuy", OrderSide::Buy, 1, 99.99, 1,
+                                   std::llround(99.99 * SCALING_FACTOR) * 1,
+                                   0}),
+    [](const ::testing::TestParamInfo<PnLTestParam> &info) {
+      return info.param.name;
+    });
+
+struct TwoFillPnLParam {
+  const char *name;
+  OrderSide side1;
+  int64_t qty1;
+  double price1;
+  OrderSide side2;
+  int64_t qty2;
+  double price2;
+  int64_t expected_filled;
+  int64_t expected_cost_basis;
+  int64_t expected_realized_pnl;
+};
+
+class PositionManagerTwoFillPnLTest
+    : public PositionManagerTest,
+      public ::testing::WithParamInterface<TwoFillPnLParam> {};
+
+TEST_P(PositionManagerTwoFillPnLTest, TwoFillsProducePnl) {
+  const auto &p = GetParam();
+  pm.onFill(createFill("AAPL", p.side1, p.qty1, p.price1));
+  pm.onFill(createFill("AAPL", p.side2, p.qty2, p.price2));
+
+  EXPECT_EQ(pm.getFilledPosition("AAPL"), p.expected_filled);
+  EXPECT_EQ(pm.getCostBasis("AAPL"), p.expected_cost_basis);
+  EXPECT_EQ(pm.getRealizedPnl("AAPL"), p.expected_realized_pnl);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PnLTwoFill, PositionManagerTwoFillPnLTest,
+    ::testing::Values(TwoFillPnLParam{"FullSellRealizesPnl", OrderSide::Buy,
+                                      100, 150.0, OrderSide::Sell, 100, 155.0,
+                                      0, 0, 5LL * SCALING_FACTOR * 100},
+                      TwoFillPnLParam{"PartialSellProRates", OrderSide::Buy,
+                                      100, 150.0, OrderSide::Sell, 50, 160.0,
+                                      50, 150LL * SCALING_FACTOR * 50,
+                                      10LL * SCALING_FACTOR * 50},
+                      TwoFillPnLParam{"BuyToCoverShort", OrderSide::Sell, 100,
+                                      150.0, OrderSide::Buy, 100, 140.0, 0, 0,
+                                      10LL * SCALING_FACTOR * 100},
+                      TwoFillPnLParam{"RoundTripExactZero", OrderSide::Buy, 100,
+                                      150.25, OrderSide::Sell, 100, 150.25, 0,
+                                      0, 0},
+                      TwoFillPnLParam{"SellReversesLongToShort", OrderSide::Buy,
+                                      50, 100.0, OrderSide::Sell, 80, 110.0,
+                                      -30, -110LL * SCALING_FACTOR * 30,
+                                      10LL * SCALING_FACTOR * 50},
+                      TwoFillPnLParam{"BuyReversesShortToLong", OrderSide::Sell,
+                                      50, 100.0, OrderSide::Buy, 80, 90.0, 30,
+                                      90LL * SCALING_FACTOR * 30,
+                                      10LL * SCALING_FACTOR * 50}),
+    [](const ::testing::TestParamInfo<TwoFillPnLParam> &info) {
+      return info.param.name;
+    });
+
+TEST_F(PositionManagerTest, ConcurrentFillsPreservePnlConsistency) {
+  constexpr int kThreads = 4;
+  constexpr int kFillsPerThread = 250;
+  constexpr double kPrice = 100.0;
+  std::atomic<int> done_count{0};
+  std::promise<void> all_done;
+
+  std::vector<ThreadGuard> threads;
+  threads.reserve(kThreads);
+
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back(std::thread([this, &done_count, &all_done]() {
+      for (int j = 0; j < kFillsPerThread; ++j) {
+        pm.onFill(createFill("AAPL", OrderSide::Buy, 1, kPrice));
+      }
+      if (done_count.fetch_add(1, std::memory_order_acq_rel) + 1 == kThreads) {
+        all_done.set_value();
+      }
+    }));
+  }
+
+  auto status = all_done.get_future().wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "timeout";
+  threads.clear();
+
+  const int64_t total_qty = static_cast<int64_t>(kThreads) * kFillsPerThread;
+  EXPECT_EQ(pm.getFilledPosition("AAPL"), total_qty);
+  EXPECT_EQ(pm.getCostBasis("AAPL"),
+            static_cast<int64_t>(kPrice * SCALING_FACTOR) * total_qty);
+  EXPECT_EQ(pm.getRealizedPnl("AAPL"), 0);
 }


### PR DESCRIPTION
## Summary

- Extend Entry from 64 to 128 bytes: `cost_basis_total` and `realized_pnl` (scaled int64) in second cache line, hot-path fields untouched in first cache line
- `onFill()` accumulates cost basis on buys, computes realized PnL on sells using proportional cost removal (single integer truncation per trade)
- Handles long close, short sell, buy-to-cover, and position reversal (long-to-short, short-to-long in a single fill)
- `std::llround` for double-to-int64 price conversion (round-to-nearest, not truncate)
- New `getCostBasis()` and `getRealizedPnl()` read accessors
- Zero changes to hot-path methods (`onOrderSent`, `getTotalExposure`, `onOrderCancelled`)
- 14 new test cases: 3 parameterized single-fill, 6 parameterized two-fill (including position reversals), 3 multi-fill TEST_F, 1 concurrent, 1 zero-state

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added queries to view cost basis and realized profit/loss for individual positions.

* **Tests**
  * Expanded coverage with weighted-average buys/sells, partial closes, reversals, round-trips, and concurrent fill scenarios to validate cost-basis and P&L behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->